### PR TITLE
HBW-002: implement core data models and arena manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Ajouté
 - Initialisation de la structure du projet Maven pour Spigot 1.21.
-- Création du système de gestion d'arène (modèles de données).
-- Implémentation de la commande `/bedwars admin` pour ouvrir le GUI de gestion.
-- Développement de l'interface graphique principale pour la création et la configuration des arènes.
-- Mise en place de la persistance des arènes dans des fichiers YAML.
+- Création des modèles de données de base : `Arena`, `Team`, `Generator`.
+- Ajout des énumérations `GameState`, `GeneratorType`, et `TeamColor`.
+- Implémentation de la structure initiale de l' `ArenaManager` pour la gestion des arènes en mémoire.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,11 +13,11 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
     * [✔] Création du workflow GitHub Actions pour la compilation automatique (CI).
     * [✔] Initialisation de la structure des packages Java (`com.heneria.bedwars.*`).
 
-* **[ ] 1.2 : Modèles de Données (Core Engine)**
-    * [ ] Créer la classe `Arena` : Contiendra toutes les informations d'une arène (nom, état, joueurs, équipes, configuration du monde, etc.).
-    * [ ] Créer la classe `Team` : Gérera les informations d'une équipe (nom, couleur, joueurs, lit, améliorations).
-    * [ ] Créer la classe `Generator` : Modélisera les générateurs de ressources (type, emplacement, niveau).
-    * [ ] Créer des Enums pour les états de jeu (`GameState`: WAITING, STARTING, PLAYING, ENDING), les types de générateurs (`GeneratorType`: IRON, GOLD, DIAMOND, EMERALD), et les couleurs d'équipe (`TeamColor`).
+* **[✔] 1.2 : Modèles de Données (Core Engine)**
+    * [✔] Créer la classe `Arena`.
+    * [✔] Créer la classe `Team`.
+    * [✔] Créer la classe `Generator`.
+    * [✔] Créer des Enums pour les états de jeu, types de générateurs, et couleurs d'équipe.
 
 * **[ ] 1.3 : Système de Commandes & Permissions**
     * [ ] Implémenter un gestionnaire de commandes robuste pour la commande principale `/bedwars` (ou `/hbw`).

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -1,43 +1,49 @@
 package com.heneria.bedwars;
 
+import com.heneria.bedwars.managers.ArenaManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
+/**
+ * Main plugin class for HeneriaBedwars.
+ */
 public final class HeneriaBedwars extends JavaPlugin {
 
     private static HeneriaBedwars instance;
 
-    // Managers à implémenter
-    // private ArenaManager arenaManager;
+    private ArenaManager arenaManager;
 
     @Override
     public void onEnable() {
         instance = this;
         getLogger().info("HeneriaBedwars v" + getDescription().getVersion() + " est en cours de chargement...");
 
-        // 1. Charger les configurations
-
-        // 2. Initialiser les managers
-        // this.arenaManager = new ArenaManager(this);
-
-        // 3. Enregistrer les commandes
-
-        // 4. Enregistrer les listeners
+        // Initialize managers
+        this.arenaManager = new ArenaManager(this);
+        this.arenaManager.loadArenas();
 
         getLogger().info("HeneriaBedwars a été activé avec succès.");
     }
 
     @Override
     public void onDisable() {
-        // Logique de sauvegarde ou de nettoyage
         getLogger().info("HeneriaBedwars a été désactivé.");
     }
 
+    /**
+     * Gets the singleton instance of the plugin.
+     *
+     * @return plugin instance
+     */
     public static HeneriaBedwars getInstance() {
         return instance;
     }
 
-    // Getters pour les managers
-    // public ArenaManager getArenaManager() {
-    //     return arenaManager;
-    // }
+    /**
+     * Gets the arena manager.
+     *
+     * @return the arena manager
+     */
+    public ArenaManager getArenaManager() {
+        return arenaManager;
+    }
 }

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -1,0 +1,178 @@
+package com.heneria.bedwars.arena;
+
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.arena.enums.TeamColor;
+import org.bukkit.Location;
+
+import java.util.*;
+
+/**
+ * Represents a BedWars arena with its configuration and runtime state.
+ */
+public class Arena {
+
+    private final String name;
+    private GameState state = GameState.WAITING;
+    private String worldName;
+    private int minPlayers;
+    private int maxPlayers;
+    private final List<UUID> players = new ArrayList<>();
+    private final Map<TeamColor, Team> teams = new EnumMap<>(TeamColor.class);
+    private final List<Generator> generators = new ArrayList<>();
+    private Location lobbyLocation;
+
+    /**
+     * Creates a new arena with the given name.
+     *
+     * @param name the arena name
+     */
+    public Arena(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the arena name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the current state of the arena.
+     *
+     * @return the game state
+     */
+    public GameState getState() {
+        return state;
+    }
+
+    /**
+     * Sets the current state of the arena.
+     *
+     * @param state the new state
+     */
+    public void setState(GameState state) {
+        this.state = state;
+    }
+
+    /**
+     * Gets the name of the world used by the arena.
+     *
+     * @return the world name
+     */
+    public String getWorldName() {
+        return worldName;
+    }
+
+    /**
+     * Sets the world used by the arena.
+     *
+     * @param worldName the world name
+     */
+    public void setWorldName(String worldName) {
+        this.worldName = worldName;
+    }
+
+    /**
+     * Gets the minimum number of players required to start the arena.
+     *
+     * @return minimum player count
+     */
+    public int getMinPlayers() {
+        return minPlayers;
+    }
+
+    /**
+     * Sets the minimum number of players required.
+     *
+     * @param minPlayers minimum player count
+     */
+    public void setMinPlayers(int minPlayers) {
+        this.minPlayers = minPlayers;
+    }
+
+    /**
+     * Gets the maximum number of players allowed in the arena.
+     *
+     * @return maximum player count
+     */
+    public int getMaxPlayers() {
+        return maxPlayers;
+    }
+
+    /**
+     * Sets the maximum number of players allowed in the arena.
+     *
+     * @param maxPlayers maximum player count
+     */
+    public void setMaxPlayers(int maxPlayers) {
+        this.maxPlayers = maxPlayers;
+    }
+
+    /**
+     * Gets the list of players currently in the arena.
+     *
+     * @return list of players
+     */
+    public List<UUID> getPlayers() {
+        return players;
+    }
+
+    /**
+     * Adds a player to the arena.
+     *
+     * @param uuid player's unique id
+     */
+    public void addPlayer(UUID uuid) {
+        players.add(uuid);
+    }
+
+    /**
+     * Removes a player from the arena.
+     *
+     * @param uuid player's unique id
+     */
+    public void removePlayer(UUID uuid) {
+        players.remove(uuid);
+    }
+
+    /**
+     * Gets the teams registered in the arena.
+     *
+     * @return map of teams by color
+     */
+    public Map<TeamColor, Team> getTeams() {
+        return teams;
+    }
+
+    /**
+     * Gets the generators available in the arena.
+     *
+     * @return list of generators
+     */
+    public List<Generator> getGenerators() {
+        return generators;
+    }
+
+    /**
+     * Gets the lobby spawn location of the arena.
+     *
+     * @return lobby location
+     */
+    public Location getLobbyLocation() {
+        return lobbyLocation;
+    }
+
+    /**
+     * Sets the lobby spawn location of the arena.
+     *
+     * @param lobbyLocation lobby location
+     */
+    public void setLobbyLocation(Location lobbyLocation) {
+        this.lobbyLocation = lobbyLocation;
+    }
+}

--- a/src/main/java/com/heneria/bedwars/arena/elements/Generator.java
+++ b/src/main/java/com/heneria/bedwars/arena/elements/Generator.java
@@ -1,0 +1,81 @@
+package com.heneria.bedwars.arena.elements;
+
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import org.bukkit.Location;
+
+/**
+ * Represents a resource generator within an arena.
+ */
+public class Generator {
+
+    private Location location;
+    private GeneratorType type;
+    private int level;
+
+    /**
+     * Creates a new generator.
+     *
+     * @param location the location of the generator
+     * @param type     the type of resource generated
+     * @param level    the current level of the generator
+     */
+    public Generator(Location location, GeneratorType type, int level) {
+        this.location = location;
+        this.type = type;
+        this.level = level;
+    }
+
+    /**
+     * Gets the location of the generator.
+     *
+     * @return the location
+     */
+    public Location getLocation() {
+        return location;
+    }
+
+    /**
+     * Sets the location of the generator.
+     *
+     * @param location the new location
+     */
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+
+    /**
+     * Gets the generator type.
+     *
+     * @return the generator type
+     */
+    public GeneratorType getType() {
+        return type;
+    }
+
+    /**
+     * Sets the generator type.
+     *
+     * @param type the new generator type
+     */
+    public void setType(GeneratorType type) {
+        this.type = type;
+    }
+
+    /**
+     * Gets the level of the generator.
+     *
+     * @return the level
+     */
+    public int getLevel() {
+        return level;
+    }
+
+    /**
+     * Sets the level of the generator.
+     *
+     * @param level the new level
+     */
+    public void setLevel(int level) {
+        this.level = level;
+    }
+}

--- a/src/main/java/com/heneria/bedwars/arena/elements/Team.java
+++ b/src/main/java/com/heneria/bedwars/arena/elements/Team.java
@@ -1,0 +1,129 @@
+package com.heneria.bedwars.arena.elements;
+
+import com.heneria.bedwars.arena.enums.TeamColor;
+import org.bukkit.Location;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Represents a team within an arena.
+ */
+public class Team {
+
+    private final TeamColor color;
+    private final List<UUID> members = new ArrayList<>();
+    private Location spawnLocation;
+    private Location bedLocation;
+    private boolean hasBed = true;
+
+    /**
+     * Creates a new team with the given color.
+     *
+     * @param color the team color
+     */
+    public Team(TeamColor color) {
+        this.color = color;
+    }
+
+    /**
+     * Gets the color of the team.
+     *
+     * @return the team color
+     */
+    public TeamColor getColor() {
+        return color;
+    }
+
+    /**
+     * Gets the members of the team.
+     *
+     * @return list of members
+     */
+    public List<UUID> getMembers() {
+        return members;
+    }
+
+    /**
+     * Adds a player to the team.
+     *
+     * @param uuid player's unique id
+     */
+    public void addMember(UUID uuid) {
+        members.add(uuid);
+    }
+
+    /**
+     * Removes a player from the team.
+     *
+     * @param uuid player's unique id
+     */
+    public void removeMember(UUID uuid) {
+        members.remove(uuid);
+    }
+
+    /**
+     * Checks if a player is part of the team.
+     *
+     * @param uuid player's unique id
+     * @return true if the player is in the team
+     */
+    public boolean isMember(UUID uuid) {
+        return members.contains(uuid);
+    }
+
+    /**
+     * Gets the spawn location of the team.
+     *
+     * @return the spawn location
+     */
+    public Location getSpawnLocation() {
+        return spawnLocation;
+    }
+
+    /**
+     * Sets the spawn location of the team.
+     *
+     * @param spawnLocation the new spawn location
+     */
+    public void setSpawnLocation(Location spawnLocation) {
+        this.spawnLocation = spawnLocation;
+    }
+
+    /**
+     * Gets the location of the team's bed.
+     *
+     * @return the bed location
+     */
+    public Location getBedLocation() {
+        return bedLocation;
+    }
+
+    /**
+     * Sets the location of the team's bed.
+     *
+     * @param bedLocation the bed location
+     */
+    public void setBedLocation(Location bedLocation) {
+        this.bedLocation = bedLocation;
+    }
+
+    /**
+     * Checks whether the team still has its bed.
+     *
+     * @return true if the bed is intact
+     */
+    public boolean hasBed() {
+        return hasBed;
+    }
+
+    /**
+     * Sets whether the team has a bed.
+     *
+     * @param hasBed new bed state
+     */
+    public void setHasBed(boolean hasBed) {
+        this.hasBed = hasBed;
+    }
+}

--- a/src/main/java/com/heneria/bedwars/arena/enums/GameState.java
+++ b/src/main/java/com/heneria/bedwars/arena/enums/GameState.java
@@ -1,0 +1,15 @@
+package com.heneria.bedwars.arena.enums;
+
+/**
+ * Represents the possible states of a BedWars arena.
+ */
+public enum GameState {
+    /** Waiting for players in the arena lobby. */
+    WAITING,
+    /** Countdown before the game begins. */
+    STARTING,
+    /** The game is currently running. */
+    PLAYING,
+    /** The game has finished and winners are displayed. */
+    ENDING;
+}

--- a/src/main/java/com/heneria/bedwars/arena/enums/GeneratorType.java
+++ b/src/main/java/com/heneria/bedwars/arena/enums/GeneratorType.java
@@ -1,0 +1,15 @@
+package com.heneria.bedwars.arena.enums;
+
+/**
+ * Types of resources produced by generators.
+ */
+public enum GeneratorType {
+    /** Generates iron ingots. */
+    IRON,
+    /** Generates gold ingots. */
+    GOLD,
+    /** Generates diamonds. */
+    DIAMOND,
+    /** Generates emeralds. */
+    EMERALD;
+}

--- a/src/main/java/com/heneria/bedwars/arena/enums/TeamColor.java
+++ b/src/main/java/com/heneria/bedwars/arena/enums/TeamColor.java
@@ -1,0 +1,55 @@
+package com.heneria.bedwars.arena.enums;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+
+/**
+ * Represents the available team colors with useful metadata.
+ */
+public enum TeamColor {
+    RED("Rouge", ChatColor.RED, Material.RED_WOOL),
+    BLUE("Bleu", ChatColor.BLUE, Material.BLUE_WOOL),
+    GREEN("Vert", ChatColor.GREEN, Material.LIME_WOOL),
+    YELLOW("Jaune", ChatColor.YELLOW, Material.YELLOW_WOOL),
+    AQUA("Cyan", ChatColor.AQUA, Material.CYAN_WOOL),
+    WHITE("Blanc", ChatColor.WHITE, Material.WHITE_WOOL),
+    PINK("Rose", ChatColor.LIGHT_PURPLE, Material.PINK_WOOL),
+    GRAY("Gris", ChatColor.GRAY, Material.GRAY_WOOL);
+
+    private final String displayName;
+    private final ChatColor chatColor;
+    private final Material woolMaterial;
+
+    TeamColor(String displayName, ChatColor chatColor, Material woolMaterial) {
+        this.displayName = displayName;
+        this.chatColor = chatColor;
+        this.woolMaterial = woolMaterial;
+    }
+
+    /**
+     * Gets the localized display name of the team color.
+     *
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Gets the chat color associated with the team.
+     *
+     * @return the chat color
+     */
+    public ChatColor getChatColor() {
+        return chatColor;
+    }
+
+    /**
+     * Gets the wool material representing the team color.
+     *
+     * @return the wool material
+     */
+    public Material getWoolMaterial() {
+        return woolMaterial;
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -1,0 +1,71 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages all arenas loaded on the server.
+ */
+public class ArenaManager {
+
+    private final HeneriaBedwars plugin;
+    private final Map<String, Arena> arenas = new HashMap<>();
+
+    /**
+     * Creates a new arena manager.
+     *
+     * @param plugin the plugin instance
+     */
+    public ArenaManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Loads arenas from persistent storage.
+     * Implementation will be added in a later step.
+     */
+    public void loadArenas() {
+        // To be implemented in step 1.5
+    }
+
+    /**
+     * Saves arenas to persistent storage.
+     * Implementation will be added in a later step.
+     */
+    public void saveArenas() {
+        // To be implemented in step 1.5
+    }
+
+    /**
+     * Retrieves an arena by name.
+     *
+     * @param name the arena name
+     * @return the arena or {@code null} if not found
+     */
+    public Arena getArena(String name) {
+        return arenas.get(name.toLowerCase());
+    }
+
+    /**
+     * Gets all loaded arenas.
+     *
+     * @return a collection of arenas
+     */
+    public Collection<Arena> getAllArenas() {
+        return arenas.values();
+    }
+
+    /**
+     * Creates a new arena in memory.
+     * GUI integration will handle configuration later on.
+     *
+     * @param name the arena name
+     */
+    public void createArena(String name) {
+        arenas.put(name.toLowerCase(), new Arena(name));
+    }
+}


### PR DESCRIPTION
## Summary
- add game state, generator type and team color enums
- implement Generator, Team and Arena data classes
- introduce basic ArenaManager and hook into plugin start-up
- update roadmap and changelog for core engine completion

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a22f4bac0483299c85e1e9ff4e9c6d