### PR TITLE
fix(build): Use <release> flag in maven-compiler-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@
 - Création des modèles de données de base : `Arena`, `Team`, `Generator`.
 - Ajout des énumérations `GameState`, `GeneratorType`, et `TeamColor`.
 - Implémentation de la structure initiale de l' `ArenaManager` pour la gestion des arènes en mémoire.
+
+### Corrigé
+- Avertissement de compilation Maven en remplaçant les flags `<source>`/`<target>` par `<release>` pour une meilleure compatibilité avec le JDK 21.

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- replace `<source>`/`<target>` with `<release>` in the Maven compiler plugin
- document the compiler warning fix in the changelog

## Testing
- `mvn clean package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2313c254083299de1ef8cb44aa87a