### PR TITLE
feat(admin): Implement admin command and main GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Création des modèles de données de base : `Arena`, `Team`, `Generator`.
 - Ajout des énumérations `GameState`, `GeneratorType`, et `TeamColor`.
 - Implémentation de la structure initiale de l' `ArenaManager` pour la gestion des arènes en mémoire.
+- Commande `/bedwars admin` (alias: `/bw`, `/hbw`) avec permission `heneriabw.admin`.
+- Interface graphique (GUI) principale pour l'administration.
+- Gestionnaire de commandes pour supporter de futures sous-commandes.
 
 ### Corrigé
 - Avertissement de compilation Maven en remplaçant les flags `<source>`/`<target>` par `<release>` pour une meilleure compatibilité avec le JDK 21.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ Consultez notre [ROADMAP.md](ROADMAP.md) pour suivre le développement du projet
 2.  Naviguez dans le dossier : `cd HeneriaBW`
 3.  Compilez avec Maven : `mvn clean package`
 4.  Le JAR final se trouvera dans le dossier `target/`.
+
+## 🎮 Commandes & Permissions
+
+### Commandes Administrateur
+- `/bedwars admin` (Alias: `/bw admin`, `/hbw admin`)
+  - Ouvre le menu principal de gestion des arènes.
+  - **Permission :** `heneriabw.admin`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,23 +19,14 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
     * [✔] Créer la classe `Generator`.
     * [✔] Créer des Enums pour les états de jeu, types de générateurs, et couleurs d'équipe.
 
-* **[ ] 1.3 : Système de Commandes & Permissions**
-    * [ ] Implémenter un gestionnaire de commandes robuste pour la commande principale `/bedwars` (ou `/hbw`).
-    * [ ] Créer la sous-commande `/bedwars admin` (permission : `heneriabw.admin`).
-    * [ ] L'exécution de `/bedwars admin` ouvrira l'interface graphique principale de gestion.
+* **[✔] 1.3 : Système de Commandes & Permissions**
+    * [✔] Implémenter le gestionnaire de commandes pour `/bedwars`.
+    * [✔] Créer la sous-commande `/bedwars admin` avec la permission `heneriabw.admin`.
 
-* **[ ] 1.4 : Développement du GUI d'Administration**
-    * [ ] **GUI Principal (`/bw admin`)** : Proposera les options "Créer une Arène" et "Gérer les Arènes Existantes".
-    * [ ] **GUI de Création d'Arène (Wizard)** :
-        * Étape 1 : Demander le nom de l'arène via un anvil GUI.
-        * Étape 2 : Définir le nombre de joueurs min/max et le nombre d'équipes.
-        * Étape 3 : Confirmer la création, ce qui génère un fichier de configuration vide et ajoute l'arène au gestionnaire.
-    * [ ] **GUI de Configuration d'Arène (Menu par arène)** :
-        * Item "Définir le Lobby d'attente" : Enregistre la position du joueur comme point de spawn d'attente.
-        * Item "Gestion des Équipes" : Ouvre un sous-menu pour configurer chaque équipe (couleur, taille max, position du lit, point de spawn).
-        * Item "Gestion des Générateurs" : Ouvre un sous-menu pour ajouter/supprimer des générateurs. L'ajout se fera via un item à placer physiquement, qui ouvrira un GUI pour choisir le type de ressource.
-        * Item "Gestion des PNJ" : Permet de définir les emplacements pour le PNJ de la boutique et celui des améliorations.
-        * Item "Activer/Désactiver l'arène" : Permet de rendre une arène jouable ou non.
+* **[WIP] 1.4 : Développement du GUI d'Administration**
+    * [✔] Créer le GUI Principal (`/bw admin`).
+    * [ ] Créer le GUI de Création d'Arène (Wizard).
+    * [ ] Créer le GUI de Configuration d'Arène.
 
 * **[ ] 1.5 : Persistance des Données**
     * [ ] Développer un `ArenaManager` qui charge toutes les configurations d'arène au démarrage du serveur.

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -1,5 +1,7 @@
 package com.heneria.bedwars;
 
+import com.heneria.bedwars.commands.CommandManager;
+import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -20,6 +22,14 @@ public final class HeneriaBedwars extends JavaPlugin {
         // Initialize managers
         this.arenaManager = new ArenaManager(this);
         this.arenaManager.loadArenas();
+
+        // Register commands
+        CommandManager commandManager = new CommandManager(this);
+        getCommand("bedwars").setExecutor(commandManager);
+        getCommand("bedwars").setTabCompleter(commandManager);
+
+        // Register listeners
+        getServer().getPluginManager().registerEvents(new GUIListener(), this);
 
         getLogger().info("HeneriaBedwars a été activé avec succès.");
     }

--- a/src/main/java/com/heneria/bedwars/commands/CommandManager.java
+++ b/src/main/java/com/heneria/bedwars/commands/CommandManager.java
@@ -1,0 +1,79 @@
+package com.heneria.bedwars.commands;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.commands.subcommands.AdminCommand;
+import com.heneria.bedwars.commands.subcommands.SubCommand;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.*;
+
+/**
+ * Central command manager handling the main "/bedwars" command and its sub-commands.
+ */
+public class CommandManager implements CommandExecutor, TabCompleter {
+
+    private final Map<String, SubCommand> subCommands = new HashMap<>();
+
+    /**
+     * Creates a new command manager.
+     *
+     * @param plugin the plugin instance
+     */
+    public CommandManager(HeneriaBedwars plugin) {
+        registerSubCommand(new AdminCommand());
+    }
+
+    private void registerSubCommand(SubCommand subCommand) {
+        subCommands.put(subCommand.getName().toLowerCase(), subCommand);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Cette commande est réservée aux joueurs.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (args.length == 0) {
+            player.sendMessage("Usage: /" + label + " <admin>");
+            return true;
+        }
+
+        SubCommand subCommand = subCommands.get(args[0].toLowerCase());
+        if (subCommand != null) {
+            subCommand.execute(player, Arrays.copyOfRange(args, 1, args.length));
+        } else {
+            player.sendMessage("Sous-commande inconnue.");
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            List<String> completions = new ArrayList<>();
+            for (String name : subCommands.keySet()) {
+                if (name.startsWith(args[0].toLowerCase())) {
+                    completions.add(name);
+                }
+            }
+            return completions;
+        }
+
+        if (!(sender instanceof Player)) {
+            return Collections.emptyList();
+        }
+
+        SubCommand subCommand = subCommands.get(args[0].toLowerCase());
+        if (subCommand != null) {
+            return subCommand.tabComplete((Player) sender, Arrays.copyOfRange(args, 1, args.length));
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -1,0 +1,32 @@
+package com.heneria.bedwars.commands.subcommands;
+
+import com.heneria.bedwars.gui.admin.AdminMainMenu;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Handles the "/bedwars admin" sub-command.
+ */
+public class AdminCommand implements SubCommand {
+
+    @Override
+    public String getName() {
+        return "admin";
+    }
+
+    @Override
+    public void execute(Player player, String[] args) {
+        if (!player.hasPermission("heneriabw.admin")) {
+            player.sendMessage("Vous n'avez pas la permission.");
+            return;
+        }
+        new AdminMainMenu().open(player);
+    }
+
+    @Override
+    public List<String> tabComplete(Player player, String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/SubCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/SubCommand.java
@@ -1,0 +1,35 @@
+package com.heneria.bedwars.commands.subcommands;
+
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * Represents a sub-command of the main BedWars command.
+ */
+public interface SubCommand {
+
+    /**
+     * Gets the name of the sub-command.
+     *
+     * @return the sub-command name
+     */
+    String getName();
+
+    /**
+     * Executes the sub-command for the given player.
+     *
+     * @param player the player executing the command
+     * @param args   additional arguments
+     */
+    void execute(Player player, String[] args);
+
+    /**
+     * Provides tab completion for this sub-command.
+     *
+     * @param player the player
+     * @param args   current arguments
+     * @return list of tab completions
+     */
+    List<String> tabComplete(Player player, String[] args);
+}

--- a/src/main/java/com/heneria/bedwars/gui/Menu.java
+++ b/src/main/java/com/heneria/bedwars/gui/Menu.java
@@ -1,0 +1,57 @@
+package com.heneria.bedwars.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * Base class for simple inventory based GUIs.
+ */
+public abstract class Menu implements InventoryHolder {
+
+    protected Inventory inventory;
+
+    /**
+     * Gets the title of the menu.
+     *
+     * @return menu title
+     */
+    public abstract String getTitle();
+
+    /**
+     * Gets the size of the inventory.
+     *
+     * @return inventory size
+     */
+    public abstract int getSize();
+
+    /**
+     * Fills the inventory with the necessary items.
+     */
+    public abstract void setupItems();
+
+    /**
+     * Handles a click inside this menu.
+     *
+     * @param event click event
+     */
+    public abstract void handleClick(InventoryClickEvent event);
+
+    /**
+     * Opens the menu for the given player.
+     *
+     * @param player the player
+     */
+    public void open(Player player) {
+        inventory = Bukkit.createInventory(this, getSize(), getTitle());
+        setupItems();
+        player.openInventory(inventory);
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/admin/AdminMainMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/AdminMainMenu.java
@@ -1,0 +1,57 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Main administration menu opened via "/bedwars admin".
+ */
+public class AdminMainMenu extends Menu {
+
+    private static final int CREATE_ARENA_SLOT = 11;
+    private static final int MANAGE_ARENAS_SLOT = 15;
+
+    @Override
+    public String getTitle() {
+        return "Gestion Bedwars";
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        ItemStack createArena = new ItemBuilder(Material.NETHER_STAR)
+                .setName("Créer une Arène")
+                .build();
+        inventory.setItem(CREATE_ARENA_SLOT, createArena);
+
+        ItemStack manageArenas = new ItemBuilder(Material.COMPASS)
+                .setName("Gérer les Arènes Existantes")
+                .build();
+        inventory.setItem(MANAGE_ARENAS_SLOT, manageArenas);
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        int slot = event.getRawSlot();
+        if (slot == CREATE_ARENA_SLOT) {
+            player.sendMessage("Bientôt disponible...");
+            player.closeInventory();
+        } else if (slot == MANAGE_ARENAS_SLOT) {
+            player.sendMessage("Bientôt disponible...");
+            player.closeInventory();
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/GUIListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GUIListener.java
@@ -1,0 +1,20 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.gui.Menu;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+/**
+ * Listener that dispatches inventory click events to active menus.
+ */
+public class GUIListener implements Listener {
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getInventory().getHolder() instanceof Menu) {
+            Menu menu = (Menu) event.getInventory().getHolder();
+            menu.handleClick(event);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
+++ b/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
@@ -1,0 +1,59 @@
+package com.heneria.bedwars.utils;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+/**
+ * Utility class to simplify ItemStack creation.
+ */
+public class ItemBuilder {
+
+    private final ItemStack itemStack;
+    private final ItemMeta meta;
+
+    /**
+     * Creates a new builder for the given material.
+     *
+     * @param material the item material
+     */
+    public ItemBuilder(Material material) {
+        this.itemStack = new ItemStack(material);
+        this.meta = itemStack.getItemMeta();
+    }
+
+    /**
+     * Sets the display name of the item.
+     *
+     * @param name the display name
+     * @return this builder
+     */
+    public ItemBuilder setName(String name) {
+        meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
+        return this;
+    }
+
+    /**
+     * Sets the lore of the item.
+     *
+     * @param lore the lore lines
+     * @return this builder
+     */
+    public ItemBuilder setLore(List<String> lore) {
+        meta.setLore(lore);
+        return this;
+    }
+
+    /**
+     * Builds the item stack.
+     *
+     * @return the resulting ItemStack
+     */
+    public ItemStack build() {
+        itemStack.setItemMeta(meta);
+        return itemStack;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,3 +8,8 @@ commands:
   bedwars:
     description: Commande principale de HeneriaBedwars.
     aliases: [bw, hbw]
+
+permissions:
+  heneriabw.admin:
+    description: Donne accès à toutes les commandes d'administration de HeneriaBedwars.
+    default: op


### PR DESCRIPTION
## Summary
- add command framework with `/bedwars admin` subcommand
- show placeholder admin menu for arena creation and management
- document commands, permissions, and roadmap progress

## Testing
- `mvn -q package` *(fails: PluginResolutionException - Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68a232b7de808329b1bfdfb45cdc4f54