### PR TITLE
fix(build): Resolve compilation errors in ArenaNameMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,5 @@
 
 ### Corrigé
 - Avertissement de compilation Maven en remplaçant les flags `<source>`/`<target>` par `<release>` pour une meilleure compatibilité avec le JDK 21.
+- Correction d'une erreur de compilation critique dans `ArenaNameMenu` due à une mauvaise importation de `InventoryType`.
+- Suppression d'un avertissement de dépréciation lié à `getRenameText()` dans le GUI de l'enclume.

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
@@ -1,0 +1,54 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.gui.Menu;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.AnvilInventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Simple anvil GUI used to capture an arena name from the player.
+ */
+public class ArenaNameMenu extends Menu {
+
+    @Override
+    public String getTitle() {
+        return "Nom de l'arène";
+    }
+
+    @Override
+    public int getSize() {
+        // Size is ignored for anvil inventories but required by the abstract class.
+        return 3;
+    }
+
+    @Override
+    public void setupItems() {
+        // Slot 0 is the left input of the anvil.
+        inventory.setItem(0, new ItemStack(Material.PAPER));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        String name = ((AnvilInventory) event.getInventory()).getRenameText();
+        player.sendMessage("Nom choisi : " + name);
+        player.closeInventory();
+    }
+
+    @Override
+    public void open(Player player) {
+        inventory = Bukkit.createInventory(this, InventoryType.ANVIL, getTitle());
+        setupItems();
+        player.openInventory(inventory);
+    }
+}
+


### PR DESCRIPTION
## Summary
- create anvil-based `ArenaNameMenu` with correct `InventoryType` import
- silence `getRenameText` deprecation warning
- document compilation fix in changelog

## Testing
- `mvn -B package --file pom.xml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2372a9fd88329bc1bed5d90b6e719