### PR TITLE
feat(admin): Complete Step 1 with full arena configuration GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 - Commande `/bedwars admin` (alias: `/bw`, `/hbw`) avec permission `heneriabw.admin`.
 - Interface graphique (GUI) principale pour l'administration.
 - Gestionnaire de commandes pour supporter de futures sous-commandes.
+- Menu de gestion pour lister toutes les arènes existantes.
+- Menu de configuration complet par arène.
+- Outil de positionnement en jeu pour définir les emplacements (lobby, lits, spawns, etc.).
+- Configuration des équipes (lits et spawns) via GUI.
+- Ajout et suppression des générateurs de ressources via GUI.
+- Configuration des emplacements des PNJ (boutiques) via GUI.
+- Possibilité d'activer une arène une fois sa configuration terminée.
+- **L'ensemble des fonctionnalités de l'Étape 1 de la roadmap est désormais implémenté.**
 
 ### Corrigé
 - Avertissement de compilation Maven en remplaçant les flags `<source>`/`<target>` par `<release>` pour une meilleure compatibilité avec le JDK 21.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Notre objectif principal est de fournir un système de gestion d'arène via une 
 - **Gestion d'Arène 100% GUI** : Créez, configurez et gérez vos arènes sans taper une seule commande de configuration.
 - **Système d'Arène Flexible** : Définissez les points de spawn, les générateurs, les PNJ de boutique, et plus encore, directement en jeu.
 - **Persistance des Données** : Les configurations d'arène sont sauvegardées de manière fiable dans des fichiers locaux.
+- **Activation d'Arène** : Activez ou désactivez vos arènes une fois leur configuration complétée.
 - **Conçu pour la 1.21** : Entièrement développé sur l'API Spigot 1.21 pour une performance et une stabilité optimales.
 
 ## 🚀 Roadmap
@@ -28,3 +29,14 @@ Consultez notre [ROADMAP.md](ROADMAP.md) pour suivre le développement du projet
 - `/bedwars admin` (Alias: `/bw admin`, `/hbw admin`)
   - Ouvre le menu principal de gestion des arènes.
   - **Permission :** `heneriabw.admin`
+
+## 📘 Guide de l'Administrateur
+
+1. **Ouvrir le menu d'administration** : `/bw admin`.
+2. **Créer une nouvelle arène** : cliquez sur "Créer une Arène" et entrez un nom.
+3. **Configurer l'arène** : dans la liste des arènes, sélectionnez l'arène puis utilisez les options pour :
+   - Définir le lobby d'attente.
+   - Configurer les équipes (spawns et lits).
+   - Ajouter ou retirer des générateurs de ressources.
+   - Placer les PNJ de boutique et d'améliorations.
+4. **Activer l'arène** : lorsque tout est configuré, utilisez le bouton d'activation pour rendre l'arène disponible.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,8 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 
 ---
 
-## 🎯 **Étape 1 : Fondations et Gestionnaire d'Arène via GUI (Version Cible : 0.1.0)**
-*Objectif : Mettre en place un socle technique solide et un système complet de création/gestion d'arènes via une interface graphique intuitive. À la fin de cette étape, un administrateur doit pouvoir configurer une arène de A à Z sans utiliser de commandes complexes.* 
+## 🎯 **Étape 1 : Fondations et Gestionnaire d'Arène via GUI (Version Cible : 0.1.0) - [✔] TERMINÉE**
+*Objectif : Mettre en place un socle technique solide et un système complet de création/gestion d'arènes via une interface graphique intuitive. À la fin de cette étape, un administrateur doit pouvoir configurer une arène de A à Z sans utiliser de commandes complexes.*
 
 * **[✔] 1.1 : Structure du Projet & Intégration Continue**
     * [✔] Mise en place du projet Maven pour Spigot 1.21.
@@ -23,15 +23,14 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
     * [✔] Implémenter le gestionnaire de commandes pour `/bedwars`.
     * [✔] Créer la sous-commande `/bedwars admin` avec la permission `heneriabw.admin`.
 
-* **[WIP] 1.4 : Développement du GUI d'Administration**
-    * [✔] Créer le GUI Principal (`/bw admin`).
-    * [ ] Créer le GUI de Création d'Arène (Wizard).
-    * [ ] Créer le GUI de Configuration d'Arène.
+* **[✔] 1.4 : Développement du GUI d'Administration**
+    * [✔] Créer le GUI de Création d'Arène (Wizard).
+    * [✔] Créer le GUI de Configuration d'Arène (Lobby, Équipes, Lits, Spawns, Générateurs, PNJ).
 
-* **[ ] 1.5 : Persistance des Données**
-    * [ ] Développer un `ArenaManager` qui charge toutes les configurations d'arène au démarrage du serveur.
-    * [ ] Les configurations d'arène seront stockées dans des fichiers YAML dédiés (`plugins/HeneriaBedwars/arenas/<nom_arene>.yml`).
-    * [ ] Toute modification via le GUI doit être immédiatement sauvegardée dans le fichier correspondant pour éviter toute perte de données.
+* **[✔] 1.5 : Persistance des Données**
+    * [✔] Développer un `ArenaManager` qui charge toutes les configurations d'arène au démarrage du serveur.
+    * [✔] Les configurations d'arène sont stockées dans des fichiers YAML dédiés (`plugins/HeneriaBedwars/arenas/<nom_arene>.yml`).
+    * [✔] Toute modification via le GUI est immédiatement sauvegardée dans le fichier correspondant pour éviter toute perte de données.
 
 ---
 

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -2,6 +2,7 @@ package com.heneria.bedwars;
 
 import com.heneria.bedwars.commands.CommandManager;
 import com.heneria.bedwars.listeners.GUIListener;
+import com.heneria.bedwars.listeners.PositionToolListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -30,6 +31,7 @@ public final class HeneriaBedwars extends JavaPlugin {
 
         // Register listeners
         getServer().getPluginManager().registerEvents(new GUIListener(), this);
+        getServer().getPluginManager().registerEvents(new PositionToolListener(), this);
 
         getLogger().info("HeneriaBedwars a été activé avec succès.");
     }

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -22,6 +22,9 @@ public class Arena {
     private final Map<TeamColor, Team> teams = new EnumMap<>(TeamColor.class);
     private final List<Generator> generators = new ArrayList<>();
     private Location lobbyLocation;
+    private Location shopNpcLocation;
+    private Location upgradeNpcLocation;
+    private boolean enabled = false;
 
     /**
      * Creates a new arena with the given name.
@@ -174,5 +177,59 @@ public class Arena {
      */
     public void setLobbyLocation(Location lobbyLocation) {
         this.lobbyLocation = lobbyLocation;
+    }
+
+    /**
+     * Gets the location of the item shop NPC.
+     *
+     * @return shop NPC location
+     */
+    public Location getShopNpcLocation() {
+        return shopNpcLocation;
+    }
+
+    /**
+     * Sets the location of the item shop NPC.
+     *
+     * @param shopNpcLocation shop NPC location
+     */
+    public void setShopNpcLocation(Location shopNpcLocation) {
+        this.shopNpcLocation = shopNpcLocation;
+    }
+
+    /**
+     * Gets the location of the upgrade shop NPC.
+     *
+     * @return upgrade shop NPC location
+     */
+    public Location getUpgradeNpcLocation() {
+        return upgradeNpcLocation;
+    }
+
+    /**
+     * Sets the location of the upgrade shop NPC.
+     *
+     * @param upgradeNpcLocation upgrade shop NPC location
+     */
+    public void setUpgradeNpcLocation(Location upgradeNpcLocation) {
+        this.upgradeNpcLocation = upgradeNpcLocation;
+    }
+
+    /**
+     * Checks if the arena is enabled.
+     *
+     * @return true if enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether the arena is enabled.
+     *
+     * @param enabled enabled state
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/admin/AdminMainMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/AdminMainMenu.java
@@ -47,11 +47,11 @@ public class AdminMainMenu extends Menu {
 
         int slot = event.getRawSlot();
         if (slot == CREATE_ARENA_SLOT) {
-            player.sendMessage("Bientôt disponible...");
             player.closeInventory();
+            new ArenaNameMenu().open(player);
         } else if (slot == MANAGE_ARENAS_SLOT) {
-            player.sendMessage("Bientôt disponible...");
             player.closeInventory();
+            new ArenaListMenu().open(player);
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaConfigMenu.java
@@ -1,0 +1,93 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.PositionTool;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Main configuration menu for a specific arena.
+ */
+public class ArenaConfigMenu extends Menu {
+
+    private final Arena arena;
+
+    private static final int LOBBY_SLOT = 10;
+    private static final int TEAMS_SLOT = 12;
+    private static final int GENERATORS_SLOT = 14;
+    private static final int NPCS_SLOT = 16;
+    private static final int TOGGLE_SLOT = 22;
+
+    public ArenaConfigMenu(Arena arena) {
+        this.arena = arena;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Config: " + arena.getName();
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        inventory.setItem(LOBBY_SLOT, new ItemBuilder(Material.ENDER_PEARL)
+                .setName("Définir le Lobby d'attente")
+                .build());
+
+        inventory.setItem(TEAMS_SLOT, new ItemBuilder(Material.RED_BED)
+                .setName("Gestion des Équipes")
+                .build());
+
+        inventory.setItem(GENERATORS_SLOT, new ItemBuilder(Material.IRON_INGOT)
+                .setName("Gestion des Générateurs")
+                .build());
+
+        inventory.setItem(NPCS_SLOT, new ItemBuilder(Material.VILLAGER_SPAWN_EGG)
+                .setName("Gestion des PNJ")
+                .build());
+
+        Material toggleMat = arena.isEnabled() ? Material.EMERALD_BLOCK : Material.REDSTONE_BLOCK;
+        String toggleName = arena.isEnabled() ? "Désactiver l'arène" : "Activer l'arène";
+        inventory.setItem(TOGGLE_SLOT, new ItemBuilder(toggleMat).setName(toggleName).build());
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        int slot = event.getRawSlot();
+        if (slot == LOBBY_SLOT) {
+            player.closeInventory();
+            PositionTool.request(player, loc -> {
+                arena.setLobbyLocation(loc);
+                HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
+                player.sendMessage("Lobby défini.");
+            });
+        } else if (slot == TEAMS_SLOT) {
+            player.closeInventory();
+            new TeamListMenu(arena).open(player);
+        } else if (slot == GENERATORS_SLOT) {
+            player.closeInventory();
+            new GeneratorConfigMenu(arena).open(player);
+        } else if (slot == NPCS_SLOT) {
+            player.closeInventory();
+            new NpcConfigMenu(arena).open(player);
+        } else if (slot == TOGGLE_SLOT) {
+            arena.setEnabled(!arena.isEnabled());
+            HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
+            setupItems();
+            player.updateInventory();
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaListMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaListMenu.java
@@ -1,0 +1,54 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Lists all existing arenas for selection.
+ */
+public class ArenaListMenu extends Menu {
+
+    @Override
+    public String getTitle() {
+        return "Sélection d'arène";
+    }
+
+    @Override
+    public int getSize() {
+        return 54;
+    }
+
+    @Override
+    public void setupItems() {
+        int slot = 0;
+        for (Arena arena : HeneriaBedwars.getInstance().getArenaManager().getAllArenas()) {
+            ItemStack item = new ItemBuilder(Material.PAPER)
+                    .setName(arena.getName())
+                    .build();
+            inventory.setItem(slot++, item);
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        int slot = event.getRawSlot();
+        ItemStack item = inventory.getItem(slot);
+        if (item == null) return;
+        String name = item.getItemMeta().getDisplayName();
+        Arena arena = HeneriaBedwars.getInstance().getArenaManager().getArena(name);
+        if (arena != null) {
+            player.closeInventory();
+            new ArenaConfigMenu(arena).open(player);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
@@ -1,5 +1,6 @@
 package com.heneria.bedwars.gui.admin;
 
+import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.gui.Menu;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -40,7 +41,10 @@ public class ArenaNameMenu extends Menu {
         }
 
         String name = ((AnvilInventory) event.getInventory()).getRenameText();
-        player.sendMessage("Nom choisi : " + name);
+        if (name != null && !name.isBlank()) {
+            HeneriaBedwars.getInstance().getArenaManager().createArena(name);
+            player.sendMessage("Arène créée: " + name);
+        }
         player.closeInventory();
     }
 

--- a/src/main/java/com/heneria/bedwars/gui/admin/GeneratorConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/GeneratorConfigMenu.java
@@ -1,0 +1,90 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.PositionTool;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+/**
+ * Menu to add or remove resource generators.
+ */
+public class GeneratorConfigMenu extends Menu {
+
+    private final Arena arena;
+
+    public GeneratorConfigMenu(Arena arena) {
+        this.arena = arena;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Générateurs";
+    }
+
+    @Override
+    public int getSize() {
+        return 54;
+    }
+
+    @Override
+    public void setupItems() {
+        inventory.setItem(0, new ItemBuilder(Material.IRON_INGOT).setName("Ajouter un générateur de Fer").build());
+        inventory.setItem(1, new ItemBuilder(Material.GOLD_INGOT).setName("Ajouter un générateur d'Or").build());
+        inventory.setItem(2, new ItemBuilder(Material.DIAMOND).setName("Ajouter un générateur de Diamant").build());
+        inventory.setItem(3, new ItemBuilder(Material.EMERALD).setName("Ajouter un générateur d'Émeraude").build());
+
+        int slot = 9;
+        List<Generator> gens = arena.getGenerators();
+        for (Generator gen : gens) {
+            ItemStack item = new ItemBuilder(Material.DROPPER)
+                    .setName(gen.getType().name())
+                    .addLore("Clic pour supprimer")
+                    .build();
+            inventory.setItem(slot++, item);
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        int slot = event.getRawSlot();
+        if (slot == 0) {
+            addGenerator(player, GeneratorType.IRON);
+        } else if (slot == 1) {
+            addGenerator(player, GeneratorType.GOLD);
+        } else if (slot == 2) {
+            addGenerator(player, GeneratorType.DIAMOND);
+        } else if (slot == 3) {
+            addGenerator(player, GeneratorType.EMERALD);
+        } else if (slot >= 9) {
+            int index = slot - 9;
+            if (index < arena.getGenerators().size()) {
+                arena.getGenerators().remove(index);
+                HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
+                setupItems();
+                player.updateInventory();
+            }
+        }
+    }
+
+    private void addGenerator(Player player, GeneratorType type) {
+        player.closeInventory();
+        PositionTool.request(player, loc -> {
+            arena.getGenerators().add(new Generator(loc, type, 1));
+            HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
+            player.sendMessage("Générateur ajouté.");
+        });
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/admin/NpcConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/NpcConfigMenu.java
@@ -1,0 +1,68 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.PositionTool;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+/**
+ * Menu to configure shop NPC positions.
+ */
+public class NpcConfigMenu extends Menu {
+
+    private final Arena arena;
+    private static final int SHOP_SLOT = 11;
+    private static final int UPGRADE_SLOT = 15;
+
+    public NpcConfigMenu(Arena arena) {
+        this.arena = arena;
+    }
+
+    @Override
+    public String getTitle() {
+        return "PNJ";
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        inventory.setItem(SHOP_SLOT, new ItemBuilder(Material.CHEST)
+                .setName("Définir PNJ Boutique")
+                .build());
+        inventory.setItem(UPGRADE_SLOT, new ItemBuilder(Material.ANVIL)
+                .setName("Définir PNJ Améliorations")
+                .build());
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        int slot = event.getRawSlot();
+        if (slot == SHOP_SLOT) {
+            player.closeInventory();
+            PositionTool.request(player, loc -> {
+                arena.setShopNpcLocation(loc);
+                HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
+                player.sendMessage("PNJ Boutique défini.");
+            });
+        } else if (slot == UPGRADE_SLOT) {
+            player.closeInventory();
+            PositionTool.request(player, loc -> {
+                arena.setUpgradeNpcLocation(loc);
+                HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
+                player.sendMessage("PNJ Améliorations défini.");
+            });
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/admin/TeamConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/TeamConfigMenu.java
@@ -1,0 +1,74 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.arena.enums.TeamColor;
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.PositionTool;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+/**
+ * Configuration menu for a specific team.
+ */
+public class TeamConfigMenu extends Menu {
+
+    private final Arena arena;
+    private final TeamColor color;
+
+    private static final int SPAWN_SLOT = 11;
+    private static final int BED_SLOT = 15;
+
+    public TeamConfigMenu(Arena arena, TeamColor color) {
+        this.arena = arena;
+        this.color = color;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Équipe: " + color.getDisplayName();
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        inventory.setItem(SPAWN_SLOT, new ItemBuilder(Material.COMPASS)
+                .setName("Définir le Spawn")
+                .build());
+        inventory.setItem(BED_SLOT, new ItemBuilder(Material.RED_BED)
+                .setName("Définir le Lit")
+                .build());
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        Team team = arena.getTeams().computeIfAbsent(color, Team::new);
+        int slot = event.getRawSlot();
+        if (slot == SPAWN_SLOT) {
+            player.closeInventory();
+            PositionTool.request(player, loc -> {
+                team.setSpawnLocation(loc);
+                HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
+                player.sendMessage("Spawn défini pour l'équipe " + color.getDisplayName());
+            });
+        } else if (slot == BED_SLOT) {
+            player.closeInventory();
+            PositionTool.request(player, loc -> {
+                team.setBedLocation(loc);
+                HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
+                player.sendMessage("Lit défini pour l'équipe " + color.getDisplayName());
+            });
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/admin/TeamListMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/TeamListMenu.java
@@ -1,0 +1,55 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.TeamColor;
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Menu listing all teams of an arena.
+ */
+public class TeamListMenu extends Menu {
+
+    private final Arena arena;
+
+    public TeamListMenu(Arena arena) {
+        this.arena = arena;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Équipes";
+    }
+
+    @Override
+    public int getSize() {
+        return 54;
+    }
+
+    @Override
+    public void setupItems() {
+        int slot = 0;
+        for (TeamColor color : TeamColor.values()) {
+            ItemStack item = new ItemBuilder(color.getWoolMaterial())
+                    .setName(color.getDisplayName())
+                    .build();
+            inventory.setItem(slot++, item);
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        int slot = event.getRawSlot();
+        if (slot < 0 || slot >= TeamColor.values().length) return;
+        TeamColor color = TeamColor.values()[slot];
+        player.closeInventory();
+        new TeamConfigMenu(arena, color).open(player);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/PositionToolListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/PositionToolListener.java
@@ -1,0 +1,27 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.utils.PositionTool;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+
+/**
+ * Listener handling the use of the position tool.
+ */
+public class PositionToolListener implements Listener {
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return; // avoid double trigger
+        }
+        if (!PositionTool.isTool(event.getItem())) {
+            return;
+        }
+        event.setCancelled(true);
+        PositionTool.handleSelection(event.getPlayer(), event.getPlayer().getLocation());
+        event.getPlayer().getInventory().remove(event.getItem());
+        event.getPlayer().sendMessage("Position enregistrée.");
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -2,7 +2,15 @@ package com.heneria.bedwars.managers;
 
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import com.heneria.bedwars.arena.enums.TeamColor;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.Location;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,18 +34,99 @@ public class ArenaManager {
 
     /**
      * Loads arenas from persistent storage.
-     * Implementation will be added in a later step.
      */
     public void loadArenas() {
-        // To be implemented in step 1.5
+        arenas.clear();
+        File folder = new File(plugin.getDataFolder(), "arenas");
+        if (!folder.exists()) {
+            return;
+        }
+
+        File[] files = folder.listFiles((dir, name) -> name.endsWith(".yml"));
+        if (files == null) {
+            return;
+        }
+
+        for (File file : files) {
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+            String name = config.getString("name");
+            if (name == null) continue;
+            Arena arena = new Arena(name);
+            arena.setEnabled(config.getBoolean("enabled", false));
+            arena.setLobbyLocation(config.getLocation("lobby"));
+            arena.setShopNpcLocation(config.getLocation("npcs.shop"));
+            arena.setUpgradeNpcLocation(config.getLocation("npcs.upgrade"));
+
+            if (config.isConfigurationSection("teams")) {
+                for (String key : config.getConfigurationSection("teams").getKeys(false)) {
+                    TeamColor color = TeamColor.valueOf(key);
+                    Team team = new Team(color);
+                    team.setSpawnLocation(config.getLocation("teams." + key + ".spawn"));
+                    team.setBedLocation(config.getLocation("teams." + key + ".bed"));
+                    arena.getTeams().put(color, team);
+                }
+            }
+
+            if (config.isList("generators")) {
+                for (int i = 0; i < config.getList("generators").size(); i++) {
+                    String path = "generators." + i;
+                    GeneratorType type = GeneratorType.valueOf(config.getString(path + ".type"));
+                    Location loc = config.getLocation(path + ".location");
+                    int level = config.getInt(path + ".level", 1);
+                    arena.getGenerators().add(new Generator(loc, type, level));
+                }
+            }
+
+            arenas.put(name.toLowerCase(), arena);
+        }
     }
 
     /**
-     * Saves arenas to persistent storage.
-     * Implementation will be added in a later step.
+     * Saves all arenas to disk.
      */
     public void saveArenas() {
-        // To be implemented in step 1.5
+        for (Arena arena : arenas.values()) {
+            saveArena(arena);
+        }
+    }
+
+    /**
+     * Saves a single arena to its YAML file.
+     *
+     * @param arena arena to save
+     */
+    public void saveArena(Arena arena) {
+        File folder = new File(plugin.getDataFolder(), "arenas");
+        if (!folder.exists()) {
+            folder.mkdirs();
+        }
+        File file = new File(folder, arena.getName().toLowerCase() + ".yml");
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("name", arena.getName());
+        config.set("enabled", arena.isEnabled());
+        config.set("lobby", arena.getLobbyLocation());
+        config.set("npcs.shop", arena.getShopNpcLocation());
+        config.set("npcs.upgrade", arena.getUpgradeNpcLocation());
+
+        for (Map.Entry<TeamColor, Team> entry : arena.getTeams().entrySet()) {
+            String path = "teams." + entry.getKey().name();
+            config.set(path + ".spawn", entry.getValue().getSpawnLocation());
+            config.set(path + ".bed", entry.getValue().getBedLocation());
+        }
+
+        for (int i = 0; i < arena.getGenerators().size(); i++) {
+            Generator gen = arena.getGenerators().get(i);
+            String path = "generators." + i;
+            config.set(path + ".type", gen.getType().name());
+            config.set(path + ".location", gen.getLocation());
+            config.set(path + ".level", gen.getLevel());
+        }
+
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Could not save arena " + arena.getName() + ": " + e.getMessage());
+        }
     }
 
     /**
@@ -66,6 +155,8 @@ public class ArenaManager {
      * @param name the arena name
      */
     public void createArena(String name) {
-        arenas.put(name.toLowerCase(), new Arena(name));
+        Arena arena = new Arena(name);
+        arenas.put(name.toLowerCase(), arena);
+        saveArena(arena);
     }
 }

--- a/src/main/java/com/heneria/bedwars/utils/PositionTool.java
+++ b/src/main/java/com/heneria/bedwars/utils/PositionTool.java
@@ -1,0 +1,67 @@
+package com.heneria.bedwars.utils;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.Location;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Gives players a special tool to select positions in the world.
+ */
+public final class PositionTool {
+
+    private PositionTool() {}
+
+    private static final String TOOL_NAME = "Outil de Positionnement";
+    private static final Map<UUID, Consumer<Location>> pending = new HashMap<>();
+
+    /**
+     * Gives the player the position tool and registers a callback to be executed
+     * once the player selects a position.
+     *
+     * @param player   player receiving the tool
+     * @param callback action executed with the selected location
+     */
+    public static void request(Player player, Consumer<Location> callback) {
+        pending.put(player.getUniqueId(), callback);
+        ItemStack rod = new ItemStack(Material.BLAZE_ROD);
+        ItemMeta meta = rod.getItemMeta();
+        meta.setDisplayName(TOOL_NAME);
+        rod.setItemMeta(meta);
+        player.getInventory().addItem(rod);
+        player.sendMessage("Faites un clic droit pour définir la position.");
+    }
+
+    /**
+     * Handles a selection made by the player.
+     *
+     * @param player  the player
+     * @param location selected location
+     */
+    public static void handleSelection(Player player, Location location) {
+        Consumer<Location> callback = pending.remove(player.getUniqueId());
+        if (callback != null) {
+            callback.accept(location);
+        }
+    }
+
+    /**
+     * Checks whether the given item is the position tool.
+     *
+     * @param item item to check
+     * @return true if it is the tool
+     */
+    public static boolean isTool(ItemStack item) {
+        if (item == null || item.getType() != Material.BLAZE_ROD) {
+            return false;
+        }
+        ItemMeta meta = item.getItemMeta();
+        return meta != null && TOOL_NAME.equals(meta.getDisplayName());
+    }
+}


### PR DESCRIPTION
## Summary
- add ArenaList and per-arena configuration menus with options for lobby, teams, generators, NPCs and activation
- implement position tool for in-game location selection with listener and YAML persistence
- document completion of roadmap Step 1 and add administrator guide

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a23bb675948329a98bc7f3eee8b1c4