### PR TITLE
fix(arena): Resolve wizard flow interruption after name input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Corrigé
 - Suppression définitive de l'avertissement de dépréciation récurrent dans `ArenaNameMenu.java` pour assurer un build 100% propre.
+- Correction d'un bug critique où le wizard de création d'arène ne continuait pas après la saisie du nom dans l'enclume.
 
 ## [0.0.1] - En développement
 

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
@@ -5,8 +5,8 @@ import com.heneria.bedwars.gui.Menu;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
-import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.ItemStack;
 
 /**
@@ -31,19 +31,39 @@ public class ArenaNameMenu extends Menu {
         inventory.setItem(0, new ItemStack(Material.PAPER));
     }
 
-    @SuppressWarnings("deprecation")
     @Override
-    public void handleClick(org.bukkit.event.inventory.InventoryClickEvent event) {
+    public void handleClick(InventoryClickEvent event) {
         event.setCancelled(true);
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }
 
-        String name = ((AnvilInventory) event.getInventory()).getRenameText();
-        HeneriaBedwars.getInstance().getArenaManager().createArena(name);
+        if (event.getRawSlot() != 2) {
+            return;
+        }
+
+        ItemStack result = event.getCurrentItem();
+        if (result == null || !result.hasItemMeta()) {
+            player.sendMessage("Nom invalide.");
+            return;
+        }
+
+        String name = result.getItemMeta().getDisplayName().trim();
+        if (name.isEmpty()) {
+            player.sendMessage("Le nom ne peut pas être vide.");
+            return;
+        }
+
+        var manager = HeneriaBedwars.getInstance().getArenaManager();
+        if (manager.getArena(name) != null) {
+            player.sendMessage("Une arène avec ce nom existe déjà.");
+            return;
+        }
+
+        manager.createArena(name);
         player.sendMessage("Arène " + name + " créée.");
         player.closeInventory();
-        new ArenaConfigMenu(HeneriaBedwars.getInstance().getArenaManager().getArena(name)).open(player);
+        new ArenaConfigMenu(manager.getArena(name)).open(player);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- validate anvil result click when capturing arena name
- prevent empty or duplicate arena names and proceed to configuration
- document arena creation wizard fix

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2458e87148329a1bf2082cf54a01e