### PR TITLE
fix(arena): correct faulty name validation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Corrigé
 - Suppression définitive de l'avertissement de dépréciation récurrent dans `ArenaNameMenu.java` pour assurer un build 100% propre.
 - Correction d'un bug critique où le wizard de création d'arène ne continuait pas après la saisie du nom dans l'enclume.
+- Correction d'un bug critique où la validation du nom d'arène échouait systématiquement, empêchant toute création.
 
 ## [0.0.1] - En développement
 

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
@@ -42,21 +42,21 @@ public class ArenaNameMenu extends Menu {
             return;
         }
 
-        ItemStack result = event.getCurrentItem();
-        if (result == null || !result.hasItemMeta()) {
-            player.sendMessage("Nom invalide.");
+        ItemStack result = event.getInventory().getItem(0);
+        if (result == null || !result.hasItemMeta() || !result.getItemMeta().hasDisplayName()) {
+            player.sendMessage("§cLe nom de l'arène ne peut pas être vide.");
             return;
         }
 
         String name = result.getItemMeta().getDisplayName().trim();
         if (name.isEmpty()) {
-            player.sendMessage("Le nom ne peut pas être vide.");
+            player.sendMessage("§cLe nom de l'arène ne peut pas être vide.");
             return;
         }
 
         var manager = HeneriaBedwars.getInstance().getArenaManager();
         if (manager.getArena(name) != null) {
-            player.sendMessage("Une arène avec ce nom existe déjà.");
+            player.sendMessage("§cUne arène avec le nom '" + name + "' existe déjà.");
             return;
         }
 


### PR DESCRIPTION
## Summary
- fix arena name capture by reading anvil input slot and validating the display name
- add specific feedback when the name is empty or already taken
- document critical arena name validation bug in changelog

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a247fb0a9c832990b59c53810a0295