### PR TITLE
fix(arena): Definitive fix for arena creation wizard regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Suppression définitive de l'avertissement de dépréciation récurrent dans `ArenaNameMenu.java` pour assurer un build 100% propre.
 - Correction d'un bug critique où le wizard de création d'arène ne continuait pas après la saisie du nom dans l'enclume.
 - Correction d'un bug critique où la validation du nom d'arène échouait systématiquement, empêchant toute création.
+- Correction définitive d'une régression critique où le wizard de création d'arène se bloquait silencieusement après la saisie du nom.
 
 ## [0.0.1] - En développement
 

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaNameMenu.java
@@ -42,13 +42,17 @@ public class ArenaNameMenu extends Menu {
             return;
         }
 
-        ItemStack result = event.getInventory().getItem(0);
-        if (result == null || !result.hasItemMeta() || !result.getItemMeta().hasDisplayName()) {
+        ItemStack item = event.getCurrentItem();
+        if (item == null || item.getType() == Material.AIR) {
+            return;
+        }
+
+        if (!item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) {
             player.sendMessage("§cLe nom de l'arène ne peut pas être vide.");
             return;
         }
 
-        String name = result.getItemMeta().getDisplayName().trim();
+        String name = item.getItemMeta().getDisplayName().trim();
         if (name.isEmpty()) {
             player.sendMessage("§cLe nom de l'arène ne peut pas être vide.");
             return;


### PR DESCRIPTION
## Summary
- rewrite anvil click handler to properly validate arena names and open the next menu
- document the regression fix in the changelog

## Testing
- `mvn -q test` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a24a85c7c48329961e22d0b1d311d7