### PR TITLE
feat(ui): Implement GUI pagination, visual redesign, and message utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - HeneriaBedwars
 
+## [0.2.0] - En développement
+
+### Ajouté
+- Système de menus paginés avec classe de base `PaginatedMenu` et refonte du menu des générateurs.
+- Design unifié de toutes les interfaces avec bordures en vitres grises et lores colorées.
+- Utilitaire `MessageUtils` centralisant l'envoi de messages avec préfixe et codes couleurs.
+
 ## [0.1.2] - En développement
 
 ### Ajouté

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,10 +16,17 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 
 ---
 
-## 🎯 **Étape 2 : Cycle de Jeu & Lobby (Version Cible : 0.2.0)**
+## 🎯 **Étape 1.5 - Polissage & UX (Version Cible : 0.2.0) - [✔] TERMINÉE**
+* Ajout d'un système de pagination pour les menus.
+* Amélioration visuelle générale des GUIs.
+* Centralisation des messages via `MessageUtils`.
+
+---
+
+## 🎯 **Étape 2 : Cycle de Jeu & Lobby (Version Cible : 0.3.0)**
 *Objectif : Rendre les arènes jouables avec un cycle de vie complet, de l'attente au décompte, jusqu'à la fin de partie.*
 
-## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.3.0)**
+## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.4.0)**
 *Objectif : Intégrer les boutiques d'objets et d'améliorations d'équipe.*
 
 ## 🎯 **Étape 4 : Polissage & Fonctionnalités Avancées (Version Cible : 1.0.0)**

--- a/src/main/java/com/heneria/bedwars/commands/CommandManager.java
+++ b/src/main/java/com/heneria/bedwars/commands/CommandManager.java
@@ -3,6 +3,7 @@ package com.heneria.bedwars.commands;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.commands.subcommands.AdminCommand;
 import com.heneria.bedwars.commands.subcommands.SubCommand;
+import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -34,14 +35,14 @@ public class CommandManager implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage("Cette commande est réservée aux joueurs.");
+            MessageUtils.sendMessage(sender, "&cCette commande est réservée aux joueurs.");
             return true;
         }
 
         Player player = (Player) sender;
 
         if (args.length == 0) {
-            player.sendMessage("Usage: /" + label + " <admin>");
+            MessageUtils.sendMessage(player, "&eUsage: /" + label + " <admin>");
             return true;
         }
 
@@ -49,7 +50,7 @@ public class CommandManager implements CommandExecutor, TabCompleter {
         if (subCommand != null) {
             subCommand.execute(player, Arrays.copyOfRange(args, 1, args.length));
         } else {
-            player.sendMessage("Sous-commande inconnue.");
+            MessageUtils.sendMessage(player, "&cSous-commande inconnue.");
         }
         return true;
     }

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -1,6 +1,7 @@
 package com.heneria.bedwars.commands.subcommands;
 
 import com.heneria.bedwars.gui.admin.AdminMainMenu;
+import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.entity.Player;
 
 import java.util.Collections;
@@ -19,7 +20,7 @@ public class AdminCommand implements SubCommand {
     @Override
     public void execute(Player player, String[] args) {
         if (!player.hasPermission("heneriabw.admin")) {
-            player.sendMessage("Vous n'avez pas la permission.");
+            MessageUtils.sendMessage(player, "&cVous n'avez pas la permission.");
             return;
         }
         new AdminMainMenu().open(player);

--- a/src/main/java/com/heneria/bedwars/gui/PaginatedMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/PaginatedMenu.java
@@ -1,0 +1,89 @@
+package com.heneria.bedwars.gui;
+
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+/**
+ * Base menu supporting pagination.
+ */
+public abstract class PaginatedMenu extends Menu {
+
+    protected int page = 0;
+
+    protected ItemStack filler() {
+        return new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+    }
+
+    protected ItemStack previousButton() {
+        return new ItemBuilder(Material.ARROW).setName("&ePage précédente").build();
+    }
+
+    protected ItemStack nextButton() {
+        return new ItemBuilder(Material.ARROW).setName("&ePage suivante").build();
+    }
+
+    protected int getPrevButtonSlot() {
+        return 0;
+    }
+
+    protected int getNextButtonSlot() {
+        return getSize() - 1;
+    }
+
+    protected abstract int getItemStartSlot();
+
+    protected abstract int getItemsPerPage();
+
+    protected abstract List<ItemStack> getPaginatedItems();
+
+    protected abstract void handleMenuClick(InventoryClickEvent event);
+
+    protected void onItemSet(int index, int slot) {
+    }
+
+    @Override
+    public void setupItems() {
+        inventory.clear();
+        List<ItemStack> items = getPaginatedItems();
+        int start = page * getItemsPerPage();
+        for (int i = 0; i < getItemsPerPage(); i++) {
+            int index = start + i;
+            if (index >= items.size()) break;
+            int slot = getItemStartSlot() + i;
+            inventory.setItem(slot, items.get(index));
+            onItemSet(index, slot);
+        }
+        if (page > 0) {
+            inventory.setItem(getPrevButtonSlot(), previousButton());
+        }
+        if ((page + 1) * getItemsPerPage() < items.size()) {
+            inventory.setItem(getNextButtonSlot(), nextButton());
+        }
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler());
+            }
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        int slot = event.getRawSlot();
+        if (slot == getPrevButtonSlot() && page > 0) {
+            page--;
+            setupItems();
+            return;
+        }
+        if (slot == getNextButtonSlot() && (page + 1) * getItemsPerPage() < getPaginatedItems().size()) {
+            page++;
+            setupItems();
+            return;
+        }
+        handleMenuClick(event);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/admin/AdminMainMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/AdminMainMenu.java
@@ -3,6 +3,7 @@ package com.heneria.bedwars.gui.admin;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.gui.Menu;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -17,10 +18,16 @@ public class AdminMainMenu extends Menu {
 
     @Override
     public void setupItems() {
-        inventory.setItem(11, new ItemBuilder(Material.NETHER_STAR).setName("§aCréer une Arène").addLore("§7Cliquez pour lancer l'assistant")
-                .addLore("§7de création d'arène.").build());
-        inventory.setItem(15, new ItemBuilder(Material.COMPASS).setName("§eGérer les Arènes Existantes").addLore("§7Cliquez pour voir et configurer")
-                .addLore("§7les arènes déjà créées.").build());
+        inventory.setItem(11, new ItemBuilder(Material.NETHER_STAR)
+                .setName("&aCréer une Arène")
+                .addLore("&7Cliquez pour lancer l'assistant")
+                .addLore("&7de création d'arène.")
+                .build());
+        inventory.setItem(15, new ItemBuilder(Material.COMPASS)
+                .setName("&eGérer les Arènes Existantes")
+                .addLore("&7Cliquez pour voir et configurer")
+                .addLore("&7les arènes déjà créées.")
+                .build());
         for (int i = 0; i < getSize(); i++) {
             if (inventory.getItem(i) == null) {
                 inventory.setItem(i, new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build());
@@ -37,12 +44,11 @@ public class AdminMainMenu extends Menu {
         if (event.getSlot() == 11) {
             player.closeInventory();
             HeneriaBedwars.getInstance().getArenaManager().setPlayerInCreationMode(player);
-            player.sendMessage("§aVeuillez entrer le nom de la nouvelle arène dans le chat.");
-            player.sendMessage("§7Tapez 'annuler' pour quitter le mode création.");
+            MessageUtils.sendMessage(player, "&aVeuillez entrer le nom de la nouvelle arène dans le chat.");
+            MessageUtils.sendMessage(player, "&7Tapez 'annuler' pour quitter le mode création.");
         } else if (event.getSlot() == 15) {
             player.closeInventory();
             new ArenaListMenu().open(player);
         }
     }
 }
-

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaConfigMenu.java
@@ -4,12 +4,14 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.gui.Menu;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.MessageUtils;
 import com.heneria.bedwars.setup.SetupAction;
 import com.heneria.bedwars.setup.SetupType;
 import com.heneria.bedwars.arena.elements.Team;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Main configuration menu for a specific arena.
@@ -41,26 +43,38 @@ public class ArenaConfigMenu extends Menu {
     @Override
     public void setupItems() {
         inventory.setItem(SET_LOBBY_SLOT, new ItemBuilder(Material.ENDER_PEARL)
-                .setName("Définir le Lobby d'attente")
+                .setName("&eDéfinir le Lobby d'attente")
+                .addLore("&7Cliquez pour définir la position")
                 .build());
 
         inventory.setItem(TEAMS_SLOT, new ItemBuilder(Material.WHITE_BANNER)
-                .setName("Gestion des Équipes")
+                .setName("&eGestion des Équipes")
+                .addLore("&7Configurer les équipes de l'arène")
                 .build());
 
         inventory.setItem(GENERATORS_SLOT, new ItemBuilder(Material.FURNACE)
-                .setName("Gestion des Générateurs")
+                .setName("&eGestion des Générateurs")
+                .addLore("&7Ajouter ou supprimer des générateurs")
                 .build());
 
         inventory.setItem(NPC_SLOT, new ItemBuilder(Material.VILLAGER_SPAWN_EGG)
-                .setName("Gestion des PNJ")
+                .setName("&eGestion des PNJ")
+                .addLore("&7Définir les PNJ boutique et amélioration")
                 .build());
 
         Material toggleMaterial = arena.isEnabled() ? Material.REDSTONE_BLOCK : Material.EMERALD_BLOCK;
-        String toggleName = arena.isEnabled() ? "Désactiver l'arène" : "Activer l'arène";
+        String toggleName = arena.isEnabled() ? "&cDésactiver l'arène" : "&aActiver l'arène";
         inventory.setItem(TOGGLE_SLOT, new ItemBuilder(toggleMaterial)
                 .setName(toggleName)
+                .addLore("&7Statut actuel: " + (arena.isEnabled() ? "&aJOUABLE" : "&cINACTIF"))
                 .build());
+
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
+        }
     }
 
     @Override
@@ -74,7 +88,7 @@ public class ArenaConfigMenu extends Menu {
         if (slot == SET_LOBBY_SLOT) {
             HeneriaBedwars.getInstance().getSetupManager().startSetup(player,
                     new SetupAction(arena, SetupType.LOBBY));
-            player.sendMessage("Faites un clic droit pour définir le lobby.");
+            MessageUtils.sendMessage(player, "&eFaites un clic droit pour définir le lobby.");
             player.closeInventory();
         } else if (slot == TEAMS_SLOT) {
             new TeamListMenu(arena).open(player);
@@ -85,24 +99,24 @@ public class ArenaConfigMenu extends Menu {
         } else if (slot == TOGGLE_SLOT) {
             if (!arena.isEnabled()) {
                 if (arena.getLobbyLocation() == null) {
-                    player.sendMessage("Le lobby n'est pas défini.");
+                    MessageUtils.sendMessage(player, "&cLe lobby n'est pas défini.");
                     return;
                 }
                 for (Team team : arena.getTeams().values()) {
                     if (team.getSpawnLocation() == null || team.getBedLocation() == null) {
-                        player.sendMessage("Toutes les équipes n'ont pas leur spawn et leur lit définis.");
+                        MessageUtils.sendMessage(player, "&cToutes les équipes n'ont pas leur spawn et leur lit définis.");
                         return;
                     }
                 }
                 if (arena.getTeams().isEmpty()) {
-                    player.sendMessage("Aucune équipe configurée.");
+                    MessageUtils.sendMessage(player, "&cAucune équipe configurée.");
                     return;
                 }
                 arena.setEnabled(true);
-                player.sendMessage("Arène activée.");
+                MessageUtils.sendMessage(player, "&aArène activée.");
             } else {
                 arena.setEnabled(false);
-                player.sendMessage("Arène désactivée.");
+                MessageUtils.sendMessage(player, "&cArène désactivée.");
             }
             HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
             player.closeInventory();

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaListMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaListMenu.java
@@ -33,14 +33,21 @@ public class ArenaListMenu extends Menu {
     public void setupItems() {
         int slot = 0;
         for (Arena arena : HeneriaBedwars.getInstance().getArenaManager().getAllArenas()) {
-            String status = arena.isEnabled() ? "§aJOUABLE" : "§cINCOMPLET";
+            String status = arena.isEnabled() ? "&aJOUABLE" : "&cINCOMPLET";
             ItemStack item = new ItemBuilder(Material.PAPER)
-                    .setName(arena.getName())
-                    .addLore("Statut : " + status)
+                    .setName("&e" + arena.getName())
+                    .addLore("&7Statut actuel: " + status)
+                    .addLore("&eCliquez pour configurer")
                     .build();
             inventory.setItem(slot, item);
             arenaSlots.put(slot, arena);
             slot++;
+        }
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
         }
     }
 

--- a/src/main/java/com/heneria/bedwars/gui/admin/GeneratorConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/GeneratorConfigMenu.java
@@ -2,32 +2,36 @@ package com.heneria.bedwars.gui.admin;
 
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
-import com.heneria.bedwars.gui.Menu;
-import com.heneria.bedwars.utils.ItemBuilder;
-import com.heneria.bedwars.setup.SetupAction;
-import com.heneria.bedwars.setup.SetupType;
 import com.heneria.bedwars.arena.elements.Generator;
 import com.heneria.bedwars.arena.enums.GeneratorType;
+import com.heneria.bedwars.gui.PaginatedMenu;
+import com.heneria.bedwars.setup.SetupAction;
+import com.heneria.bedwars.setup.SetupType;
+import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
- * Menu for configuring resource generators.
+ * Menu for configuring resource generators with pagination.
  */
-public class GeneratorConfigMenu extends Menu {
+public class GeneratorConfigMenu extends PaginatedMenu {
 
     private final Arena arena;
+    private final Map<Integer, Generator> generatorSlots = new HashMap<>();
+    private List<Generator> generators = new ArrayList<>();
 
     private static final int IRON_SLOT = 10;
     private static final int GOLD_SLOT = 12;
     private static final int DIAMOND_SLOT = 14;
     private static final int EMERALD_SLOT = 16;
-
-    private final Map<Integer, Generator> generatorSlots = new HashMap<>();
 
     public GeneratorConfigMenu(Arena arena) {
         this.arena = arena;
@@ -44,64 +48,96 @@ public class GeneratorConfigMenu extends Menu {
     }
 
     @Override
-    public void setupItems() {
-        inventory.setItem(IRON_SLOT, new ItemBuilder(Material.IRON_INGOT)
-                .setName("Ajouter un générateur de Fer")
-                .build());
-        inventory.setItem(GOLD_SLOT, new ItemBuilder(Material.GOLD_INGOT)
-                .setName("Ajouter un générateur d'Or")
-                .build());
-        inventory.setItem(DIAMOND_SLOT, new ItemBuilder(Material.DIAMOND)
-                .setName("Ajouter un générateur de Diamant")
-                .build());
-        inventory.setItem(EMERALD_SLOT, new ItemBuilder(Material.EMERALD)
-                .setName("Ajouter un générateur d'Émeraude")
-                .build());
-
-        int slot = 18;
-        for (Generator gen : arena.getGenerators()) {
-            Material mat = materialFromType(gen.getType());
-            ItemStack item = new ItemBuilder(mat)
-                    .setName("Générateur " + gen.getType().name())
-                    .addLore("Cliquez pour supprimer")
-                    .build();
-            inventory.setItem(slot, item);
-            generatorSlots.put(slot, gen);
-            slot++;
-        }
+    protected int getItemStartSlot() {
+        return 18;
     }
 
     @Override
-    public void handleClick(InventoryClickEvent event) {
-        event.setCancelled(true);
-        if (!(event.getWhoClicked() instanceof Player player)) {
-            return;
+    protected int getItemsPerPage() {
+        return 9;
+    }
+
+    @Override
+    protected int getPrevButtonSlot() {
+        return 0;
+    }
+
+    @Override
+    protected int getNextButtonSlot() {
+        return 8;
+    }
+
+    @Override
+    protected List<ItemStack> getPaginatedItems() {
+        generators = new ArrayList<>(arena.getGenerators());
+        List<ItemStack> items = new ArrayList<>();
+        for (Generator gen : generators) {
+            Material mat = materialFromType(gen.getType());
+            ItemStack item = new ItemBuilder(mat)
+                    .setName("&eGénérateur " + gen.getType().name())
+                    .addLore("&cCliquez pour supprimer")
+                    .build();
+            items.add(item);
         }
+        return items;
+    }
+
+    @Override
+    protected void onItemSet(int index, int slot) {
+        generatorSlots.put(slot, generators.get(index));
+    }
+
+    @Override
+    protected void handleMenuClick(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
         int slot = event.getRawSlot();
         if (slot == IRON_SLOT) {
-            HeneriaBedwars.getInstance().getSetupManager().startSetup(player,
-                    new SetupAction(arena, SetupType.GENERATOR, GeneratorType.IRON));
+            startSetup(player, GeneratorType.IRON);
         } else if (slot == GOLD_SLOT) {
-            HeneriaBedwars.getInstance().getSetupManager().startSetup(player,
-                    new SetupAction(arena, SetupType.GENERATOR, GeneratorType.GOLD));
+            startSetup(player, GeneratorType.GOLD);
         } else if (slot == DIAMOND_SLOT) {
-            HeneriaBedwars.getInstance().getSetupManager().startSetup(player,
-                    new SetupAction(arena, SetupType.GENERATOR, GeneratorType.DIAMOND));
+            startSetup(player, GeneratorType.DIAMOND);
         } else if (slot == EMERALD_SLOT) {
-            HeneriaBedwars.getInstance().getSetupManager().startSetup(player,
-                    new SetupAction(arena, SetupType.GENERATOR, GeneratorType.EMERALD));
+            startSetup(player, GeneratorType.EMERALD);
         } else if (generatorSlots.containsKey(slot)) {
             arena.getGenerators().remove(generatorSlots.get(slot));
             HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
-            player.sendMessage("Générateur supprimé.");
-            player.closeInventory();
-            new GeneratorConfigMenu(arena).open(player);
-            return;
-        } else {
-            return;
+            MessageUtils.sendMessage(player, "&cGénérateur supprimé.");
+            generatorSlots.clear();
+            if (page > 0 && page * getItemsPerPage() >= arena.getGenerators().size()) {
+                page--;
+            }
+            setupItems();
         }
-        player.sendMessage("Clic droit pour définir la position du générateur.");
+    }
+
+    private void startSetup(Player player, GeneratorType type) {
+        HeneriaBedwars.getInstance().getSetupManager().startSetup(player,
+                new SetupAction(arena, SetupType.GENERATOR, type));
+        MessageUtils.sendMessage(player, "&eClic droit pour définir la position du générateur.");
         player.closeInventory();
+    }
+
+    @Override
+    public void setupItems() {
+        generatorSlots.clear();
+        super.setupItems();
+        inventory.setItem(IRON_SLOT, new ItemBuilder(Material.IRON_INGOT)
+                .setName("&fAjouter un générateur de Fer")
+                .addLore("&eCliquez pour commencer")
+                .build());
+        inventory.setItem(GOLD_SLOT, new ItemBuilder(Material.GOLD_INGOT)
+                .setName("&fAjouter un générateur d'Or")
+                .addLore("&eCliquez pour commencer")
+                .build());
+        inventory.setItem(DIAMOND_SLOT, new ItemBuilder(Material.DIAMOND)
+                .setName("&fAjouter un générateur de Diamant")
+                .addLore("&eCliquez pour commencer")
+                .build());
+        inventory.setItem(EMERALD_SLOT, new ItemBuilder(Material.EMERALD)
+                .setName("&fAjouter un générateur d'Émeraude")
+                .addLore("&eCliquez pour commencer")
+                .build());
     }
 
     private Material materialFromType(GeneratorType type) {

--- a/src/main/java/com/heneria/bedwars/gui/admin/NpcConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/NpcConfigMenu.java
@@ -4,11 +4,13 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.gui.Menu;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.MessageUtils;
 import com.heneria.bedwars.setup.SetupAction;
 import com.heneria.bedwars.setup.SetupType;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Menu for configuring NPC positions.
@@ -37,11 +39,19 @@ public class NpcConfigMenu extends Menu {
     @Override
     public void setupItems() {
         inventory.setItem(SHOP_SLOT, new ItemBuilder(Material.EMERALD)
-                .setName("Définir le PNJ Boutique")
+                .setName("&eDéfinir le PNJ Boutique")
+                .addLore("&7Cliquez pour définir la position")
                 .build());
         inventory.setItem(UPGRADE_SLOT, new ItemBuilder(Material.ANVIL)
-                .setName("Définir le PNJ Améliorations")
+                .setName("&eDéfinir le PNJ Améliorations")
+                .addLore("&7Cliquez pour définir la position")
                 .build());
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
+        }
     }
 
     @Override
@@ -60,7 +70,7 @@ public class NpcConfigMenu extends Menu {
         } else {
             return;
         }
-        player.sendMessage("Clic droit pour définir la position du PNJ.");
+        MessageUtils.sendMessage(player, "&eClic droit pour définir la position du PNJ.");
         player.closeInventory();
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/admin/TeamConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/TeamConfigMenu.java
@@ -5,11 +5,13 @@ import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.enums.TeamColor;
 import com.heneria.bedwars.gui.Menu;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.MessageUtils;
 import com.heneria.bedwars.setup.SetupAction;
 import com.heneria.bedwars.setup.SetupType;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Menu to configure spawn and bed for a specific team.
@@ -40,11 +42,19 @@ public class TeamConfigMenu extends Menu {
     @Override
     public void setupItems() {
         inventory.setItem(SPAWN_SLOT, new ItemBuilder(Material.COMPASS)
-                .setName("Définir le spawn")
+                .setName("&eDéfinir le spawn")
+                .addLore("&7Cliquez pour définir la position")
                 .build());
         inventory.setItem(BED_SLOT, new ItemBuilder(Material.RED_BED)
-                .setName("Définir le lit")
+                .setName("&eDéfinir le lit")
+                .addLore("&7Cliquez pour définir la position")
                 .build());
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
+        }
     }
 
     @Override
@@ -57,12 +67,12 @@ public class TeamConfigMenu extends Menu {
         if (slot == SPAWN_SLOT) {
             HeneriaBedwars.getInstance().getSetupManager().startSetup(player,
                     new SetupAction(arena, SetupType.TEAM_SPAWN, color));
-            player.sendMessage("Clic droit pour définir le spawn.");
+            MessageUtils.sendMessage(player, "&eClic droit pour définir le spawn.");
             player.closeInventory();
         } else if (slot == BED_SLOT) {
             HeneriaBedwars.getInstance().getSetupManager().startSetup(player,
                     new SetupAction(arena, SetupType.TEAM_BED, color));
-            player.sendMessage("Clic droit pour définir le lit.");
+            MessageUtils.sendMessage(player, "&eClic droit pour définir le lit.");
             player.closeInventory();
         }
     }

--- a/src/main/java/com/heneria/bedwars/gui/admin/TeamListMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/TeamListMenu.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.enums.TeamColor;
 import com.heneria.bedwars.gui.Menu;
 import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
@@ -39,10 +40,17 @@ public class TeamListMenu extends Menu {
         for (TeamColor color : TeamColor.values()) {
             ItemStack item = new ItemBuilder(color.getWoolMaterial())
                     .setName(color.getChatColor() + color.getDisplayName())
+                    .addLore("&eCliquez pour configurer")
                     .build();
             inventory.setItem(slot, item);
             teamSlots.put(slot, color);
             slot++;
+        }
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
         }
     }
 

--- a/src/main/java/com/heneria/bedwars/gui/admin/creation/ArenaSettingsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/creation/ArenaSettingsMenu.java
@@ -3,9 +3,11 @@ package com.heneria.bedwars.gui.admin.creation;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.gui.Menu;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
 
 public class ArenaSettingsMenu extends Menu {
 
@@ -30,14 +32,25 @@ public class ArenaSettingsMenu extends Menu {
     @Override
     public void setupItems() {
         inventory.setItem(11, new ItemBuilder(Material.PLAYER_HEAD)
-                .setName("§aJoueurs par équipe: " + playersPerTeam)
+                .setName("&aJoueurs par équipe: " + playersPerTeam)
+                .addLore("&7Clic gauche: &e+1")
+                .addLore("&7Clic droit: &e-1")
                 .build());
         inventory.setItem(13, new ItemBuilder(Material.PAPER)
-                .setName("§aNombre d'équipes: " + teamCount)
+                .setName("&aNombre d'équipes: " + teamCount)
+                .addLore("&7Clic gauche: &e+1")
+                .addLore("&7Clic droit: &e-1")
                 .build());
         inventory.setItem(15, new ItemBuilder(Material.EMERALD_BLOCK)
-                .setName("§2§lCONFIRMER LA CRÉATION")
+                .setName("&2&lCONFIRMER LA CRÉATION")
+                .addLore("&7Valider et créer l'arène")
                 .build());
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
+        }
     }
 
     @Override
@@ -62,7 +75,7 @@ public class ArenaSettingsMenu extends Menu {
             Player player = (Player) event.getWhoClicked();
             player.closeInventory();
             HeneriaBedwars.getInstance().getArenaManager().createAndSaveArena(arenaName, playersPerTeam, teamCount);
-            player.sendMessage("§aL'arène '§e" + arenaName + "§a' a été créée avec succès !");
+            MessageUtils.sendMessage(player, "&aL'arène '&e" + arenaName + "&a' a été créée avec succès !");
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
@@ -3,6 +3,7 @@ package com.heneria.bedwars.listeners;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.gui.admin.creation.ArenaSettingsMenu;
 import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -22,21 +23,21 @@ public class ChatListener implements Listener {
 
             if (arenaName.equalsIgnoreCase("annuler")) {
                 arenaManager.removePlayerFromCreationMode(player);
-                player.sendMessage("§cCréation d'arène annulée.");
+                MessageUtils.sendMessage(player, "&cCréation d'arène annulée.");
                 return;
             }
 
             if (arenaName.trim().isEmpty() || arenaName.length() > 16) {
-                player.sendMessage("§cNom invalide (1-16 caractères). Veuillez réessayer ou tapez 'annuler'.");
+                MessageUtils.sendMessage(player, "&cNom invalide (1-16 caractères). Veuillez réessayer ou tapez 'annuler'.");
                 return;
             }
             if (arenaManager.getArena(arenaName) != null) {
-                player.sendMessage("§cUne arène avec ce nom existe déjà. Veuillez réessayer ou tapez 'annuler'.");
+                MessageUtils.sendMessage(player, "&cUne arène avec ce nom existe déjà. Veuillez réessayer ou tapez 'annuler'.");
                 return;
             }
 
             arenaManager.removePlayerFromCreationMode(player);
-            player.sendMessage("§aNom '§e" + arenaName + "§a' validé !");
+            MessageUtils.sendMessage(player, "&aNom '&e" + arenaName + "&a' validé !");
 
             Bukkit.getScheduler().runTask(HeneriaBedwars.getInstance(), () -> {
                 new ArenaSettingsMenu(arenaName).open(player);

--- a/src/main/java/com/heneria/bedwars/listeners/SetupListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SetupListener.java
@@ -9,6 +9,7 @@ import com.heneria.bedwars.arena.enums.TeamColor;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.setup.SetupAction;
 import com.heneria.bedwars.setup.SetupType;
+import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -49,24 +50,24 @@ public class SetupListener implements Listener {
 
         if (action.getType() == SetupType.LOBBY) {
             arena.setLobbyLocation(loc);
-            player.sendMessage("Lobby défini.");
+            MessageUtils.sendMessage(player, "&aLobby défini.");
         } else if (action.getType() == SetupType.TEAM_SPAWN && action.getTeamColor() != null) {
             Team team = arena.getTeams().computeIfAbsent(action.getTeamColor(), Team::new);
             team.setSpawnLocation(loc);
-            player.sendMessage("Spawn de l'équipe " + action.getTeamColor().getDisplayName() + " défini.");
+            MessageUtils.sendMessage(player, "&aSpawn de l'équipe " + action.getTeamColor().getDisplayName() + " défini.");
         } else if (action.getType() == SetupType.TEAM_BED && action.getTeamColor() != null) {
             Team team = arena.getTeams().computeIfAbsent(action.getTeamColor(), Team::new);
             team.setBedLocation(loc);
-            player.sendMessage("Lit de l'équipe " + action.getTeamColor().getDisplayName() + " défini.");
+            MessageUtils.sendMessage(player, "&aLit de l'équipe " + action.getTeamColor().getDisplayName() + " défini.");
         } else if (action.getType() == SetupType.GENERATOR && action.getGeneratorType() != null) {
             arena.getGenerators().add(new Generator(loc, action.getGeneratorType(), 1));
-            player.sendMessage("Générateur " + action.getGeneratorType().name() + " ajouté.");
+            MessageUtils.sendMessage(player, "&aGénérateur " + action.getGeneratorType().name() + " ajouté.");
         } else if (action.getType() == SetupType.NPC_SHOP) {
             arena.setShopNpcLocation(loc);
-            player.sendMessage("PNJ Boutique défini.");
+            MessageUtils.sendMessage(player, "&aPNJ Boutique défini.");
         } else if (action.getType() == SetupType.NPC_UPGRADE) {
             arena.setUpgradeNpcLocation(loc);
-            player.sendMessage("PNJ Améliorations défini.");
+            MessageUtils.sendMessage(player, "&aPNJ Améliorations défini.");
         }
 
         HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);

--- a/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
+++ b/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
@@ -44,7 +44,11 @@ public class ItemBuilder {
      * @return this builder
      */
     public ItemBuilder setLore(List<String> lore) {
-        meta.setLore(lore);
+        List<String> colored = new ArrayList<>();
+        for (String line : lore) {
+            colored.add(ChatColor.translateAlternateColorCodes('&', line));
+        }
+        meta.setLore(colored);
         return this;
     }
 
@@ -59,7 +63,7 @@ public class ItemBuilder {
         if (lore == null) {
             lore = new ArrayList<>();
         }
-        lore.add(line);
+        lore.add(ChatColor.translateAlternateColorCodes('&', line));
         meta.setLore(lore);
         itemStack.setItemMeta(meta);
         return this;

--- a/src/main/java/com/heneria/bedwars/utils/MessageUtils.java
+++ b/src/main/java/com/heneria/bedwars/utils/MessageUtils.java
@@ -1,0 +1,36 @@
+package com.heneria.bedwars.utils;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Utility for sending formatted plugin messages.
+ */
+public final class MessageUtils {
+
+    private static final String PREFIX = "§8[§bHeneriaBedwars§8]§r ";
+
+    private MessageUtils() {
+    }
+
+    /**
+     * Sends a formatted message to a player.
+     *
+     * @param player the player
+     * @param message the message
+     */
+    public static void sendMessage(Player player, String message) {
+        sendMessage((CommandSender) player, message);
+    }
+
+    /**
+     * Sends a formatted message to any command sender.
+     *
+     * @param sender the command sender
+     * @param message the message
+     */
+    public static void sendMessage(CommandSender sender, String message) {
+        sender.sendMessage(PREFIX + ChatColor.translateAlternateColorCodes('&', message));
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `PaginatedMenu` base class and refactor generator config to support multi-page lists
- polish GUIs with gray glass borders, richer lore, and consistent design
- create `MessageUtils` for prefixed & colored chat messages and update codebase

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a262ceb1a883299b735de331a3f8a9