### PR TITLE
feat: configurable generator tiers and central manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Commandes `/bw join` et `/bw leave` pour les joueurs.
 - Lobby d'attente avec décompte et barre d'expérience en progression.
 - Lancement de la partie avec téléportation des joueurs et démarrage des générateurs.
+- Système de vitesse de génération des ressources configurable par type et par niveau.
 
 ## [0.1.2] - En développement
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,22 @@ Consultez notre [ROADMAP.md](ROADMAP.md) pour suivre le développement du projet
    - *Gérer les Générateurs* : ajoutez un générateur de ressource ou cliquez sur un existant pour le supprimer.
    - *Gérer les PNJ* : positionnez la **Boutique d'objets** et la **Boutique d'améliorations**.
 5. **Activer l'arène** : lorsque le lobby, les spawns et lits de chaque équipe sont définis, utilisez le bouton d'activation pour rendre l'arène jouable. Toutes les positions sont sauvegardées immédiatement.
+
+## ⚙️ Configuration des Générateurs
+
+Les vitesses et quantités des ressources générées sont définies dans le fichier `generators.yml`. Ce fichier est créé automatiquement lors du premier lancement du plugin et peut être personnalisé pour ajuster le délai (en secondes) et le nombre d'items produits pour chaque type de ressource et chaque niveau.
+
+```yaml
+IRON:
+  tier-1:
+    delay: 1.5
+    amount: 1
+  tier-2:
+    delay: 1.0
+    amount: 1
+  tier-3:
+    delay: 0.5
+    amount: 2
+```
+
+Modifiez ces valeurs selon vos besoins puis rechargez le plugin pour appliquer les changements.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 * [✔] Système pour rejoindre/quitter une arène.
 * [✔] Lobby d'attente avec décompte.
 * [✔] Lancement de la partie (téléportation, démarrage des générateurs).
+* [✔] Vitesse et niveaux des générateurs de ressources.
 * [ ] Gestion de la réapparition et de la destruction des lits.
 
 ## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.4.0)**

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -7,6 +7,7 @@ import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.listeners.GameListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
+import com.heneria.bedwars.managers.GeneratorManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class HeneriaBedwars extends JavaPlugin {
@@ -14,6 +15,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private static HeneriaBedwars instance;
     private ArenaManager arenaManager;
     private SetupManager setupManager;
+    private GeneratorManager generatorManager;
 
     @Override
     public void onEnable() {
@@ -24,6 +26,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.arenaManager = new ArenaManager(this);
         this.arenaManager.loadArenas(); // Charge les arènes depuis les fichiers de config
         this.setupManager = new SetupManager();
+        this.generatorManager = new GeneratorManager(this);
 
         // Enregistrement des commandes
         CommandManager commandManager = new CommandManager(this);
@@ -76,5 +79,9 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public SetupManager getSetupManager() {
         return setupManager;
+    }
+
+    public GeneratorManager getGeneratorManager() {
+        return generatorManager;
     }
 }

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -4,7 +4,6 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.elements.Generator;
 import com.heneria.bedwars.arena.elements.Team;
 import com.heneria.bedwars.arena.enums.GameState;
-import com.heneria.bedwars.arena.enums.GeneratorType;
 import com.heneria.bedwars.arena.enums.TeamColor;
 import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.Bukkit;
@@ -36,7 +35,6 @@ public class Arena {
     private Location upgradeNpcLocation;
     private final Map<UUID, PlayerData> savedStates = new HashMap<>();
     private BukkitTask countdownTask;
-    private final List<BukkitTask> generatorTasks = new ArrayList<>();
     private int countdownDuration = 10;
 
     /**
@@ -316,26 +314,8 @@ public class Arena {
             p.setLevel(0);
             p.setExp(0f);
         }
-        startGenerators();
-    }
-
-    private void startGenerators() {
         for (Generator gen : generators) {
-            BukkitTask task = new BukkitRunnable() {
-                @Override
-                public void run() {
-                    Material material;
-                    GeneratorType type = gen.getType();
-                    switch (type) {
-                        case GOLD -> material = Material.GOLD_INGOT;
-                        case DIAMOND -> material = Material.DIAMOND;
-                        case EMERALD -> material = Material.EMERALD;
-                        default -> material = Material.IRON_INGOT;
-                    }
-                    gen.getLocation().getWorld().dropItemNaturally(gen.getLocation(), new ItemStack(material));
-                }
-            }.runTaskTimer(HeneriaBedwars.getInstance(), 0L, 20L * 5);
-            generatorTasks.add(task);
+            HeneriaBedwars.getInstance().getGeneratorManager().registerGenerator(gen);
         }
     }
 

--- a/src/main/java/com/heneria/bedwars/arena/elements/Generator.java
+++ b/src/main/java/com/heneria/bedwars/arena/elements/Generator.java
@@ -11,6 +11,7 @@ public class Generator {
     private Location location;
     private GeneratorType type;
     private int level;
+    private int tier = 1;
 
     /**
      * Creates a new generator.
@@ -77,5 +78,23 @@ public class Generator {
      */
     public void setLevel(int level) {
         this.level = level;
+    }
+
+    /**
+     * Gets the tier of the generator.
+     *
+     * @return the tier
+     */
+    public int getTier() {
+        return tier;
+    }
+
+    /**
+     * Sets the tier of the generator.
+     *
+     * @param tier the new tier
+     */
+    public void setTier(int tier) {
+        this.tier = tier;
     }
 }

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -1,0 +1,114 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Centralized manager handling resource generators for all arenas.
+ */
+public class GeneratorManager {
+
+    private static final int TICK_RATE = 10; // 0.5 seconds
+
+    private final HeneriaBedwars plugin;
+    private final Map<Generator, Integer> counters = new HashMap<>();
+    private final Map<GeneratorType, Map<Integer, GeneratorSettings>> settings = new EnumMap<>(GeneratorType.class);
+
+    public GeneratorManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        loadConfiguration();
+        startTask();
+    }
+
+    private void loadConfiguration() {
+        File file = new File(plugin.getDataFolder(), "generators.yml");
+        if (!file.exists()) {
+            plugin.saveResource("generators.yml", false);
+        }
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        for (GeneratorType type : GeneratorType.values()) {
+            Map<Integer, GeneratorSettings> tierMap = new HashMap<>();
+            if (config.contains(type.name())) {
+                for (String key : Objects.requireNonNull(config.getConfigurationSection(type.name())).getKeys(false)) {
+                    if (!key.startsWith("tier-")) {
+                        continue;
+                    }
+                    int tier = Integer.parseInt(key.substring(5));
+                    double delay = config.getDouble(type.name() + "." + key + ".delay", 1.0);
+                    int amount = config.getInt(type.name() + "." + key + ".amount", 1);
+                    tierMap.put(tier, new GeneratorSettings(delay, amount));
+                }
+            }
+            settings.put(type, tierMap);
+        }
+    }
+
+    private void startTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                tick();
+            }
+        }.runTaskTimer(plugin, 0L, TICK_RATE);
+    }
+
+    private void tick() {
+        for (Map.Entry<Generator, Integer> entry : counters.entrySet()) {
+            int remaining = entry.getValue() - 1;
+            if (remaining <= 0) {
+                spawn(entry.getKey());
+                remaining = getDelayCycles(entry.getKey());
+            }
+            entry.setValue(remaining);
+        }
+    }
+
+    private void spawn(Generator gen) {
+        GeneratorSettings gs = getSettings(gen);
+        if (gs == null || gen.getLocation() == null || gen.getLocation().getWorld() == null) {
+            return;
+        }
+        Material material;
+        switch (gen.getType()) {
+            case GOLD -> material = Material.GOLD_INGOT;
+            case DIAMOND -> material = Material.DIAMOND;
+            case EMERALD -> material = Material.EMERALD;
+            default -> material = Material.IRON_INGOT;
+        }
+        gen.getLocation().getWorld().dropItemNaturally(gen.getLocation(), new ItemStack(material, gs.amount()));
+    }
+
+    private GeneratorSettings getSettings(Generator gen) {
+        Map<Integer, GeneratorSettings> map = settings.get(gen.getType());
+        if (map == null) {
+            return null;
+        }
+        return map.get(gen.getTier());
+    }
+
+    private int getDelayCycles(Generator gen) {
+        GeneratorSettings gs = getSettings(gen);
+        if (gs == null) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) Math.round(gs.delay() * 20.0 / TICK_RATE);
+    }
+
+    public void registerGenerator(Generator gen) {
+        counters.put(gen, getDelayCycles(gen));
+    }
+
+    /**
+     * Record of delay and amount for a generator tier.
+     */
+    private record GeneratorSettings(double delay, int amount) {
+    }
+}

--- a/src/main/resources/generators.yml
+++ b/src/main/resources/generators.yml
@@ -1,0 +1,28 @@
+IRON:
+  tier-1:
+    delay: 1.5
+    amount: 1
+  tier-2:
+    delay: 1.0
+    amount: 1
+  tier-3:
+    delay: 0.5
+    amount: 2
+GOLD:
+  tier-1:
+    delay: 6.0
+    amount: 1
+  tier-2:
+    delay: 4.0
+    amount: 1
+DIAMOND:
+  tier-1:
+    delay: 30.0
+    amount: 1
+  tier-2:
+    delay: 20.0
+    amount: 1
+EMERALD:
+  tier-1:
+    delay: 65.0
+    amount: 1


### PR DESCRIPTION
## Summary
- add configurable generator tiers via new `generators.yml`
- centralize generator logic in `GeneratorManager`
- document generator configuration and update roadmap/changelog

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e7ba035083299ff5b051f1ad0b2f