### PR TITLE
HBW-023: Correction de l'orientation de la vue au spawn du lobby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Amélioré
 - L'orientation des joueurs au spawn est désormais normalisée pour qu'ils regardent toujours droit devant.
+- L'orientation de la vue est également normalisée lors de l'apparition dans le lobby d'attente.
 
 ## [0.1.2] - En développement
 

--- a/src/main/java/com/heneria/bedwars/listeners/SetupListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SetupListener.java
@@ -50,7 +50,18 @@ public class SetupListener implements Listener {
         Location loc = player.getLocation();
 
         if (action.getType() == SetupType.LOBBY) {
-            arena.setLobbyLocation(loc);
+            Block clickedBlock = event.getClickedBlock();
+            if (clickedBlock == null) {
+                MessageUtils.sendMessage(player, "&cVeuillez cliquer sur un bloc pour définir le lobby.");
+                return;
+            }
+            double x = clickedBlock.getX() + 0.5;
+            double y = clickedBlock.getY() + 1.0;
+            double z = clickedBlock.getZ() + 0.5;
+            float yaw = player.getLocation().getYaw();
+            float pitch = 0.0f;
+            Location lobbyLocation = new Location(player.getWorld(), x, y, z, yaw, pitch);
+            arena.setLobbyLocation(lobbyLocation);
             MessageUtils.sendMessage(player, "&aLobby défini.");
         } else if (action.getType() == SetupType.TEAM_SPAWN && action.getTeamColor() != null) {
             Block clickedBlock = event.getClickedBlock();


### PR DESCRIPTION
## Summary
- Construit une `Location` normalisée lors de la définition du lobby, en forçant le pitch à 0.
- Documente l'amélioration de l'apparition dans le lobby.

## Testing
- ⚠️ `mvn -q test` *(failed: Network is unreachable while resolving Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ed393f84832984321ae1bac36514