### PR TITLE
HBW-024: ajout des mécaniques de mort et destruction des lits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Lobby d'attente avec décompte et barre d'expérience en progression.
 - Lancement de la partie avec téléportation des joueurs et démarrage des générateurs.
 - Système de vitesse de génération des ressources configurable par type et par niveau.
+- Mécaniques de mort, réapparition et destruction des lits.
 
 ### Amélioré
 - L'orientation des joueurs au spawn est désormais normalisée pour qu'ils regardent toujours droit devant.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Notre objectif principal est de fournir un système de gestion d'arène via une 
 
 Consultez notre [ROADMAP.md](ROADMAP.md) pour suivre le développement du projet étape par étape.
 
+## 🕹️ Gameplay
+
+Chaque équipe possède un lit. Tant que ce lit est intact, les joueurs de l'équipe réapparaissent après quelques secondes.
+Si le lit est détruit, toute mort devient définitive : le joueur est éliminé et passe en mode spectateur pour la fin de la partie.
+Détruisez les lits adverses tout en protégeant le vôtre pour remporter la victoire.
+
 ## 🔧 Compilation
 
 1.  Clonez ce dépôt : `git clone https://github.com/tomashb/HeneriaBW.git`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,8 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 * [✔] Lobby d'attente avec décompte.
 * [✔] Lancement de la partie (téléportation, démarrage des générateurs).
 * [✔] Vitesse et niveaux des générateurs de ressources.
-* [ ] Gestion de la réapparition et de la destruction des lits.
+* [✔] Gestion de la réapparition et de la destruction des lits.
+* [ ] Conditions de victoire et fin de partie.
 
 ## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.4.0)**
 *Objectif : Intégrer les boutiques d'objets et d'améliorations d'équipe.*

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -5,6 +5,8 @@ import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.listeners.ChatListener;
 import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.listeners.GameListener;
+import com.heneria.bedwars.listeners.PlayerDeathListener;
+import com.heneria.bedwars.listeners.BedBreakListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -58,6 +60,8 @@ public final class HeneriaBedwars extends JavaPlugin {
         // Gère les interactions avec l'outil de positionnement
         getServer().getPluginManager().registerEvents(new SetupListener(setupManager), this);
         getServer().getPluginManager().registerEvents(new GameListener(), this);
+        getServer().getPluginManager().registerEvents(new PlayerDeathListener(), this);
+        getServer().getPluginManager().registerEvents(new BedBreakListener(), this);
     }
 
 

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -28,6 +28,8 @@ public class Arena {
     private int minPlayers;
     private int maxPlayers;
     private final List<UUID> players = new ArrayList<>();
+    private final List<UUID> alivePlayers = new ArrayList<>();
+    private final List<UUID> spectators = new ArrayList<>();
     private final Map<TeamColor, Team> teams = new EnumMap<>(TeamColor.class);
     private final List<Generator> generators = new ArrayList<>();
     private Location lobbyLocation;
@@ -161,6 +163,7 @@ public class Arena {
      */
     public void addPlayer(UUID uuid) {
         players.add(uuid);
+        alivePlayers.add(uuid);
     }
 
     /**
@@ -170,6 +173,8 @@ public class Arena {
      */
     public void removePlayer(UUID uuid) {
         players.remove(uuid);
+        alivePlayers.remove(uuid);
+        spectators.remove(uuid);
     }
 
     /**
@@ -218,7 +223,7 @@ public class Arena {
         }
     }
 
-    private Team getTeam(UUID uuid) {
+    public Team getTeam(UUID uuid) {
         for (Team team : teams.values()) {
             if (team.isMember(uuid)) {
                 return team;
@@ -239,13 +244,37 @@ public class Arena {
         return result;
     }
 
-    private void broadcast(String message) {
+    public void broadcast(String message) {
         for (UUID id : players) {
             Player p = Bukkit.getPlayer(id);
             if (p != null) {
                 MessageUtils.sendMessage(p, message);
             }
         }
+    }
+
+    public List<UUID> getAlivePlayers() {
+        return alivePlayers;
+    }
+
+    public List<UUID> getSpectators() {
+        return spectators;
+    }
+
+    public void addSpectator(UUID uuid) {
+        spectators.add(uuid);
+    }
+
+    public void removeSpectator(UUID uuid) {
+        spectators.remove(uuid);
+    }
+
+    public void addAlivePlayer(UUID uuid) {
+        alivePlayers.add(uuid);
+    }
+
+    public void removeAlivePlayer(UUID uuid) {
+        alivePlayers.remove(uuid);
     }
 
     private void startCountdown() {

--- a/src/main/java/com/heneria/bedwars/listeners/BedBreakListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/BedBreakListener.java
@@ -1,0 +1,88 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.utils.MessageUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.Tag;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+import java.util.UUID;
+
+public class BedBreakListener implements Listener {
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArenaByPlayer(player.getUniqueId());
+        if (arena == null) {
+            return;
+        }
+
+        Block block = event.getBlock();
+        if (!Tag.BEDS.isTagged(block.getType())) {
+            return;
+        }
+
+        Team targetTeam = null;
+        for (Team team : arena.getTeams().values()) {
+            Location loc = team.getBedLocation();
+            if (loc != null && loc.getWorld().equals(block.getWorld())
+                    && loc.getBlockX() == block.getX()
+                    && loc.getBlockY() == block.getY()
+                    && loc.getBlockZ() == block.getZ()) {
+                targetTeam = team;
+                break;
+            }
+        }
+
+        if (targetTeam == null) {
+            event.setCancelled(true);
+            return;
+        }
+
+        Team playerTeam = arena.getTeam(player.getUniqueId());
+        if (playerTeam != null && playerTeam == targetTeam) {
+            event.setCancelled(true);
+            MessageUtils.sendMessage(player, "&cVous ne pouvez pas détruire votre propre lit !");
+            return;
+        }
+
+        if (!targetTeam.hasBed()) {
+            event.setCancelled(true);
+            return;
+        }
+
+        event.setDropItems(false);
+        block.setType(Material.AIR);
+        if (block.getBlockData() instanceof Bed bed) {
+            Block other = block.getRelative(bed.getFacing().getOppositeFace());
+            if (Tag.BEDS.isTagged(other.getType())) {
+                other.setType(Material.AIR);
+            }
+        }
+
+        targetTeam.setHasBed(false);
+
+        for (UUID id : arena.getPlayers()) {
+            Player p = Bukkit.getPlayer(id);
+            if (p != null) {
+                MessageUtils.sendMessage(p, "&cLe lit de l'équipe " + targetTeam.getColor().getDisplayName() + " a été détruit par " + player.getName() + " !");
+                p.sendTitle("§cLit détruit", "§fLe lit de l'équipe " + targetTeam.getColor().getDisplayName() + " a été détruit par " + player.getName() + " !", 10, 60, 10);
+                p.playSound(p.getLocation(), Sound.ENTITY_WITHER_DEATH, 1f, 1f);
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/PlayerDeathListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/PlayerDeathListener.java
@@ -1,0 +1,70 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.utils.MessageUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.UUID;
+
+public class PlayerDeathListener implements Listener {
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+    private static final int RESPAWN_DELAY_SECONDS = 5;
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        Arena arena = arenaManager.getArenaByPlayer(player.getUniqueId());
+        if (arena == null) {
+            return;
+        }
+
+        event.setDeathMessage(null);
+        event.getDrops().clear();
+        event.setDroppedExp(0);
+        event.setKeepInventory(true);
+
+        Bukkit.getScheduler().runTask(HeneriaBedwars.getInstance(), () -> {
+            player.spigot().respawn();
+            Team team = arena.getTeam(player.getUniqueId());
+            if (team == null) {
+                return;
+            }
+            if (team.hasBed()) {
+                player.setGameMode(GameMode.SPECTATOR);
+                if (team.getSpawnLocation() != null) {
+                    player.teleport(team.getSpawnLocation());
+                }
+                Bukkit.getScheduler().runTaskLater(HeneriaBedwars.getInstance(), () -> {
+                    player.setGameMode(GameMode.SURVIVAL);
+                    if (team.getSpawnLocation() != null) {
+                        player.teleport(team.getSpawnLocation());
+                    }
+                    player.getInventory().clear();
+                    player.getInventory().addItem(new ItemStack(Material.WOODEN_SWORD));
+                }, RESPAWN_DELAY_SECONDS * 20L);
+            } else {
+                arena.removeAlivePlayer(player.getUniqueId());
+                arena.addSpectator(player.getUniqueId());
+                player.setGameMode(GameMode.SPECTATOR);
+                for (UUID id : arena.getPlayers()) {
+                    Player p = Bukkit.getPlayer(id);
+                    if (p != null) {
+                        MessageUtils.sendMessage(p, "&c" + player.getName() + " a été éliminé !");
+                        p.sendTitle("§c" + player.getName(), "§7a été éliminé !", 10, 40, 10);
+                    }
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- gérer la mort des joueurs avec respawn temporaire ou élimination
- détecter et annoncer la destruction des lits d'équipe
- suivre joueurs vivants/spectateurs et enregistrer les nouveaux listeners
- documentation roadmap, changelog et README

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin from/to central (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68a2f06532b083298c200fc4ec4c256d