### PR TITLE
Fix bed destruction and void death handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - HeneriaBedwars
 
+## [0.2.1] - En développement
+
+### Corrigé
+- Correction d'un bug empêchant la destruction des lits ennemis.
+- La réapparition personnalisée se déclenche désormais pour toutes les morts, y compris environnementales.
+- Ajout d'une mort rapide dans le vide configurable (`void-kill-height`).
+
 ## [0.2.0] - En développement
 
 ### Ajouté

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -7,6 +7,7 @@ import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.listeners.GameListener;
 import com.heneria.bedwars.listeners.PlayerDeathListener;
 import com.heneria.bedwars.listeners.BedBreakListener;
+import com.heneria.bedwars.listeners.VoidKillListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -22,6 +23,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     @Override
     public void onEnable() {
         instance = this;
+        saveDefaultConfig();
         getLogger().info("HeneriaBedwars v" + getDescription().getVersion() + " est en cours de chargement...");
 
         // Initialisation des managers
@@ -62,6 +64,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new GameListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerDeathListener(), this);
         getServer().getPluginManager().registerEvents(new BedBreakListener(), this);
+        getServer().getPluginManager().registerEvents(new VoidKillListener(), this);
     }
 
 

--- a/src/main/java/com/heneria/bedwars/listeners/BedBreakListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/BedBreakListener.java
@@ -39,12 +39,28 @@ public class BedBreakListener implements Listener {
         Team targetTeam = null;
         for (Team team : arena.getTeams().values()) {
             Location loc = team.getBedLocation();
-            if (loc != null && loc.getWorld().equals(block.getWorld())
-                    && loc.getBlockX() == block.getX()
+            if (loc == null || !loc.getWorld().equals(block.getWorld())) {
+                continue;
+            }
+
+            // Direct match with the stored bed block
+            if (loc.getBlockX() == block.getX()
                     && loc.getBlockY() == block.getY()
                     && loc.getBlockZ() == block.getZ()) {
                 targetTeam = team;
                 break;
+            }
+
+            // Check the second part of the bed in case the player breaks the other half
+            Block bedBlock = loc.getBlock();
+            if (bedBlock.getBlockData() instanceof Bed bed) {
+                Block other = bedBlock.getRelative(bed.getFacing());
+                if (other.getX() == block.getX()
+                        && other.getY() == block.getY()
+                        && other.getZ() == block.getZ()) {
+                    targetTeam = team;
+                    break;
+                }
             }
         }
 

--- a/src/main/java/com/heneria/bedwars/listeners/PlayerDeathListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/PlayerDeathListener.java
@@ -3,6 +3,7 @@ package com.heneria.bedwars.listeners;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.arena.enums.GameState;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.Bukkit;
@@ -25,7 +26,7 @@ public class PlayerDeathListener implements Listener {
     public void onPlayerDeath(PlayerDeathEvent event) {
         Player player = event.getEntity();
         Arena arena = arenaManager.getArenaByPlayer(player.getUniqueId());
-        if (arena == null) {
+        if (arena == null || arena.getState() != GameState.PLAYING) {
             return;
         }
 

--- a/src/main/java/com/heneria/bedwars/listeners/VoidKillListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/VoidKillListener.java
@@ -1,0 +1,35 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+/**
+ * Kills players who fall below a configured Y level in active arenas.
+ */
+public class VoidKillListener implements Listener {
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+    private final int voidKillHeight;
+
+    public VoidKillListener() {
+        this.voidKillHeight = HeneriaBedwars.getInstance().getConfig().getInt("void-kill-height", 0);
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArenaByPlayer(player.getUniqueId());
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        if (player.getLocation().getY() < voidKillHeight) {
+            player.setHealth(0.0);
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,1 @@
+void-kill-height: 0


### PR DESCRIPTION
## Summary
- allow breaking enemy beds by checking both halves
- handle all deaths during games and add configurable void kill
- document bug fixes for 0.2.1

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f615a8248329b2b71885ae6e1d96