### PR TITLE
HBW-027: Re-register SetupListener to restore arena configuration tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Correction d'un bug empêchant la destruction des lits ennemis.
 - La réapparition personnalisée se déclenche désormais pour toutes les morts, y compris environnementales.
 - Ajout d'une mort rapide dans le vide configurable (`void-kill-height`).
+- Correction d'une régression critique où l'outil de configuration d'arène était devenu inactif.
 
 ## [0.2.0] - En développement
 

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.commands.CommandManager;
 import com.heneria.bedwars.listeners.ChatListener;
 import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.listeners.GameListener;
+import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.GeneratorManager;
 import com.heneria.bedwars.managers.SetupManager;
@@ -44,6 +45,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new GUIListener(), this);
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
         getServer().getPluginManager().registerEvents(new GameListener(), this);
+        getServer().getPluginManager().registerEvents(new SetupListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {


### PR DESCRIPTION
## Summary
- Re-register `SetupListener` so arena configuration tool works again
- Document regression fix in `CHANGELOG`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ffda195083299f54d5337fcd28a9