### PR TITLE
HBW-028: inject SetupManager into SetupListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Correction d'un bug empêchant la destruction des lits ennemis.
 - La réapparition personnalisée se déclenche désormais pour toutes les morts, y compris environnementales.
 - Ajout d'une mort rapide dans le vide configurable (`void-kill-height`).
+- Correction d'une erreur de compilation liée à l'initialisation du `SetupListener`.
 
 ## [0.2.0] - En développement
 

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -4,9 +4,10 @@ import com.heneria.bedwars.commands.CommandManager;
 import com.heneria.bedwars.listeners.ChatListener;
 import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.listeners.GameListener;
+import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.managers.ArenaManager;
-import com.heneria.bedwars.managers.GeneratorManager;
 import com.heneria.bedwars.managers.SetupManager;
+import com.heneria.bedwars.managers.GeneratorManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class HeneriaBedwars extends JavaPlugin {
@@ -21,11 +22,13 @@ public final class HeneriaBedwars extends JavaPlugin {
         instance = this;
         getLogger().info("HeneriaBedwars v" + getDescription().getVersion() + " est en cours de chargement...");
 
+        // Initialisation des managers
         this.arenaManager = new ArenaManager(this);
-        this.arenaManager.loadArenas();
         this.setupManager = new SetupManager();
+        this.arenaManager.loadArenas();
         this.generatorManager = new GeneratorManager(this);
 
+        // Enregistrement des commandes
         CommandManager commandManager = new CommandManager(this);
         getCommand("bedwars").setExecutor(commandManager);
         getCommand("bedwars").setTabCompleter(commandManager);
@@ -44,6 +47,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new GUIListener(), this);
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
         getServer().getPluginManager().registerEvents(new GameListener(), this);
+        getServer().getPluginManager().registerEvents(new SetupListener(this.setupManager), this);
     }
 
     public static HeneriaBedwars getInstance() {


### PR DESCRIPTION
## Summary
- inject SetupManager into SetupListener and register listener
- document compilation fix

## Testing
- `mvn -B package --file pom.xml` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3010ce8ec8329a04386f7bc8777b7