### PR TITLE
feat(gameplay): Improve death cycle and add back buttons to GUIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.2.1] - En développement
 
+### Ajouté
+- Amélioration complète du cycle de mort/réapparition (void kill, timer visuel, rééquipement)
+- Ajout de boutons de retour pour la navigation dans les menus d'administration
+
 ### Corrigé
 - Refactorisation majeure des listeners de jeu pour corriger les bugs de lits et de morts, avec ajout d'un logging de débogage.
 - Correction d'un bug critique qui empêchait la destruction des lits en raison d'une mauvaise détection d'équipe.

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -5,14 +5,13 @@ import com.heneria.bedwars.arena.elements.Generator;
 import com.heneria.bedwars.arena.elements.Team;
 import com.heneria.bedwars.arena.enums.GameState;
 import com.heneria.bedwars.arena.enums.TeamColor;
+import com.heneria.bedwars.utils.GameUtils;
 import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -380,10 +379,7 @@ public class Arena {
             if (team != null && team.getSpawnLocation() != null) {
                 p.teleport(team.getSpawnLocation());
             }
-            p.getInventory().clear();
-            p.getInventory().addItem(new ItemStack(Material.WOODEN_SWORD));
-            p.setLevel(0);
-            p.setExp(0f);
+            GameUtils.giveDefaultKit(p);
         }
         for (Generator gen : generators) {
             HeneriaBedwars.getInstance().getGeneratorManager().registerGenerator(gen);

--- a/src/main/java/com/heneria/bedwars/gui/Menu.java
+++ b/src/main/java/com/heneria/bedwars/gui/Menu.java
@@ -1,10 +1,13 @@
 package com.heneria.bedwars.gui;
 
+import com.heneria.bedwars.utils.ItemBuilder;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Base class for simple inventory based GUIs.
@@ -12,6 +15,7 @@ import org.bukkit.inventory.InventoryHolder;
 public abstract class Menu implements InventoryHolder {
 
     protected Inventory inventory;
+    protected Menu previousMenu;
 
     /**
      * Gets the title of the menu.
@@ -42,12 +46,42 @@ public abstract class Menu implements InventoryHolder {
     /**
      * Opens the menu for the given player.
      *
+     * @param player       the player
+     * @param previousMenu the previous menu, or {@code null} if none
+     */
+    public void open(Player player, Menu previousMenu) {
+        this.previousMenu = previousMenu;
+        inventory = Bukkit.createInventory(this, getSize(), getTitle());
+        setupItems();
+        if (previousMenu != null) {
+            inventory.setItem(getBackButtonSlot(), backButton());
+        }
+        player.openInventory(inventory);
+    }
+
+    /**
+     * Opens the menu without a previous reference.
+     *
      * @param player the player
      */
     public void open(Player player) {
-        inventory = Bukkit.createInventory(this, getSize(), getTitle());
-        setupItems();
-        player.openInventory(inventory);
+        open(player, null);
+    }
+
+    protected int getBackButtonSlot() {
+        return getSize() - 9;
+    }
+
+    protected ItemStack backButton() {
+        return new ItemBuilder(Material.BARRIER).setName("&cRetour").build();
+    }
+
+    protected boolean handleBack(InventoryClickEvent event) {
+        if (previousMenu != null && event.getRawSlot() == getBackButtonSlot()) {
+            previousMenu.open((Player) event.getWhoClicked(), previousMenu.previousMenu);
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/heneria/bedwars/gui/PaginatedMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/PaginatedMenu.java
@@ -73,15 +73,24 @@ public abstract class PaginatedMenu extends Menu {
     @Override
     public void handleClick(InventoryClickEvent event) {
         event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
         int slot = event.getRawSlot();
         if (slot == getPrevButtonSlot() && page > 0) {
             page--;
             setupItems();
+            if (previousMenu != null) {
+                inventory.setItem(getBackButtonSlot(), backButton());
+            }
             return;
         }
         if (slot == getNextButtonSlot() && (page + 1) * getItemsPerPage() < getPaginatedItems().size()) {
             page++;
             setupItems();
+            if (previousMenu != null) {
+                inventory.setItem(getBackButtonSlot(), backButton());
+            }
             return;
         }
         handleMenuClick(event);

--- a/src/main/java/com/heneria/bedwars/gui/admin/AdminMainMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/AdminMainMenu.java
@@ -48,7 +48,7 @@ public class AdminMainMenu extends Menu {
             MessageUtils.sendMessage(player, "&7Tapez 'annuler' pour quitter le mode création.");
         } else if (event.getSlot() == 15) {
             player.closeInventory();
-            new ArenaListMenu().open(player);
+            new ArenaListMenu().open(player, this);
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaConfigMenu.java
@@ -80,6 +80,9 @@ public class ArenaConfigMenu extends Menu {
     @Override
     public void handleClick(InventoryClickEvent event) {
         event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }
@@ -91,11 +94,11 @@ public class ArenaConfigMenu extends Menu {
             MessageUtils.sendMessage(player, "&eFaites un clic droit pour définir le lobby.");
             player.closeInventory();
         } else if (slot == TEAMS_SLOT) {
-            new TeamListMenu(arena).open(player);
+            new TeamListMenu(arena).open(player, this);
         } else if (slot == GENERATORS_SLOT) {
-            new GeneratorConfigMenu(arena).open(player);
+            new GeneratorConfigMenu(arena).open(player, this);
         } else if (slot == NPC_SLOT) {
-            new NpcConfigMenu(arena).open(player);
+            new NpcConfigMenu(arena).open(player, this);
         } else if (slot == TOGGLE_SLOT) {
             if (!arena.isEnabled()) {
                 if (arena.getLobbyLocation() == null) {
@@ -120,7 +123,7 @@ public class ArenaConfigMenu extends Menu {
             }
             HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);
             player.closeInventory();
-            new ArenaConfigMenu(arena).open(player);
+            new ArenaConfigMenu(arena).open(player, previousMenu);
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaListMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaListMenu.java
@@ -54,13 +54,16 @@ public class ArenaListMenu extends Menu {
     @Override
     public void handleClick(InventoryClickEvent event) {
         event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }
         Arena arena = arenaSlots.get(event.getRawSlot());
         if (arena != null) {
             player.closeInventory();
-            new ArenaConfigMenu(arena).open(player);
+            new ArenaConfigMenu(arena).open(player, this);
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/admin/GeneratorConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/GeneratorConfigMenu.java
@@ -49,12 +49,12 @@ public class GeneratorConfigMenu extends PaginatedMenu {
 
     @Override
     protected int getItemStartSlot() {
-        return 18;
+        return 19;
     }
 
     @Override
     protected int getItemsPerPage() {
-        return 9;
+        return 8;
     }
 
     @Override
@@ -108,6 +108,9 @@ public class GeneratorConfigMenu extends PaginatedMenu {
                 page--;
             }
             setupItems();
+            if (previousMenu != null) {
+                inventory.setItem(getBackButtonSlot(), backButton());
+            }
         }
     }
 

--- a/src/main/java/com/heneria/bedwars/gui/admin/NpcConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/NpcConfigMenu.java
@@ -57,6 +57,9 @@ public class NpcConfigMenu extends Menu {
     @Override
     public void handleClick(InventoryClickEvent event) {
         event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }

--- a/src/main/java/com/heneria/bedwars/gui/admin/TeamConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/TeamConfigMenu.java
@@ -60,6 +60,9 @@ public class TeamConfigMenu extends Menu {
     @Override
     public void handleClick(InventoryClickEvent event) {
         event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }

--- a/src/main/java/com/heneria/bedwars/gui/admin/TeamListMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/TeamListMenu.java
@@ -57,13 +57,16 @@ public class TeamListMenu extends Menu {
     @Override
     public void handleClick(InventoryClickEvent event) {
         event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }
         TeamColor color = teamSlots.get(event.getRawSlot());
         if (color != null) {
             player.closeInventory();
-            new TeamConfigMenu(arena, color).open(player);
+            new TeamConfigMenu(arena, color).open(player, this);
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -4,6 +4,8 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.elements.Team;
 import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.utils.GameUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -85,22 +87,26 @@ public class GameListener implements Listener {
         System.out.println("[HENERIA DEBUG - MORT] Statut du lit de l'équipe " + playerTeam.getColor().name() + ": " + playerTeam.hasBed());
         if (playerTeam.hasBed()) {
             System.out.println("[HENERIA DEBUG - MORT] Le lit est intact. Lancement de la réapparition.");
-            player.setGameMode(GameMode.SPECTATOR);
-            new BukkitRunnable() {
-                int countdown = 5;
-                @Override
-                public void run() {
-                    if (countdown > 0) {
-                        player.sendTitle("§cVOUS ÊTES MORT !", "§fRéapparition dans §e" + countdown + "s", 0, 25, 0);
-                        countdown--;
-                    } else {
-                        this.cancel();
-                        player.spigot().respawn();
-                        player.setGameMode(GameMode.SURVIVAL);
-                        player.teleport(playerTeam.getSpawnLocation());
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                player.spigot().respawn();
+                player.setGameMode(GameMode.SPECTATOR);
+                new BukkitRunnable() {
+                    int countdown = 5;
+
+                    @Override
+                    public void run() {
+                        if (countdown > 0) {
+                            player.sendTitle("§cVOUS ÊTES MORT !", "§fRéapparition dans §e" + countdown + "s", 0, 25, 0);
+                            countdown--;
+                        } else {
+                            this.cancel();
+                            player.setGameMode(GameMode.SURVIVAL);
+                            player.teleport(playerTeam.getSpawnLocation());
+                            GameUtils.giveDefaultKit(player);
+                        }
                     }
-                }
-            }.runTaskTimer(plugin, 0L, 20L);
+                }.runTaskTimer(plugin, 0L, 20L);
+            });
         } else {
             System.out.println("[HENERIA DEBUG - MORT] Le lit est détruit. Élimination finale.");
             arena.eliminatePlayer(player);

--- a/src/main/java/com/heneria/bedwars/utils/GameUtils.java
+++ b/src/main/java/com/heneria/bedwars/utils/GameUtils.java
@@ -1,0 +1,26 @@
+package com.heneria.bedwars.utils;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Utility methods for common game actions.
+ */
+public final class GameUtils {
+
+    private GameUtils() {
+    }
+
+    /**
+     * Gives the default starting kit to the specified player.
+     *
+     * @param player the player to equip
+     */
+    public static void giveDefaultKit(Player player) {
+        player.getInventory().clear();
+        player.getInventory().addItem(new ItemStack(Material.WOODEN_SWORD));
+        player.setLevel(0);
+        player.setExp(0f);
+    }
+}


### PR DESCRIPTION
## Summary
- add global utility to re-equip players with the default kit
- bypass Minecraft death screen with a custom respawn timer and kit restore
- enable back navigation across admin menus with a consistent "Retour" button

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a308e1cad0832980a8d7636a2b4e95