### PR TITLE
HBW-031: instant void kill and remove bed drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 - Refactorisation majeure des listeners de jeu pour corriger les bugs de lits et de morts, avec ajout d'un logging de débogage.
 - Correction d'un bug critique qui empêchait la destruction des lits en raison d'une mauvaise détection d'équipe.
 - La réapparition personnalisée se déclenche désormais pour toutes les morts, y compris environnementales.
-- Ajout d'une mort rapide dans le vide configurable (`void-kill-height`).
+- La mort dans le vide est maintenant instantanée (hauteur configurable via `void-kill-height`).
 - Correction d'une erreur de compilation liée à l'initialisation du `SetupListener`.
+- Les lits détruits ne drop plus d'item.
 
 ## [0.2.0] - En développement
 

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -5,6 +5,7 @@ import com.heneria.bedwars.listeners.ChatListener;
 import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.listeners.GameListener;
 import com.heneria.bedwars.listeners.SetupListener;
+import com.heneria.bedwars.listeners.VoidKillListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -20,6 +21,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     @Override
     public void onEnable() {
         instance = this;
+        saveDefaultConfig();
         getLogger().info("HeneriaBedwars v" + getDescription().getVersion() + " est en cours de chargement...");
 
         // Initialisation des managers
@@ -48,6 +50,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
         getServer().getPluginManager().registerEvents(new GameListener(), this);
         getServer().getPluginManager().registerEvents(new SetupListener(this.setupManager), this);
+        getServer().getPluginManager().registerEvents(new VoidKillListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -56,6 +56,7 @@ public class GameListener implements Listener {
             event.setCancelled(true);
         } else {
             System.out.println("[HENERIA DEBUG - LIT] C'est un lit ennemi ! Destruction autorisée.");
+            event.setDropItems(false);
             bedTeam.setHasBed(false);
             arena.broadcastTitle("§cDESTRUCTION DE LIT !", "§fLe lit de l'équipe " + bedTeam.getColor().getChatColor() + bedTeam.getColor().getDisplayName() + "§f a été détruit par §e" + player.getName() + "§f!", 10, 70, 20);
         }


### PR DESCRIPTION
## Summary
- kill players immediately when falling below the configured void height
- prevent bed blocks from dropping as items when destroyed
- document gameplay optimisations in changelog

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a314768f9c832989ac39afd59ca412