### PR TITLE
HBW-032: fix bed detection and spectator teleport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Ajouté
 - Amélioration complète du cycle de mort/réapparition (void kill, timer visuel, rééquipement)
 - Ajout de boutons de retour pour la navigation dans les menus d'administration
+- Amélioration : les joueurs en mode spectateur sont désormais téléportés sur leur île d'équipe.
 
 ### Corrigé
 - Refactorisation majeure des listeners de jeu pour corriger les bugs de lits et de morts, avec ajout d'un logging de débogage.
 - Correction d'un bug critique qui empêchait la destruction des lits en raison d'une mauvaise détection d'équipe.
+- Correction définitive du bug de destruction des lits via une détection par distance.
 - La réapparition personnalisée se déclenche désormais pour toutes les morts, y compris environnementales.
 - La mort dans le vide est maintenant instantanée (hauteur configurable via `void-kill-height`).
 - Correction d'une erreur de compilation liée à l'initialisation du `SetupListener`.

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -238,24 +238,26 @@ public class Arena {
     }
 
     /**
-     * Retrieves the team that owns a bed based on a block location.
-     *
-     * @param location the location of the broken bed block
-     * @return the owning team, or null if none matches
+     * Récupère une équipe à partir de l'emplacement d'un bloc de lit, en utilisant une vérification de distance.
+     * @param location L'emplacement du bloc de lit cassé.
+     * @return L'équipe propriétaire du lit, ou null si aucune équipe ne correspond.
      */
     public Team getTeamFromBedLocation(Location location) {
         for (Team team : teams.values()) {
             Location bedLocation = team.getBedLocation();
 
-            if (bedLocation != null
-                    && bedLocation.getWorld().equals(location.getWorld())
-                    && bedLocation.getBlockX() == location.getBlockX()
-                    && bedLocation.getBlockY() == location.getBlockY()
-                    && bedLocation.getBlockZ() == location.getBlockZ()) {
-                return team;
+            // On s'assure que le lit de l'équipe a bien été configuré
+            if (bedLocation == null) continue;
+
+            // On vérifie qu'on est bien dans le même monde
+            if (!bedLocation.getWorld().equals(location.getWorld())) continue;
+
+            // LA CORRECTION : On vérifie si le bloc cassé est à proximité (distance de 2 blocs max)
+            if (bedLocation.distanceSquared(location) <= 4) { // distanceSquared est plus performant
+                return team; // Correspondance trouvée !
             }
         }
-        return null;
+        return null; // Aucune correspondance
     }
 
     private Team getLeastPopulatedTeam() {

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -91,6 +91,7 @@ public class GameListener implements Listener {
             Bukkit.getScheduler().runTask(plugin, () -> {
                 player.spigot().respawn();
                 player.setGameMode(GameMode.SPECTATOR);
+                player.teleport(playerTeam.getSpawnLocation());
                 new BukkitRunnable() {
                     int countdown = 5;
 
@@ -112,6 +113,7 @@ public class GameListener implements Listener {
             System.out.println("[HENERIA DEBUG - MORT] Le lit est détruit. Élimination finale.");
             arena.eliminatePlayer(player);
             player.setGameMode(GameMode.SPECTATOR);
+            player.teleport(playerTeam.getSpawnLocation());
             arena.broadcastTitle("§cÉLIMINATION !", "§e" + player.getName() + "§f a été éliminé.", 10, 70, 20);
         }
         System.out.println("=============================================");


### PR DESCRIPTION
## Summary
- use distance-based detection to identify bed owners
- teleport spectators to their team spawn upon death
- document bed-destruction fix and spectator teleport in changelog

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3180f1b5c83299c28837943b85e0c