### PR TITLE
HBW-033: Correction du bug de l'écran de mort à l'élimination finale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Amélioration : les joueurs en mode spectateur sont désormais téléportés sur leur île d'équipe.
 
 ### Corrigé
+- Correction d'un bug critique où l'écran de mort de Minecraft apparaissait lors de l'élimination finale.
 - Refactorisation majeure des listeners de jeu pour corriger les bugs de lits et de morts, avec ajout d'un logging de débogage.
 - Correction d'un bug critique qui empêchait la destruction des lits en raison d'une mauvaise détection d'équipe.
 - Correction définitive du bug de destruction des lits via une détection par distance.

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -111,8 +111,13 @@ public class GameListener implements Listener {
             });
         } else {
             System.out.println("[HENERIA DEBUG - MORT] Le lit est détruit. Élimination finale.");
+
+            // Étape 1 : Forcer la réapparition immédiatement pour supprimer l'écran de mort
+            player.spigot().respawn();
+
+            // Étape 2 : Appliquer les effets de l'élimination
             arena.eliminatePlayer(player);
-            player.setGameMode(GameMode.SPECTATOR);
+            player.setGameMode(GameMode.SPECTATOR); // Spectateur permanent
             player.teleport(playerTeam.getSpawnLocation());
             arena.broadcastTitle("§cÉLIMINATION !", "§e" + player.getName() + "§f a été éliminé.", 10, 70, 20);
         }


### PR DESCRIPTION
## Résumé
- Forcer la réapparition du joueur avant son élimination finale pour masquer l'écran de mort
- Documenter le correctif dans le CHANGELOG

## Tests
- `mvn -q test` *(échec: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a31ae5766083299662597035655de6