### PR TITLE
feat(game)!: Implement win condition and end-game sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [0.3.0] - En développement
+
+### Ajouté
+- Implémentation des conditions de victoire et de la séquence de fin de partie. Le cycle de jeu de l'Étape 2 est maintenant complet.
+
 ## [0.2.1] - En développement
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Consultez notre [ROADMAP.md](ROADMAP.md) pour suivre le développement du projet
 Chaque équipe possède un lit. Tant que ce lit est intact, les joueurs de l'équipe réapparaissent après quelques secondes.
 Si le lit est détruit, toute mort devient définitive : le joueur est éliminé et passe en mode spectateur pour la fin de la partie.
 Détruisez les lits adverses tout en protégeant le vôtre pour remporter la victoire.
+La partie se termine lorsqu'une seule équipe possède encore des joueurs en vie. L'arène annonce les vainqueurs, arrête les générateurs et se réinitialise automatiquement pour le prochain match.
 
 ## 🔧 Compilation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,15 +23,13 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 
 ---
 
-## 🎯 **Étape 2 : Cycle de Jeu & Lobby (Version Cible : 0.3.0) - [WIP]**
-*Objectif : Rendre les arènes jouables avec un cycle de vie complet, de l'attente au décompte, jusqu'à la fin de partie.*
-
+## 🎯 **Étape 2 : Cycle de Jeu & Lobby (Version Cible : 0.3.0) - [✔] TERMINÉE**
 * [✔] Système pour rejoindre/quitter une arène.
 * [✔] Lobby d'attente avec décompte.
 * [✔] Lancement de la partie (téléportation, démarrage des générateurs).
 * [✔] Vitesse et niveaux des générateurs de ressources.
 * [✔] Gestion de la réapparition et de la destruction des lits.
-* [ ] Conditions de victoire et fin de partie.
+* [✔] Conditions de victoire et fin de partie.
 
 ## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.4.0)**
 *Objectif : Intégrer les boutiques d'objets et d'améliorations d'équipe.*

--- a/src/main/java/com/heneria/bedwars/arena/PlayerData.java
+++ b/src/main/java/com/heneria/bedwars/arena/PlayerData.java
@@ -1,5 +1,6 @@
 package com.heneria.bedwars.arena;
 
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -14,6 +15,7 @@ public class PlayerData {
     private final Location location;
     private final float exp;
     private final int level;
+    private final GameMode gameMode;
 
     /**
      * Captures the current state of the given player.
@@ -26,6 +28,7 @@ public class PlayerData {
         this.location = player.getLocation();
         this.exp = player.getExp();
         this.level = player.getLevel();
+        this.gameMode = player.getGameMode();
     }
 
     /**
@@ -39,6 +42,7 @@ public class PlayerData {
         player.teleport(location);
         player.setExp(exp);
         player.setLevel(level);
+        player.setGameMode(gameMode);
     }
 }
 

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -120,6 +120,10 @@ public class GameListener implements Listener {
             player.setGameMode(GameMode.SPECTATOR); // Spectateur permanent
             player.teleport(playerTeam.getSpawnLocation());
             arena.broadcastTitle("§cÉLIMINATION !", "§e" + player.getName() + "§f a été éliminé.", 10, 70, 20);
+            Team winner = arena.checkForWinner();
+            if (winner != null) {
+                arena.endGame(winner);
+            }
         }
         System.out.println("=============================================");
     }

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -106,6 +106,10 @@ public class GeneratorManager {
         counters.put(gen, getDelayCycles(gen));
     }
 
+    public void unregisterGenerator(Generator gen) {
+        counters.remove(gen);
+    }
+
     /**
      * Record of delay and amount for a generator tier.
      */


### PR DESCRIPTION
## Summary
- Add win condition checks and end-game sequence that announces winners, stops generators, schedules arena reset
- Track and restore player game modes during arena reset
- Document completion of Stage 2 with win condition details

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a31cd2b7a08329a2a98495cf6e9466