### PR TITLE
refactor(game)!: Complete rewrite of Bed and Death system with block caching

### DIFF
--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -5,7 +5,6 @@ import com.heneria.bedwars.listeners.ChatListener;
 import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.listeners.GameListener;
 import com.heneria.bedwars.listeners.SetupListener;
-import com.heneria.bedwars.listeners.VoidKillListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -50,7 +49,6 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
         getServer().getPluginManager().registerEvents(new GameListener(), this);
         getServer().getPluginManager().registerEvents(new SetupListener(this.setupManager), this);
-        getServer().getPluginManager().registerEvents(new VoidKillListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/events/GameStateChangeEvent.java
+++ b/src/main/java/com/heneria/bedwars/events/GameStateChangeEvent.java
@@ -1,0 +1,34 @@
+package com.heneria.bedwars.events;
+
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class GameStateChangeEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final Arena arena;
+    private final GameState newState;
+
+    public GameStateChangeEvent(Arena arena, GameState newState) {
+        this.arena = arena;
+        this.newState = newState;
+    }
+
+    public Arena getArena() {
+        return arena;
+    }
+
+    public GameState getNewState() {
+        return newState;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}


### PR DESCRIPTION
## Summary
- cache bed blocks directly in `Arena` and trigger game-state change event on start
- replace `GameListener` with unified handler for bed registration, breaking and player death
- add `GameStateChangeEvent` and register only the new `GameListener`

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68a32b4d0c448329933a5d5e59e77d86