### PR TITLE
feat: Stage 3 shop foundations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [0.4.0] - En développement
 
+### Ajouté
+- Mise en place des fondations du système de boutique avec PNJ interactifs et configuration via `shop.yml`.
+
 ### Corrigé
 - Reconstruction complète du système de détection des lits pour une fiabilité à 100% en synchronisant la sauvegarde et la lecture des positions.
 

--- a/README.md
+++ b/README.md
@@ -75,3 +75,25 @@ IRON:
 ```
 
 Modifiez ces valeurs selon vos besoins puis rechargez le plugin pour appliquer les changements.
+
+## 🛒 Configuration de la Boutique
+
+Le fichier `shop.yml` définit les catégories et les objets disponibles dans la boutique. Il est généré automatiquement au premier lancement du plugin et peut être modifié pour personnaliser les menus.
+
+Exemple de structure du menu principal :
+
+```yaml
+main-menu:
+  title: "Boutique d'objets"
+  rows: 4
+  items:
+    'quick-buy':
+      material: NETHER_STAR
+      name: "&aAchats Rapides"
+      lore:
+        - "&7Les objets les plus utiles"
+      slot: 10
+      category: 'quick_buy_category'
+```
+
+Chaque entrée renvoie vers une catégorie définie dans `shop-categories` où les objets à vendre seront listés.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,8 +31,12 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 * [✔] Gestion de la réapparition et de la destruction des lits.
 * [✔] Conditions de victoire et fin de partie.
 
-## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.4.0)**
+## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.4.0) - [WIP]**
 *Objectif : Intégrer les boutiques d'objets et d'améliorations d'équipe.*
+
+* [✔] Fondations du système : PNJ, configuration `shop.yml`, menu principal.
+* [ ] Logique d'achat d'objets et gestion des ressources.
+* [ ] Boutique d'améliorations d'équipe.
 
 ## 🎯 **Étape 4 : Polissage & Fonctionnalités Avancées (Version Cible : 1.0.0)**
 *Objectif : Ajouter les fonctionnalités spéciales, optimiser le code et préparer la version stable.*

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -5,9 +5,11 @@ import com.heneria.bedwars.listeners.ChatListener;
 import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.listeners.GameListener;
 import com.heneria.bedwars.listeners.SetupListener;
+import com.heneria.bedwars.listeners.ShopListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
+import com.heneria.bedwars.managers.ShopManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class HeneriaBedwars extends JavaPlugin {
@@ -16,6 +18,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private ArenaManager arenaManager;
     private SetupManager setupManager;
     private GeneratorManager generatorManager;
+    private ShopManager shopManager;
 
     @Override
     public void onEnable() {
@@ -28,6 +31,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.setupManager = new SetupManager();
         this.arenaManager.loadArenas();
         this.generatorManager = new GeneratorManager(this);
+        this.shopManager = new ShopManager(this);
 
         // Enregistrement des commandes
         CommandManager commandManager = new CommandManager(this);
@@ -49,6 +53,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
         getServer().getPluginManager().registerEvents(new GameListener(), this);
         getServer().getPluginManager().registerEvents(new SetupListener(this.setupManager), this);
+        getServer().getPluginManager().registerEvents(new ShopListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {
@@ -65,5 +70,9 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public GeneratorManager getGeneratorManager() {
         return generatorManager;
+    }
+
+    public ShopManager getShopManager() {
+        return shopManager;
     }
 }

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -13,6 +13,7 @@ import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -37,6 +38,8 @@ public class Arena {
     private Location lobbyLocation;
     private Location shopNpcLocation;
     private Location upgradeNpcLocation;
+    private Villager shopNpc;
+    private Villager upgradeNpc;
     private final Map<UUID, PlayerData> savedStates = new HashMap<>();
     // NEW CACHE SYSTEM: SIMPLE AND DIRECT
     private final Map<Block, Team> bedBlocks = new HashMap<>();
@@ -403,6 +406,7 @@ public class Arena {
         for (Generator gen : generators) {
             HeneriaBedwars.getInstance().getGeneratorManager().registerGenerator(gen);
         }
+        spawnNpcs();
     }
 
     /**
@@ -539,5 +543,42 @@ public class Arena {
             team.setHasBed(true);
         }
         state = GameState.WAITING;
+        removeNpcs();
+    }
+
+    private void spawnNpcs() {
+        if (shopNpcLocation != null && shopNpcLocation.getWorld() != null) {
+            shopNpc = shopNpcLocation.getWorld().spawn(shopNpcLocation, Villager.class, villager -> {
+                villager.setAI(false);
+                villager.setInvulnerable(true);
+                villager.setSilent(true);
+                villager.setCollidable(false);
+                villager.addScoreboardTag("shop_npc");
+                villager.setCustomName("§aBoutique");
+                villager.setCustomNameVisible(true);
+            });
+        }
+        if (upgradeNpcLocation != null && upgradeNpcLocation.getWorld() != null) {
+            upgradeNpc = upgradeNpcLocation.getWorld().spawn(upgradeNpcLocation, Villager.class, villager -> {
+                villager.setAI(false);
+                villager.setInvulnerable(true);
+                villager.setSilent(true);
+                villager.setCollidable(false);
+                villager.addScoreboardTag("upgrade_npc");
+                villager.setCustomName("§aAméliorations");
+                villager.setCustomNameVisible(true);
+            });
+        }
+    }
+
+    private void removeNpcs() {
+        if (shopNpc != null) {
+            shopNpc.remove();
+            shopNpc = null;
+        }
+        if (upgradeNpc != null) {
+            upgradeNpc.remove();
+            upgradeNpc = null;
+        }
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopCategoryMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopCategoryMenu.java
@@ -1,0 +1,78 @@
+package com.heneria.bedwars.gui.shop;
+
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.managers.ShopManager;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Menu listing shop categories defined in {@code shop.yml}.
+ */
+public class ShopCategoryMenu extends Menu {
+
+    private final ShopManager shopManager;
+    private final Map<Integer, String> slotCategories = new HashMap<>();
+
+    public ShopCategoryMenu(ShopManager shopManager) {
+        this.shopManager = shopManager;
+    }
+
+    @Override
+    public String getTitle() {
+        return shopManager.getMainMenuTitle();
+    }
+
+    @Override
+    public int getSize() {
+        return shopManager.getMainMenuRows() * 9;
+    }
+
+    @Override
+    public void setupItems() {
+        for (ShopManager.MainMenuItem item : shopManager.getMainMenuItems()) {
+            ItemStack stack = new ItemBuilder(item.material())
+                    .setName(item.name())
+                    .setLore(item.lore())
+                    .build();
+            inventory.setItem(item.slot(), stack);
+            if (item.category() != null) {
+                slotCategories.put(item.slot(), item.category());
+            }
+        }
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        String categoryId = slotCategories.get(event.getRawSlot());
+        if (categoryId != null) {
+            ShopManager.ShopCategory category = shopManager.getCategory(categoryId);
+            if (category != null) {
+                String title = ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', category.title()));
+                player.sendMessage("§eOuverture du menu des " + title.toLowerCase() + "...");
+            } else {
+                player.sendMessage("§cCatégorie introuvable.");
+            }
+            player.closeInventory();
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/ShopListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/ShopListener.java
@@ -1,0 +1,28 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.gui.shop.ShopCategoryMenu;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+
+/**
+ * Handles player interaction with shop NPCs.
+ */
+public class ShopListener implements Listener {
+
+    @EventHandler
+    public void onInteract(PlayerInteractEntityEvent event) {
+        if (!(event.getRightClicked() instanceof Villager villager)) {
+            return;
+        }
+        if (!villager.getScoreboardTags().contains("shop_npc")) {
+            return;
+        }
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        new ShopCategoryMenu(HeneriaBedwars.getInstance().getShopManager()).open(player);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/ShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ShopManager.java
@@ -1,0 +1,84 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Manages shop configuration loaded from {@code shop.yml}.
+ */
+public class ShopManager {
+
+    private final HeneriaBedwars plugin;
+    private YamlConfiguration config;
+    private final List<MainMenuItem> mainMenuItems = new ArrayList<>();
+    private final Map<String, ShopCategory> categories = new HashMap<>();
+
+    public ShopManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        loadConfiguration();
+    }
+
+    private void loadConfiguration() {
+        File file = new File(plugin.getDataFolder(), "shop.yml");
+        if (!file.exists()) {
+            plugin.saveResource("shop.yml", false);
+        }
+        this.config = YamlConfiguration.loadConfiguration(file);
+        mainMenuItems.clear();
+        categories.clear();
+
+        ConfigurationSection mainSection = config.getConfigurationSection("main-menu.items");
+        if (mainSection != null) {
+            for (String key : mainSection.getKeys(false)) {
+                String base = "main-menu.items." + key;
+                try {
+                    Material material = Material.valueOf(config.getString(base + ".material", "STONE"));
+                    String name = config.getString(base + ".name", key);
+                    List<String> lore = config.getStringList(base + ".lore");
+                    int slot = config.getInt(base + ".slot", 0);
+                    String category = config.getString(base + ".category");
+                    mainMenuItems.add(new MainMenuItem(material, name, lore, slot, category));
+                } catch (IllegalArgumentException ex) {
+                    plugin.getLogger().warning("Invalid material for main menu item " + key);
+                }
+            }
+        }
+
+        ConfigurationSection catSection = config.getConfigurationSection("shop-categories");
+        if (catSection != null) {
+            for (String id : catSection.getKeys(false)) {
+                String title = config.getString("shop-categories." + id + ".title", id);
+                int rows = config.getInt("shop-categories." + id + ".rows", 3);
+                categories.put(id, new ShopCategory(id, title, rows));
+            }
+        }
+    }
+
+    public String getMainMenuTitle() {
+        return ChatColor.translateAlternateColorCodes('&', config.getString("main-menu.title", "Boutique"));
+    }
+
+    public int getMainMenuRows() {
+        return config.getInt("main-menu.rows", 3);
+    }
+
+    public List<MainMenuItem> getMainMenuItems() {
+        return mainMenuItems;
+    }
+
+    public ShopCategory getCategory(String id) {
+        return categories.get(id);
+    }
+
+    public record MainMenuItem(Material material, String name, List<String> lore, int slot, String category) {
+    }
+
+    public record ShopCategory(String id, String title, int rows) {
+    }
+}

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -1,0 +1,46 @@
+# Ce menu affiche les catégories principales de la boutique.
+main-menu:
+  title: "Boutique d'objets"
+  rows: 4
+  items:
+    'quick-buy':
+      material: NETHER_STAR
+      name: "&aAchats Rapides"
+      lore:
+        - "&7Les objets les plus utiles"
+      slot: 10
+      category: 'quick_buy_category' # ID de la catégorie à ouvrir
+    'blocks':
+      material: BRICKS
+      name: "&aBlocs"
+      lore:
+        - "&7Pour construire et défendre"
+      slot: 11
+      category: 'blocks_category'
+
+# Définition d'une catégorie d'objets
+shop-categories:
+  'quick_buy_category':
+    title: "Achats Rapides"
+    rows: 5
+    items:
+      'wool':
+        material: WHITE_WOOL
+        name: "&fLaine"
+        amount: 16
+        cost:
+          resource: IRON
+          amount: 4
+        slot: 10
+      'stone-sword':
+        material: STONE_SWORD
+        name: "&7Épée en Pierre"
+        amount: 1
+        cost:
+          resource: IRON
+          amount: 10
+        slot: 11
+  'blocks_category':
+    title: "Blocs"
+    rows: 5
+    items: {} # à remplir plus tard


### PR DESCRIPTION
## Summary
- add configurable `shop.yml` with category menu data
- spawn invulnerable shop NPCs per arena and open menu on interaction
- document economy stage and shop configuration

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3513dbcf08329a67dae499ea40db9