### PR TITLE
fix(npc): Implement per-arena NPC management and normalize spawn orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Corrigé
 - Reconstruction complète du système de détection des lits pour une fiabilité à 100% en synchronisant la sauvegarde et la lecture des positions.
+- Correction d'un bug où les PNJ n'étaient pas gérés par arène.
+- L'orientation des PNJ au spawn est désormais normalisée.
 
 ## [0.3.1] - En développement
 

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -12,6 +12,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Bed;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -38,8 +39,11 @@ public class Arena {
     private Location lobbyLocation;
     private Location shopNpcLocation;
     private Location upgradeNpcLocation;
-    private Villager shopNpc;
-    private Villager upgradeNpc;
+    /**
+     * Stores all NPC entities spawned for this arena so they can be removed
+     * without affecting NPCs of other arenas.
+     */
+    private final List<Entity> npcs = new ArrayList<>();
     private final Map<UUID, PlayerData> savedStates = new HashMap<>();
     // NEW CACHE SYSTEM: SIMPLE AND DIRECT
     private final Map<Block, Team> bedBlocks = new HashMap<>();
@@ -548,37 +552,35 @@ public class Arena {
 
     private void spawnNpcs() {
         if (shopNpcLocation != null && shopNpcLocation.getWorld() != null) {
-            shopNpc = shopNpcLocation.getWorld().spawn(shopNpcLocation, Villager.class, villager -> {
-                villager.setAI(false);
-                villager.setInvulnerable(true);
-                villager.setSilent(true);
-                villager.setCollidable(false);
-                villager.addScoreboardTag("shop_npc");
-                villager.setCustomName("§aBoutique");
-                villager.setCustomNameVisible(true);
+            Villager villager = shopNpcLocation.getWorld().spawn(shopNpcLocation, Villager.class, v -> {
+                v.setAI(false);
+                v.setInvulnerable(true);
+                v.setSilent(true);
+                v.setCollidable(false);
+                v.addScoreboardTag("shop_npc");
+                v.setCustomName("§aBoutique");
+                v.setCustomNameVisible(true);
             });
+            npcs.add(villager);
         }
         if (upgradeNpcLocation != null && upgradeNpcLocation.getWorld() != null) {
-            upgradeNpc = upgradeNpcLocation.getWorld().spawn(upgradeNpcLocation, Villager.class, villager -> {
-                villager.setAI(false);
-                villager.setInvulnerable(true);
-                villager.setSilent(true);
-                villager.setCollidable(false);
-                villager.addScoreboardTag("upgrade_npc");
-                villager.setCustomName("§aAméliorations");
-                villager.setCustomNameVisible(true);
+            Villager villager = upgradeNpcLocation.getWorld().spawn(upgradeNpcLocation, Villager.class, v -> {
+                v.setAI(false);
+                v.setInvulnerable(true);
+                v.setSilent(true);
+                v.setCollidable(false);
+                v.addScoreboardTag("upgrade_npc");
+                v.setCustomName("§aAméliorations");
+                v.setCustomNameVisible(true);
             });
+            npcs.add(villager);
         }
     }
 
     private void removeNpcs() {
-        if (shopNpc != null) {
-            shopNpc.remove();
-            shopNpc = null;
+        for (Entity npc : npcs) {
+            npc.remove();
         }
-        if (upgradeNpc != null) {
-            upgradeNpc.remove();
-            upgradeNpc = null;
-        }
+        npcs.clear();
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/SetupListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SetupListener.java
@@ -102,10 +102,32 @@ public class SetupListener implements Listener {
             arena.getGenerators().add(new Generator(loc, action.getGeneratorType(), 1));
             MessageUtils.sendMessage(player, "&aGénérateur " + action.getGeneratorType().name() + " ajouté.");
         } else if (action.getType() == SetupType.NPC_SHOP) {
-            arena.setShopNpcLocation(loc);
+            Block clickedBlock = event.getClickedBlock();
+            if (clickedBlock == null) {
+                MessageUtils.sendMessage(player, "&cVeuillez cliquer sur un bloc pour définir le PNJ.");
+                return;
+            }
+            double x = clickedBlock.getX() + 0.5;
+            double y = clickedBlock.getY() + 1.0;
+            double z = clickedBlock.getZ() + 0.5;
+            float yaw = player.getLocation().getYaw();
+            float pitch = 0.0f;
+            Location npcLocation = new Location(player.getWorld(), x, y, z, yaw, pitch);
+            arena.setShopNpcLocation(npcLocation);
             MessageUtils.sendMessage(player, "&aPNJ Boutique défini.");
         } else if (action.getType() == SetupType.NPC_UPGRADE) {
-            arena.setUpgradeNpcLocation(loc);
+            Block clickedBlock = event.getClickedBlock();
+            if (clickedBlock == null) {
+                MessageUtils.sendMessage(player, "&cVeuillez cliquer sur un bloc pour définir le PNJ.");
+                return;
+            }
+            double x = clickedBlock.getX() + 0.5;
+            double y = clickedBlock.getY() + 1.0;
+            double z = clickedBlock.getZ() + 0.5;
+            float yaw = player.getLocation().getYaw();
+            float pitch = 0.0f;
+            Location npcLocation = new Location(player.getWorld(), x, y, z, yaw, pitch);
+            arena.setUpgradeNpcLocation(npcLocation);
             MessageUtils.sendMessage(player, "&aPNJ Améliorations défini.");
         }
 


### PR DESCRIPTION
## Summary
- Track spawned NPC entities per arena and clean them up on reset
- Normalize NPC spawn orientation and location during setup
- Document NPC fixes in changelog

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a356e1643c8329813cc32d653f1adf