### PR TITLE
feat(shop): implement item shop purchasing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [0.4.1] - En développement
 
+### Ajouté
+- La boutique d'objets est maintenant entièrement fonctionnelle, permettant l'achat d'items avec les ressources du jeu.
+
 ### Modifié
 - Re-architecture du système de PNJ pour une gestion par équipe au lieu de par arène.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Notre objectif principal est de fournir un système de gestion d'arène via une 
 - **Activation d'Arène** : Activez ou désactivez une arène une fois sa configuration terminée.
 - **Persistance des Données** : Les configurations d'arène sont sauvegardées de manière fiable dans des fichiers locaux.
 - **Conçu pour la 1.21** : Entièrement développé sur l'API Spigot 1.21 pour une performance et une stabilité optimales.
+- **Boutique d'objets fonctionnelle** : Achetez de l'équipement en dépensant vos ressources collectées.
 
 ## 🚀 Roadmap
 
@@ -96,3 +97,23 @@ main-menu:
 ```
 
 Chaque entrée renvoie vers une catégorie définie dans `shop-categories` où les objets à vendre seront listés.
+
+Exemple d'objet à l'intérieur d'une catégorie :
+
+```yaml
+shop-categories:
+  quick_buy_category:
+    title: "Achats Rapides"
+    rows: 5
+    items:
+      'wool':
+        material: WHITE_WOOL
+        name: "&fLaine"
+        amount: 16
+        cost:
+          resource: IRON
+          amount: 4
+        slot: 10
+```
+
+Le bloc `cost` indique la ressource et la quantité nécessaires pour acheter l'objet.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 *Objectif : Intégrer les boutiques d'objets et d'améliorations d'équipe.*
 
 * [✔] Fondations du système : PNJ, configuration `shop.yml`, menu principal.
-* [ ] Logique d'achat d'objets et gestion des ressources.
+* [✔] Logique d'achat d'objets et gestion des ressources.
 * [ ] Boutique d'améliorations d'équipe.
 
 ## 🎯 **Étape 4 : Polissage & Fonctionnalités Avancées (Version Cible : 1.0.0)**

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopCategoryMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopCategoryMenu.java
@@ -3,7 +3,6 @@ package com.heneria.bedwars.gui.shop;
 import com.heneria.bedwars.gui.Menu;
 import com.heneria.bedwars.managers.ShopManager;
 import com.heneria.bedwars.utils.ItemBuilder;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -67,12 +66,10 @@ public class ShopCategoryMenu extends Menu {
         if (categoryId != null) {
             ShopManager.ShopCategory category = shopManager.getCategory(categoryId);
             if (category != null) {
-                String title = ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', category.title()));
-                player.sendMessage("§eOuverture du menu des " + title.toLowerCase() + "...");
+                new ShopItemsMenu(shopManager, category).open(player, this);
             } else {
                 player.sendMessage("§cCatégorie introuvable.");
             }
-            player.closeInventory();
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/managers/ResourceManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ResourceManager.java
@@ -1,0 +1,61 @@
+package com.heneria.bedwars.managers;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Utility methods to interact with player resources.
+ */
+public final class ResourceManager {
+
+    private ResourceManager() {
+    }
+
+    /**
+     * Checks if a player has at least the required amount of a resource.
+     *
+     * @param player the player
+     * @param type   the resource type
+     * @param amount the amount required
+     * @return {@code true} if the player has enough resources
+     */
+    public static boolean hasResources(Player player, ResourceType type, int amount) {
+        int total = 0;
+        for (ItemStack stack : player.getInventory().getContents()) {
+            if (stack != null && stack.getType() == type.getMaterial()) {
+                total += stack.getAmount();
+                if (total >= amount) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Removes the specified amount of a resource from a player's inventory.
+     *
+     * @param player the player
+     * @param type   the resource type
+     * @param amount the amount to remove
+     */
+    public static void takeResources(Player player, ResourceType type, int amount) {
+        int remaining = amount;
+        ItemStack[] contents = player.getInventory().getContents();
+        for (int i = 0; i < contents.length && remaining > 0; i++) {
+            ItemStack stack = contents[i];
+            if (stack == null || stack.getType() != type.getMaterial()) {
+                continue;
+            }
+            int stackAmount = stack.getAmount();
+            if (stackAmount <= remaining) {
+                player.getInventory().setItem(i, null);
+                remaining -= stackAmount;
+            } else {
+                stack.setAmount(stackAmount - remaining);
+                player.getInventory().setItem(i, stack);
+                remaining = 0;
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/ResourceType.java
+++ b/src/main/java/com/heneria/bedwars/managers/ResourceType.java
@@ -1,0 +1,43 @@
+package com.heneria.bedwars.managers;
+
+import org.bukkit.Material;
+
+/**
+ * Types of resources used in the item shop.
+ */
+public enum ResourceType {
+    /** Iron ingot resource. */
+    IRON(Material.IRON_INGOT, "Fer"),
+    /** Gold ingot resource. */
+    GOLD(Material.GOLD_INGOT, "Or"),
+    /** Diamond resource. */
+    DIAMOND(Material.DIAMOND, "Diamant"),
+    /** Emerald resource. */
+    EMERALD(Material.EMERALD, "Émeraude");
+
+    private final Material material;
+    private final String displayName;
+
+    ResourceType(Material material, String displayName) {
+        this.material = material;
+        this.displayName = displayName;
+    }
+
+    /**
+     * Gets the Bukkit material representing this resource.
+     *
+     * @return corresponding material
+     */
+    public Material getMaterial() {
+        return material;
+    }
+
+    /**
+     * Gets the human readable name of this resource.
+     *
+     * @return display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+}


### PR DESCRIPTION
## Summary
- add resource manager for checking and removing shop currencies
- load and display item categories with costs, enabling purchases
- document item shop functionality and configuration

## Testing
- ⚠️ `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3647d6a1c8329b0a655df5feec430