### PR TITLE
feat: implement diamond-only team upgrade shop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [0.5.0] - En développement
+
+### Ajouté
+- Ajout de la boutique d'améliorations d'équipe (coûts en diamants). Le système économique de l'Étape 3 est maintenant complet.
+
 ## [0.4.1] - En développement
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Notre objectif principal est de fournir un système de gestion d'arène via une interface graphique (GUI) simple, rapide et puissante, éliminant le besoin de commandes complexes et de modifications manuelles de fichiers de configuration.
 
-## ✨ Fonctionnalités (v0.1.2)
+## ✨ Fonctionnalités (v0.5.0)
 
 - **Gestion d'Arène 100% GUI** : Créez, configurez et gérez vos arènes sans taper une seule commande de configuration.
 - **Menus de Configuration Complets** : Lobby, équipes (lits, spawns et PNJ), générateurs configurables via interface.
@@ -13,6 +13,7 @@ Notre objectif principal est de fournir un système de gestion d'arène via une 
 - **Persistance des Données** : Les configurations d'arène sont sauvegardées de manière fiable dans des fichiers locaux.
 - **Conçu pour la 1.21** : Entièrement développé sur l'API Spigot 1.21 pour une performance et une stabilité optimales.
 - **Boutique d'objets fonctionnelle** : Achetez de l'équipement en dépensant vos ressources collectées.
+- **Boutique d'améliorations d'équipe** : Investissez vos diamants pour débloquer des bonus permanents.
 
 ## 🚀 Roadmap
 
@@ -117,3 +118,35 @@ shop-categories:
 ```
 
 Le bloc `cost` indique la ressource et la quantité nécessaires pour acheter l'objet.
+
+## 🔨 Boutique d'Améliorations d'Équipe
+
+Le fichier `upgrades.yml` définit les différentes améliorations disponibles ainsi que leur coût en diamants.
+
+Exemple de configuration :
+
+```yaml
+sharpness:
+  name: "&aTranchant d'équipe"
+  item: IRON_SWORD
+  tiers:
+    1:
+      cost: 4
+      description: "&7Toutes les épées de l'équipe obtiennent Tranchant I."
+
+protection:
+  name: "&aProtection d'équipe"
+  item: IRON_CHESTPLATE
+  tiers:
+    1:
+      cost: 2
+      description: "&7Toutes les armures de l'équipe obtiennent Protection I."
+    2:
+      cost: 4
+      description: "&7Toutes les armures de l'équipe obtiennent Protection II."
+    3:
+      cost: 8
+      description: "&7Toutes les armures de l'équipe obtiennent Protection III."
+```
+
+Chaque niveau ne spécifie qu'un coût en diamants et une courte description. Les joueurs peuvent accéder à cette boutique en interagissant avec le PNJ d'améliorations de leur île.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,12 +31,10 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 * [✔] Gestion de la réapparition et de la destruction des lits.
 * [✔] Conditions de victoire et fin de partie.
 
-## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.4.0) - [WIP]**
-*Objectif : Intégrer les boutiques d'objets et d'améliorations d'équipe.*
-
+## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.5.0) - [✔] TERMINÉE**
 * [✔] Fondations du système : PNJ, configuration `shop.yml`, menu principal.
 * [✔] Logique d'achat d'objets et gestion des ressources.
-* [ ] Boutique d'améliorations d'équipe.
+* [✔] Boutique d'améliorations d'équipe (Coût en Diamants uniquement).
 
 ## 🎯 **Étape 4 : Polissage & Fonctionnalités Avancées (Version Cible : 1.0.0)**
 *Objectif : Ajouter les fonctionnalités spéciales, optimiser le code et préparer la version stable.*

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -6,10 +6,12 @@ import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.listeners.GameListener;
 import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.listeners.ShopListener;
+import com.heneria.bedwars.listeners.UpgradeListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
 import com.heneria.bedwars.managers.ShopManager;
+import com.heneria.bedwars.managers.UpgradeManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class HeneriaBedwars extends JavaPlugin {
@@ -19,6 +21,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private SetupManager setupManager;
     private GeneratorManager generatorManager;
     private ShopManager shopManager;
+    private UpgradeManager upgradeManager;
 
     @Override
     public void onEnable() {
@@ -32,6 +35,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.arenaManager.loadArenas();
         this.generatorManager = new GeneratorManager(this);
         this.shopManager = new ShopManager(this);
+        this.upgradeManager = new UpgradeManager(this);
 
         // Enregistrement des commandes
         CommandManager commandManager = new CommandManager(this);
@@ -54,6 +58,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new GameListener(), this);
         getServer().getPluginManager().registerEvents(new SetupListener(this.setupManager), this);
         getServer().getPluginManager().registerEvents(new ShopListener(), this);
+        getServer().getPluginManager().registerEvents(new UpgradeListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {
@@ -74,5 +79,9 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public ShopManager getShopManager() {
         return shopManager;
+    }
+
+    public UpgradeManager getUpgradeManager() {
+        return upgradeManager;
     }
 }

--- a/src/main/java/com/heneria/bedwars/arena/elements/Team.java
+++ b/src/main/java/com/heneria/bedwars/arena/elements/Team.java
@@ -1,11 +1,10 @@
 package com.heneria.bedwars.arena.elements;
 
 import com.heneria.bedwars.arena.enums.TeamColor;
+import com.heneria.bedwars.managers.UpgradeType;
 import org.bukkit.Location;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * Represents a team within an arena.
@@ -19,6 +18,7 @@ public class Team {
     private Location itemShopNpcLocation;
     private Location upgradeShopNpcLocation;
     private boolean hasBed = true;
+    private final Map<UpgradeType, Integer> upgrades = new EnumMap<>(UpgradeType.class);
 
     /**
      * Creates a new team with the given color.
@@ -163,5 +163,34 @@ public class Team {
      */
     public void setHasBed(boolean hasBed) {
         this.hasBed = hasBed;
+    }
+
+    /**
+     * Gets the level of a specific upgrade.
+     *
+     * @param type the upgrade type
+     * @return current level, 0 if none
+     */
+    public int getUpgradeLevel(UpgradeType type) {
+        return upgrades.getOrDefault(type, 0);
+    }
+
+    /**
+     * Sets the level of a specific upgrade.
+     *
+     * @param type  upgrade type
+     * @param level new level
+     */
+    public void setUpgradeLevel(UpgradeType type, int level) {
+        upgrades.put(type, level);
+    }
+
+    /**
+     * Gets the map of all upgrades levels.
+     *
+     * @return map of upgrades
+     */
+    public Map<UpgradeType, Integer> getUpgrades() {
+        return upgrades;
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
@@ -1,0 +1,109 @@
+package com.heneria.bedwars.gui.upgrades;
+
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.managers.ResourceManager;
+import com.heneria.bedwars.managers.ResourceType;
+import com.heneria.bedwars.managers.UpgradeManager;
+import com.heneria.bedwars.managers.UpgradeType;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Menu permettant l'achat des améliorations d'équipe.
+ */
+public class TeamUpgradesMenu extends Menu {
+
+    private final UpgradeManager upgradeManager;
+    private final Arena arena;
+    private final Team team;
+    private final Map<Integer, UpgradeType> slotTypes = new HashMap<>();
+
+    public TeamUpgradesMenu(UpgradeManager upgradeManager, Arena arena, Team team) {
+        this.upgradeManager = upgradeManager;
+        this.arena = arena;
+        this.team = team;
+    }
+
+    @Override
+    public String getTitle() {
+        return ChatColor.translateAlternateColorCodes('&', "&aAméliorations d'équipe");
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        int slot = 10;
+        for (UpgradeType type : UpgradeType.values()) {
+            UpgradeManager.Upgrade upgrade = upgradeManager.getUpgrade(type);
+            if (upgrade == null) {
+                continue;
+            }
+            int level = team.getUpgradeLevel(type);
+            UpgradeManager.UpgradeTier next = upgrade.tiers().get(level + 1);
+            ItemBuilder builder = new ItemBuilder(upgrade.item()).setName(upgrade.name());
+            if (next != null) {
+                builder.addLore(next.description())
+                        .addLore("&7Coût: &b" + next.cost() + " Diamants");
+            } else {
+                builder.addLore("&aAmélioration maximale");
+            }
+            inventory.setItem(slot, builder.build());
+            slotTypes.put(slot, type);
+            slot++;
+        }
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        UpgradeType type = slotTypes.get(event.getRawSlot());
+        if (type == null) {
+            return;
+        }
+        UpgradeManager.Upgrade upgrade = upgradeManager.getUpgrade(type);
+        int level = team.getUpgradeLevel(type);
+        UpgradeManager.UpgradeTier tier = upgrade.tiers().get(level + 1);
+        if (tier == null) {
+            player.sendMessage("\u00a7cCette amélioration est déj\u00e0 au niveau maximum.");
+            return;
+        }
+        int cost = tier.cost();
+        if (ResourceManager.hasResources(player, ResourceType.DIAMOND, cost)) {
+            ResourceManager.takeResources(player, ResourceType.DIAMOND, cost);
+            team.setUpgradeLevel(type, level + 1);
+            upgradeManager.applyUpgrade(arena, team, type, level + 1);
+            player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
+            player.sendMessage("\u00a7aAmélioration achetée !");
+            open(player, this.previousMenu);
+        } else {
+            player.sendMessage("\u00a7cVous n'avez pas assez de diamants !");
+            player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 1f, 1f);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/UpgradeListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/UpgradeListener.java
@@ -1,0 +1,39 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.gui.upgrades.TeamUpgradesMenu;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+
+/**
+ * Gère l'ouverture du menu des améliorations lors de l'interaction avec le PNJ dédié.
+ */
+public class UpgradeListener implements Listener {
+
+    @EventHandler
+    public void onInteract(PlayerInteractEntityEvent event) {
+        if (!(event.getRightClicked() instanceof Villager villager)) {
+            return;
+        }
+        if (!villager.getScoreboardTags().contains("upgrade_npc")) {
+            return;
+        }
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+        Arena arena = plugin.getArenaManager().getArena(player);
+        if (arena == null) {
+            return;
+        }
+        Team team = arena.getTeam(player);
+        if (team == null) {
+            return;
+        }
+        new TeamUpgradesMenu(plugin.getUpgradeManager(), arena, team).open(player);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
@@ -1,0 +1,135 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.elements.Team;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Gestionnaire des améliorations d'équipe chargées depuis {@code upgrades.yml}.
+ */
+public class UpgradeManager {
+
+    private final HeneriaBedwars plugin;
+    private final Map<UpgradeType, Upgrade> upgrades = new EnumMap<>(UpgradeType.class);
+
+    public UpgradeManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        loadConfiguration();
+    }
+
+    private void loadConfiguration() {
+        File file = new File(plugin.getDataFolder(), "upgrades.yml");
+        if (!file.exists()) {
+            plugin.saveResource("upgrades.yml", false);
+        }
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        upgrades.clear();
+        for (String key : config.getKeys(false)) {
+            try {
+                UpgradeType type = UpgradeType.valueOf(key.toUpperCase());
+                String name = config.getString(key + ".name", key);
+                Material item = Material.valueOf(config.getString(key + ".item", "STONE"));
+                Map<Integer, UpgradeTier> tiers = new HashMap<>();
+                ConfigurationSection tierSec = config.getConfigurationSection(key + ".tiers");
+                if (tierSec != null) {
+                    for (String tierKey : tierSec.getKeys(false)) {
+                        int level = Integer.parseInt(tierKey);
+                        int cost = tierSec.getInt(tierKey + ".cost", 1);
+                        String desc = tierSec.getString(tierKey + ".description", "");
+                        tiers.put(level, new UpgradeTier(cost, desc));
+                    }
+                }
+                upgrades.put(type, new Upgrade(type, name, item, tiers));
+            } catch (IllegalArgumentException ex) {
+                plugin.getLogger().warning("Invalid upgrade configuration: " + key);
+            }
+        }
+    }
+
+    public Upgrade getUpgrade(UpgradeType type) {
+        return upgrades.get(type);
+    }
+
+    public void applyUpgrade(Arena arena, Team team, UpgradeType type, int level) {
+        switch (type) {
+            case SHARPNESS -> applySharpness(team, level);
+            case PROTECTION -> applyProtection(team, level);
+            case HASTE -> applyHaste(team, level);
+            case FORGE -> applyForge(arena, team, level);
+            default -> {
+            }
+        }
+    }
+
+    private void applySharpness(Team team, int level) {
+        for (UUID uuid : team.getMembers()) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player == null) {
+                continue;
+            }
+            for (ItemStack stack : player.getInventory().getContents()) {
+                if (stack != null && stack.getType().name().endsWith("_SWORD")) {
+                    stack.addUnsafeEnchantment(Enchantment.DAMAGE_ALL, level);
+                }
+            }
+        }
+    }
+
+    private void applyProtection(Team team, int level) {
+        for (UUID uuid : team.getMembers()) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player == null) {
+                continue;
+            }
+            ItemStack[] armor = player.getInventory().getArmorContents();
+            for (int i = 0; i < armor.length; i++) {
+                ItemStack piece = armor[i];
+                if (piece != null) {
+                    piece.addUnsafeEnchantment(Enchantment.PROTECTION_ENVIRONMENTAL, level);
+                    armor[i] = piece;
+                }
+            }
+            player.getInventory().setArmorContents(armor);
+        }
+    }
+
+    private void applyHaste(Team team, int level) {
+        for (UUID uuid : team.getMembers()) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null) {
+                player.addPotionEffect(new PotionEffect(PotionEffectType.FAST_DIGGING, Integer.MAX_VALUE, level - 1, false, false));
+            }
+        }
+    }
+
+    private void applyForge(Arena arena, Team team, int level) {
+        if (arena == null || team.getSpawnLocation() == null) {
+            return;
+        }
+        for (Generator gen : arena.getGenerators()) {
+            if (gen.getLocation() != null && gen.getLocation().getWorld() == team.getSpawnLocation().getWorld()
+                    && gen.getLocation().distanceSquared(team.getSpawnLocation()) <= 36) {
+                gen.setTier(level + 1);
+            }
+        }
+    }
+
+    public record Upgrade(UpgradeType type, String name, Material item, Map<Integer, UpgradeTier> tiers) {
+    }
+
+    public record UpgradeTier(int cost, String description) {
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeType.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeType.java
@@ -1,0 +1,15 @@
+package com.heneria.bedwars.managers;
+
+/**
+ * Types d'améliorations d'équipe disponibles.
+ */
+public enum UpgradeType {
+    /** Augmente le tranchant des épées de l'équipe. */
+    SHARPNESS,
+    /** Ajoute de la protection sur les armures de l'équipe. */
+    PROTECTION,
+    /** Donne un effet de hâte aux joueurs de l'équipe. */
+    HASTE,
+    /** Améliore la forge de l'équipe. */
+    FORGE
+}

--- a/src/main/resources/upgrades.yml
+++ b/src/main/resources/upgrades.yml
@@ -1,0 +1,43 @@
+sharpness:
+  name: "&aTranchant d'équipe"
+  item: IRON_SWORD
+  tiers:
+    1:
+      cost: 4
+      description: "&7Toutes les épées de l'équipe obtiennent Tranchant I."
+
+protection:
+  name: "&aProtection d'équipe"
+  item: IRON_CHESTPLATE
+  tiers:
+    1:
+      cost: 2
+      description: "&7Toutes les armures de l'équipe obtiennent Protection I."
+    2:
+      cost: 4
+      description: "&7Toutes les armures de l'équipe obtiennent Protection II."
+    3:
+      cost: 8
+      description: "&7Toutes les armures de l'équipe obtiennent Protection III."
+
+haste:
+  name: "&aHâte d'équipe"
+  item: GOLDEN_PICKAXE
+  tiers:
+    1:
+      cost: 2
+      description: "&7Les membres de l'équipe obtiennent Hâte I."
+    2:
+      cost: 4
+      description: "&7Les membres de l'équipe obtiennent Hâte II."
+
+forge:
+  name: "&aForge"
+  item: FURNACE
+  tiers:
+    1:
+      cost: 4
+      description: "&7Améliore la forge de l'équipe au niveau II."
+    2:
+      cost: 8
+      description: "&7Améliore la forge de l'équipe au niveau III."


### PR DESCRIPTION
## Summary
- add configurable team upgrades with diamond-only costs
- introduce UpgradeManager, menu, and listener for upgrade NPC
- document completion of economic systems and new upgrades.yml format

## Testing
- `mvn -q -e test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a37d64297c83298f9e7ffb2d595d09