### PR TITLE
HBW-047: Correction d'erreur de compilation : Mise à jour des noms de l'API Spigot 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [0.5.1] - En développement
+
+### Corrigé
+- Correction d'erreurs de compilation dues à la mise à jour des noms de constantes de l'API Spigot 1.21.
+
 ## [0.4.1] - En développement
 
 ### Ajouté

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
@@ -1,0 +1,44 @@
+package com.heneria.bedwars.managers;
+
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Applies upgrade effects such as enchantments and potion effects.
+ */
+public class UpgradeManager {
+
+    /**
+     * Adds a sharpness enchantment to the provided item.
+     *
+     * @param item  the item to enchant
+     * @param level the level of the enchantment
+     */
+    public void applySharpness(ItemStack item, int level) {
+        item.addUnsafeEnchantment(Enchantment.SHARPNESS, level);
+    }
+
+    /**
+     * Adds a protection enchantment to the provided item.
+     *
+     * @param item  the item to enchant
+     * @param level the level of the enchantment
+     */
+    public void applyProtection(ItemStack item, int level) {
+        item.addUnsafeEnchantment(Enchantment.PROTECTION, level);
+    }
+
+    /**
+     * Applies the haste potion effect to the player.
+     *
+     * @param player    the player receiving the effect
+     * @param amplifier the amplifier of the effect
+     * @param duration  the duration of the effect in ticks
+     */
+    public void applyHaste(Player player, int amplifier, int duration) {
+        player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, duration, amplifier, true, true, true));
+    }
+}


### PR DESCRIPTION
## Summary
- Update enchantment and potion effect constants to Spigot 1.21 equivalents.
- Document compilation fix in changelog.

## Testing
- `mvn -B -Djava.net.preferIPv4Stack=true package --file pom.xml` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a37fb040588329a3f9dfd471487645