### PR TITLE
feat: add complete team upgrades shop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Corrigé
 - Correction d'erreurs de compilation dues à la mise à jour des noms de constantes de l'API Spigot 1.21.
 
+## [0.5.0] - 2024-??-??
+
+### Ajouté
+- Ajout de la boutique d'améliorations d'équipe. Le système économique de l'Étape 3 est maintenant complet.
+
 ## [0.4.1] - En développement
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -1,104 +1,69 @@
- # HeneriaBedwars
- 
- **HeneriaBedwars** est un plugin de BedWars complet et moderne pour les serveurs Spigot 1.21, conçu pour offrir une expérience de jeu et d'administration exceptionnelle.
- 
- Notre objectif principal est de fournir un système de gestion d'arène via une interface graphique (GUI) simple, rapide et puissante, éliminant le besoin de commandes complexes et de modifications manuelles de fichiers de configuration.
- 
--## ✨ Fonctionnalités (v0.1.2)
-+## ✨ Fonctionnalités (v0.5.0)
- 
- - **Gestion d'Arène 100% GUI** : Créez, configurez et gérez vos arènes sans taper une seule commande de configuration.
- - **Menus de Configuration Complets** : Lobby, équipes (lits, spawns et PNJ), générateurs configurables via interface.
- - **Outil de Positionnement** : Un simple bâton permet d'enregistrer les positions directement en jeu.
- - **Activation d'Arène** : Activez ou désactivez une arène une fois sa configuration terminée.
- - **Persistance des Données** : Les configurations d'arène sont sauvegardées de manière fiable dans des fichiers locaux.
- - **Conçu pour la 1.21** : Entièrement développé sur l'API Spigot 1.21 pour une performance et une stabilité optimales.
- - **Boutique d'objets fonctionnelle** : Achetez de l'équipement en dépensant vos ressources collectées.
-+- **Boutique d'améliorations d'équipe** : Investissez vos diamants pour débloquer des bonus permanents.
- 
- ## 🚀 Roadmap
- 
- Consultez notre [ROADMAP.md](ROADMAP.md) pour suivre le développement du projet étape par étape.
- 
- ## 🕹️ Gameplay
- 
- Chaque équipe possède un lit. Tant que ce lit est intact, les joueurs de l'équipe réapparaissent après quelques secondes.
- Si le lit est détruit, toute mort devient définitive : le joueur est éliminé et passe en mode spectateur pour la fin de la partie.
- Détruisez les lits adverses tout en protégeant le vôtre pour remporter la victoire.
- La partie se termine lorsqu'une seule équipe possède encore des joueurs en vie. L'arène annonce les vainqueurs, arrête les générateurs et se réinitialise automatiquement pour le prochain match.
- 
- ## 🔧 Compilation
- 
- 1.  Clonez ce dépôt : `git clone https://github.com/tomashb/HeneriaBW.git`
- 2.  Naviguez dans le dossier : `cd HeneriaBW`
- 3.  Compilez avec Maven : `mvn clean package`
- 4.  Le JAR final se trouvera dans le dossier `target/`.
- 
- ## 🎮 Commandes & Permissions
- 
- ### Commandes Administrateur
- - `/bedwars admin` (Alias: `/bw admin`, `/hbw admin`)
-   - Ouvre le menu principal de gestion des arènes.
-   - **Permission :** `heneriabw.admin`
-diff --git a/README.md b/README.md
-index 1acf50cf9f501fa51e0cca5a3812855a9e11c912..9f628bd52bc26a2040b8366a87fd90cc9cfd2794 100644
---- a/README.md
-+++ b/README.md
-@@ -95,25 +96,57 @@ main-menu:
-       slot: 10
-       category: 'quick_buy_category'
- ```
- 
- Chaque entrée renvoie vers une catégorie définie dans `shop-categories` où les objets à vendre seront listés.
- 
- Exemple d'objet à l'intérieur d'une catégorie :
- 
- ```yaml
- shop-categories:
-   quick_buy_category:
-     title: "Achats Rapides"
-     rows: 5
-     items:
-       'wool':
-         material: WHITE_WOOL
-         name: "&fLaine"
-         amount: 16
-         cost:
-           resource: IRON
-           amount: 4
-         slot: 10
- ```
- 
- Le bloc `cost` indique la ressource et la quantité nécessaires pour acheter l'objet.
-+
-+## 🔨 Boutique d'Améliorations d'Équipe
-+
-+Le fichier `upgrades.yml` définit les différentes améliorations disponibles ainsi que leur coût en diamants.
-+
-+Exemple de configuration :
-+
-+```yaml
-+sharpness:
-+  name: "&aTranchant d'équipe"
-+  item: IRON_SWORD
-+  tiers:
-+    1:
-+      cost: 4
-+      description: "&7Toutes les épées de l'équipe obtiennent Tranchant I."
-+
-+protection:
-+  name: "&aProtection d'équipe"
-+  item: IRON_CHESTPLATE
-+  tiers:
-+    1:
-+      cost: 2
-+      description: "&7Toutes les armures de l'équipe obtiennent Protection I."
-+    2:
-+      cost: 4
-+      description: "&7Toutes les armures de l'équipe obtiennent Protection II."
-+    3:
-+      cost: 8
-+      description: "&7Toutes les armures de l'équipe obtiennent Protection III."
-+```
-+
-+Chaque niveau ne spécifie qu'un coût en diamants et une courte description. Les joueurs peuvent accéder à cette boutique en interagissant avec le PNJ d'améliorations de leur île.
+# HeneriaBedwars
+
+**HeneriaBedwars** est un plugin de BedWars complet et moderne pour les serveurs Spigot 1.21, conçu pour offrir une expérience de jeu et d'administration exceptionnelle.
+
+Notre objectif principal est de fournir un système de gestion d'arène via une interface graphique (GUI) simple, rapide et puissante, éliminant le besoin de commandes complexes et de modifications manuelles de fichiers de configuration.
+
+## ✨ Fonctionnalités (v0.5.0)
+- **Gestion d'Arène 100% GUI** : Créez, configurez et gérez vos arènes sans taper une seule commande de configuration.
+- **Menus de Configuration Complets** : Lobby, équipes (lits, spawns et PNJ), générateurs configurables via interface.
+- **Outil de Positionnement** : Un simple bâton permet d'enregistrer les positions directement en jeu.
+- **Activation d'Arène** : Activez ou désactivez une arène une fois sa configuration terminée.
+- **Persistance des Données** : Les configurations d'arène sont sauvegardées de manière fiable dans des fichiers locaux.
+- **Conçu pour la 1.21** : Entièrement développé sur l'API Spigot 1.21 pour une performance et une stabilité optimales.
+- **Boutique d'objets fonctionnelle** : Achetez de l'équipement en dépensant vos ressources collectées.
+- **Boutique d'améliorations d'équipe** : Investissez vos diamants pour débloquer des bonus permanents.
+
+## 🚀 Roadmap
+
+Consultez notre [ROADMAP.md](ROADMAP.md) pour suivre le développement du projet étape par étape.
+
+## 🕹️ Gameplay
+
+Chaque équipe possède un lit. Tant que ce lit est intact, les joueurs de l'équipe réapparaissent après quelques secondes. Si le lit est détruit, toute mort devient définitive : le joueur est éliminé et passe en mode spectateur pour la fin de la partie. Détruisez les lits adverses tout en protégeant le vôtre pour remporter la victoire. La partie se termine lorsqu'une seule équipe possède encore des joueurs en vie. L'arène annonce les vainqueurs, arrête les générateurs et se réinitialise automatiquement pour le prochain match.
+
+## 🔧 Compilation
+
+1. Clonez ce dépôt : `git clone https://github.com/tomashb/HeneriaBW.git`
+2. Naviguez dans le dossier : `cd HeneriaBW`
+3. Compilez avec Maven : `mvn clean package`
+4. Le JAR final se trouvera dans le dossier `target/`.
+
+## 🎮 Commandes & Permissions
+
+### Commandes Administrateur
+- `/bedwars admin` (Alias: `/bw admin`, `/hbw admin`)
+  - Ouvre le menu principal de gestion des arènes.
+  - **Permission :** `heneriabw.admin`
+
+## 🔨 Boutique d'Améliorations d'Équipe
+
+Le fichier `upgrades.yml` définit les différentes améliorations disponibles ainsi que leur coût en diamants.
+
+Exemple de configuration :
+
+```yaml
+sharpness:
+  name: "&aTranchant d'équipe"
+  item: IRON_SWORD
+  tiers:
+    1:
+      cost: 4
+      description: "&7Toutes les épées de l'équipe obtiennent Tranchant I."
+
+protection:
+  name: "&aProtection d'équipe"
+  item: IRON_CHESTPLATE
+  tiers:
+    1:
+      cost: 2
+      description: "&7Toutes les armures de l'équipe obtiennent Protection I."
+    2:
+      cost: 4
+      description: "&7Toutes les armures de l'équipe obtiennent Protection II."
+    3:
+      cost: 8
+      description: "&7Toutes les armures de l'équipe obtiennent Protection III."
+```
+
+Chaque niveau ne spécifie qu'un coût en diamants et une courte description. Les joueurs peuvent accéder à cette boutique en interagissant avec le PNJ d'améliorations de leur île.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,12 +31,12 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 * [✔] Gestion de la réapparition et de la destruction des lits.
 * [✔] Conditions de victoire et fin de partie.
 
-## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.4.0) - [WIP]**
+## 🎯 **Étape 3 : Systèmes Économiques & PNJ (Version Cible : 0.4.0) - [✔] TERMINÉE**
 *Objectif : Intégrer les boutiques d'objets et d'améliorations d'équipe.*
 
 * [✔] Fondations du système : PNJ, configuration `shop.yml`, menu principal.
 * [✔] Logique d'achat d'objets et gestion des ressources.
-* [ ] Boutique d'améliorations d'équipe.
+* [✔] Boutique d'améliorations d'équipe.
 
 ## 🎯 **Étape 4 : Polissage & Fonctionnalités Avancées (Version Cible : 1.0.0)**
 *Objectif : Ajouter les fonctionnalités spéciales, optimiser le code et préparer la version stable.*

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -6,10 +6,12 @@ import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.listeners.GameListener;
 import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.listeners.ShopListener;
+import com.heneria.bedwars.listeners.UpgradeListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
 import com.heneria.bedwars.managers.ShopManager;
+import com.heneria.bedwars.managers.UpgradeManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class HeneriaBedwars extends JavaPlugin {
@@ -19,6 +21,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private SetupManager setupManager;
     private GeneratorManager generatorManager;
     private ShopManager shopManager;
+    private UpgradeManager upgradeManager;
 
     @Override
     public void onEnable() {
@@ -32,6 +35,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.arenaManager.loadArenas();
         this.generatorManager = new GeneratorManager(this);
         this.shopManager = new ShopManager(this);
+        this.upgradeManager = new UpgradeManager(this);
 
         // Enregistrement des commandes
         CommandManager commandManager = new CommandManager(this);
@@ -54,6 +58,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new GameListener(), this);
         getServer().getPluginManager().registerEvents(new SetupListener(this.setupManager), this);
         getServer().getPluginManager().registerEvents(new ShopListener(), this);
+        getServer().getPluginManager().registerEvents(new UpgradeListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {
@@ -74,5 +79,9 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public ShopManager getShopManager() {
         return shopManager;
+    }
+
+    public UpgradeManager getUpgradeManager() {
+        return upgradeManager;
     }
 }

--- a/src/main/java/com/heneria/bedwars/arena/elements/Team.java
+++ b/src/main/java/com/heneria/bedwars/arena/elements/Team.java
@@ -5,6 +5,8 @@ import org.bukkit.Location;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -19,6 +21,7 @@ public class Team {
     private Location itemShopNpcLocation;
     private Location upgradeShopNpcLocation;
     private boolean hasBed = true;
+    private final Map<String, Integer> upgradeLevels = new HashMap<>();
 
     /**
      * Creates a new team with the given color.
@@ -163,5 +166,25 @@ public class Team {
      */
     public void setHasBed(boolean hasBed) {
         this.hasBed = hasBed;
+    }
+
+    /**
+     * Gets the current level of a team upgrade.
+     *
+     * @param id the upgrade id
+     * @return the level, or {@code 0} if not purchased
+     */
+    public int getUpgradeLevel(String id) {
+        return upgradeLevels.getOrDefault(id, 0);
+    }
+
+    /**
+     * Sets the level of a team upgrade.
+     *
+     * @param id    the upgrade id
+     * @param level the new level
+     */
+    public void setUpgradeLevel(String id, int level) {
+        upgradeLevels.put(id, level);
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
@@ -1,0 +1,142 @@
+package com.heneria.bedwars.gui.upgrades;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.managers.ResourceManager;
+import com.heneria.bedwars.managers.ResourceType;
+import com.heneria.bedwars.managers.UpgradeManager;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Menu allowing players to purchase team upgrades with diamonds.
+ */
+public class TeamUpgradesMenu extends Menu {
+
+    private final HeneriaBedwars plugin;
+    private final Arena arena;
+    private final Team team;
+    private final UpgradeManager upgradeManager;
+    private final Map<Integer, UpgradeManager.Upgrade> slotUpgrades = new HashMap<>();
+
+    public TeamUpgradesMenu(HeneriaBedwars plugin, Arena arena, Team team) {
+        this.plugin = plugin;
+        this.arena = arena;
+        this.team = team;
+        this.upgradeManager = plugin.getUpgradeManager();
+    }
+
+    @Override
+    public String getTitle() {
+        return "§aAméliorations";
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        slotUpgrades.clear();
+        int slot = 10;
+        for (UpgradeManager.Upgrade upgrade : upgradeManager.getUpgrades()) {
+            int current = team.getUpgradeLevel(upgrade.id());
+            UpgradeManager.UpgradeTier tier = upgrade.tiers().get(current + 1);
+            ItemBuilder builder = new ItemBuilder(upgrade.item()).setName(upgrade.name());
+            if (tier != null) {
+                builder.addLore(tier.description())
+                        .addLore("&7Coût: &b" + tier.cost() + " Diamants");
+            } else {
+                builder.addLore("&7Amélioration maximale atteinte");
+            }
+            inventory.setItem(slot, builder.build());
+            slotUpgrades.put(slot, upgrade);
+            slot++;
+        }
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        UpgradeManager.Upgrade upgrade = slotUpgrades.get(event.getRawSlot());
+        if (upgrade == null) {
+            return;
+        }
+        int current = team.getUpgradeLevel(upgrade.id());
+        UpgradeManager.UpgradeTier tier = upgrade.tiers().get(current + 1);
+        if (tier == null) {
+            player.sendMessage("§cCette amélioration est déjà au maximum.");
+            return;
+        }
+        int cost = tier.cost();
+        if (!ResourceManager.hasResources(player, ResourceType.DIAMOND, cost)) {
+            player.sendMessage("§cVous n'avez pas assez de diamants !");
+            player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 1f, 1f);
+            return;
+        }
+        ResourceManager.takeResources(player, ResourceType.DIAMOND, cost);
+        team.setUpgradeLevel(upgrade.id(), current + 1);
+        applyUpgradeEffect(upgrade.id(), current + 1);
+        player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
+        new TeamUpgradesMenu(plugin, arena, team).open(player, previousMenu);
+    }
+
+    private void applyUpgradeEffect(String id, int level) {
+        switch (id.toLowerCase()) {
+            case "sharpness" -> {
+                for (UUID uuid : team.getMembers()) {
+                    Player p = Bukkit.getPlayer(uuid);
+                    if (p == null) continue;
+                    for (ItemStack item : p.getInventory().getContents()) {
+                        if (item != null && item.getType().name().endsWith("SWORD")) {
+                            upgradeManager.applySharpness(item, level);
+                        }
+                    }
+                }
+            }
+            case "protection" -> {
+                for (UUID uuid : team.getMembers()) {
+                    Player p = Bukkit.getPlayer(uuid);
+                    if (p == null) continue;
+                    for (ItemStack item : p.getInventory().getArmorContents()) {
+                        if (item != null) {
+                            upgradeManager.applyProtection(item, level);
+                        }
+                    }
+                }
+            }
+            case "haste" -> {
+                for (UUID uuid : team.getMembers()) {
+                    Player p = Bukkit.getPlayer(uuid);
+                    if (p == null) continue;
+                    upgradeManager.applyHaste(p, level - 1, 20 * 60 * 60);
+                }
+            }
+            case "forge" -> plugin.getGeneratorManager().upgradeTeamGenerators(arena, team, level + 1);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/UpgradeListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/UpgradeListener.java
@@ -1,0 +1,40 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.gui.upgrades.TeamUpgradesMenu;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+
+/**
+ * Handles interaction with upgrade shop NPCs.
+ */
+public class UpgradeListener implements Listener {
+
+    @EventHandler
+    public void onInteract(PlayerInteractEntityEvent event) {
+        if (!(event.getRightClicked() instanceof Villager villager)) {
+            return;
+        }
+        if (!villager.getScoreboardTags().contains("upgrade_npc")) {
+            return;
+        }
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+        Arena arena = plugin.getArenaManager().getArenaByPlayer(player.getUniqueId());
+        if (arena == null) {
+            return;
+        }
+        Team team = arena.getTeam(player);
+        if (team == null) {
+            player.sendMessage("§cVous n'avez pas d'équipe.");
+            return;
+        }
+        new TeamUpgradesMenu(plugin, arena, team).open(player);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -1,8 +1,11 @@
 package com.heneria.bedwars.managers;
 
 import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.elements.Team;
 import com.heneria.bedwars.arena.enums.GeneratorType;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
@@ -108,6 +111,29 @@ public class GeneratorManager {
 
     public void unregisterGenerator(Generator gen) {
         counters.remove(gen);
+    }
+
+    /**
+     * Upgrades the tier of generators near a team's spawn point.
+     *
+     * @param arena the arena containing the generators
+     * @param team  the team whose generators to upgrade
+     * @param tier  the new tier
+     */
+    public void upgradeTeamGenerators(Arena arena, Team team, int tier) {
+        Location spawn = team.getSpawnLocation();
+        if (spawn == null) {
+            return;
+        }
+        for (Generator gen : arena.getGenerators()) {
+            if (gen.getType() == GeneratorType.IRON || gen.getType() == GeneratorType.GOLD) {
+                if (gen.getLocation() != null && gen.getLocation().getWorld() == spawn.getWorld()
+                        && gen.getLocation().distance(spawn) < 10) {
+                    gen.setTier(tier);
+                    counters.put(gen, getDelayCycles(gen));
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
@@ -1,15 +1,67 @@
 package com.heneria.bedwars.managers;
 
+import com.heneria.bedwars.HeneriaBedwars;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import java.io.File;
+import java.util.*;
+
 /**
- * Applies upgrade effects such as enchantments and potion effects.
+ * Handles loading of team upgrades and applying their effects.
  */
 public class UpgradeManager {
+
+    private final HeneriaBedwars plugin;
+    private YamlConfiguration config;
+    private final Map<String, Upgrade> upgrades = new HashMap<>();
+
+    public UpgradeManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        loadConfiguration();
+    }
+
+    private void loadConfiguration() {
+        File file = new File(plugin.getDataFolder(), "upgrades.yml");
+        if (!file.exists()) {
+            plugin.saveResource("upgrades.yml", false);
+        }
+        this.config = YamlConfiguration.loadConfiguration(file);
+        upgrades.clear();
+        for (String id : config.getKeys(false)) {
+            String base = id + ".";
+            String name = config.getString(base + "name", id);
+            Material item = Material.valueOf(config.getString(base + "item", "STONE"));
+            Map<Integer, UpgradeTier> tiers = new HashMap<>();
+            ConfigurationSection sec = config.getConfigurationSection(base + "tiers");
+            if (sec != null) {
+                for (String tierKey : sec.getKeys(false)) {
+                    try {
+                        int tier = Integer.parseInt(tierKey);
+                        int cost = sec.getInt(tierKey + ".cost", 1);
+                        String desc = sec.getString(tierKey + ".description", "");
+                        tiers.put(tier, new UpgradeTier(cost, desc));
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+            }
+            upgrades.put(id, new Upgrade(id, name, item, tiers));
+        }
+    }
+
+    public Collection<Upgrade> getUpgrades() {
+        return upgrades.values();
+    }
+
+    public Upgrade getUpgrade(String id) {
+        return upgrades.get(id);
+    }
 
     /**
      * Adds a sharpness enchantment to the provided item.
@@ -40,5 +92,11 @@ public class UpgradeManager {
      */
     public void applyHaste(Player player, int amplifier, int duration) {
         player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, duration, amplifier, true, true, true));
+    }
+
+    public record Upgrade(String id, String name, Material item, Map<Integer, UpgradeTier> tiers) {
+    }
+
+    public record UpgradeTier(int cost, String description) {
     }
 }

--- a/src/main/resources/upgrades.yml
+++ b/src/main/resources/upgrades.yml
@@ -1,0 +1,40 @@
+sharpness:
+  name: "&aTranchant d'équipe"
+  item: DIAMOND_SWORD
+  tiers:
+    1:
+      cost: 4
+      description: "&7Les épées de l'équipe obtiennent Tranchant I."
+protection:
+  name: "&aProtection d'équipe"
+  item: DIAMOND_CHESTPLATE
+  tiers:
+    1:
+      cost: 2
+      description: "&7Les armures de l'équipe obtiennent Protection I."
+    2:
+      cost: 4
+      description: "&7Les armures de l'équipe obtiennent Protection II."
+    3:
+      cost: 8
+      description: "&7Les armures de l'équipe obtiennent Protection III."
+haste:
+  name: "&aHâte d'équipe"
+  item: GOLDEN_PICKAXE
+  tiers:
+    1:
+      cost: 2
+      description: "&7Les joueurs gagnent Hâte I."
+    2:
+      cost: 4
+      description: "&7Les joueurs gagnent Hâte II."
+forge:
+  name: "&aForge améliorée"
+  item: FURNACE
+  tiers:
+    1:
+      cost: 4
+      description: "&7Augmente la vitesse des générateurs de l'équipe."
+    2:
+      cost: 8
+      description: "&7Générateurs encore plus rapides."


### PR DESCRIPTION
## Summary
- add configurable team upgrades with diamond costs
- implement upgrade menu, purchase logic, and effects using modern 1.21 API
- finalize economic systems docs and roadmap

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3843037e883298f31048af321bdc8