### PR TITLE
HBW-050: Implement player building system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [0.6.0] - En développement
+
+### Ajouté
+- Ajout de la mécanique de construction : les joueurs peuvent maintenant acheter, poser et casser des blocs.
+
 ## [0.5.1] - En développement
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
 - 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, et détruisez celui de vos ennemis pour les éliminer définitivement.
 - 💰 **Système Économique** : Collectez du Fer, de l'Or, des Diamants et des Émeraudes à des vitesses différentes pour acheter de l'équipement.
 - 🛒 **Boutiques Fonctionnelles** : Interagissez avec les PNJ pour acheter des objets dans la boutique d'items ou des améliorations permanentes pour votre équipe.
+- 🧱 **Construction de Blocs** : Achetez, placez et cassez des blocs pour bâtir ponts et défenses.
 - 🏆 **Conditions de Victoire** : La partie se termine automatiquement lorsque la dernière équipe en vie est déclarée vainqueur, et l'arène se réinitialise pour le prochain combat.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,5 +38,9 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 * [✔] Logique d'achat d'objets et gestion des ressources.
 * [✔] Boutique d'améliorations d'équipe.
 
-## 🎯 **Étape 4 : Polissage & Fonctionnalités Avancées (Version Cible : 1.0.0)**
+## 🎯 **Étape 4 : Polissage & Fonctionnalités Avancées (Version Cible : 1.0.0) - [WIP]**
 *Objectif : Ajouter les fonctionnalités spéciales, optimiser le code et préparer la version stable.*
+
+* [✔] La Construction : Ajout de la pose/destruction de blocs par les joueurs.
+* [ ] Les Objets Spéciaux (TNT, Boules de feu...).
+* [ ] Le Tableau de Bord (Scoreboard).

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.commands.CommandManager;
 import com.heneria.bedwars.listeners.ChatListener;
 import com.heneria.bedwars.listeners.GUIListener;
 import com.heneria.bedwars.listeners.GameListener;
+import com.heneria.bedwars.listeners.BlockPlaceListener;
 import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.listeners.ShopListener;
 import com.heneria.bedwars.listeners.UpgradeListener;
@@ -56,6 +57,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new GUIListener(), this);
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
         getServer().getPluginManager().registerEvents(new GameListener(), this);
+        getServer().getPluginManager().registerEvents(new BlockPlaceListener(), this);
         getServer().getPluginManager().registerEvents(new SetupListener(this.setupManager), this);
         getServer().getPluginManager().registerEvents(new ShopListener(), this);
         getServer().getPluginManager().registerEvents(new UpgradeListener(), this);

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -10,6 +10,7 @@ import com.heneria.bedwars.utils.GameUtils;
 import com.heneria.bedwars.utils.MessageUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.entity.Entity;
@@ -46,6 +47,7 @@ public class Arena {
     private final Map<UUID, PlayerData> savedStates = new HashMap<>();
     // NEW CACHE SYSTEM: SIMPLE AND DIRECT
     private final Map<Block, Team> bedBlocks = new HashMap<>();
+    private final List<Block> placedBlocks = new ArrayList<>();
     private BukkitTask countdownTask;
     private int countdownDuration = 10;
 
@@ -257,6 +259,11 @@ public class Arena {
 
     public void clearBeds() {
         bedBlocks.clear();
+    }
+
+    // Player placed blocks
+    public List<Block> getPlacedBlocks() {
+        return placedBlocks;
     }
 
     public void registerBeds() {
@@ -535,5 +542,9 @@ public class Arena {
         state = GameState.WAITING;
         liveNpcs.forEach(Entity::remove);
         liveNpcs.clear();
+        for (Block block : placedBlocks) {
+            block.setType(Material.AIR);
+        }
+        placedBlocks.clear();
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
@@ -1,0 +1,30 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+/**
+ * Tracks blocks placed by players during a game.
+ */
+public class BlockPlaceListener implements Listener {
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        Block block = event.getBlockPlaced();
+        arena.getPlacedBlocks().add(block);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -35,17 +35,13 @@ public class GameListener implements Listener {
         Player player = event.getPlayer();
         Block block = event.getBlock();
         Arena arena = arenaManager.getArena(player);
-        if (arena == null || arena.getState() != GameState.PLAYING) return;
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
 
-        // On utilise la nouvelle méthode DIRECTE
         Team bedTeam = arena.getTeamOfBed(block);
 
-        System.out.println("=============================================");
-        System.out.println("[NOUVEAU DEBUG - LIT] Joueur: " + player.getName());
-        System.out.println("[NOUVEAU DEBUG - LIT] Bloc cassé: " + block.getType() + " @ " + block.getLocation());
-        
         if (bedTeam != null) {
-            System.out.println("[NOUVEAU DEBUG - LIT] Le bloc appartient à l'équipe: " + bedTeam.getColor().name());
             Team playerTeam = arena.getTeam(player);
             if (playerTeam != null && playerTeam.equals(bedTeam)) {
                 player.sendMessage("§cVous ne pouvez pas casser votre propre lit.");
@@ -55,10 +51,12 @@ public class GameListener implements Listener {
                 bedTeam.setHasBed(false);
                 arena.broadcastTitle("§cDESTRUCTION DE LIT !", "Lit de l'équipe " + bedTeam.getColor().getDisplayName() + " détruit par " + player.getName(), 10, 70, 20);
             }
-        } else {
-            System.out.println("[NOUVEAU DEBUG - LIT] Ce bloc n'est pas un lit d'équipe enregistré.");
+            return;
         }
-        System.out.println("=============================================");
+
+        if (!arena.getPlacedBlocks().remove(block)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -43,4 +43,28 @@ shop-categories:
   'blocks_category':
     title: "Blocs"
     rows: 5
-    items: {} # à remplir plus tard
+    items:
+      'wool':
+        material: WHITE_WOOL
+        name: "&fLaine"
+        amount: 16
+        cost:
+          resource: IRON
+          amount: 4
+        slot: 10
+      'oak-planks':
+        material: OAK_PLANKS
+        name: "&6Planches de Chêne"
+        amount: 16
+        cost:
+          resource: IRON
+          amount: 12
+        slot: 11
+      'end-stone':
+        material: END_STONE
+        name: "&ePierre de l'End"
+        amount: 12
+        cost:
+          resource: IRON
+          amount: 24
+        slot: 12


### PR DESCRIPTION
## Summary
- track player-placed blocks in arenas for cleanup and block-breaking logic
- allow players to place and break blocks in games while protecting map terrain
- add basic building blocks to shop and document construction feature

## Testing
- `mvn -q -e package` *(failed: Could not resolve Maven resources plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a38c7656848329a8a6cd89f21dc613