### PR TITLE
feat: bound starter kits and smarter shop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Ajouté
 - Ajout de la mécanique de construction : les joueurs peuvent maintenant acheter, poser et casser des blocs.
+- Amélioration des kits de départ (armure colorée liée, épée non-jetable). La laine achetée est désormais de la couleur de l'équipe et les nouvelles épées remplacent les anciennes.
 
 ## [0.5.1] - En développement
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
 - 💰 **Système Économique** : Collectez du Fer, de l'Or, des Diamants et des Émeraudes à des vitesses différentes pour acheter de l'équipement.
 - 🛒 **Boutiques Fonctionnelles** : Interagissez avec les PNJ pour acheter des objets dans la boutique d'items ou des améliorations permanentes pour votre équipe.
 - 🧱 **Construction de Blocs** : Achetez, placez et cassez des blocs pour bâtir ponts et défenses.
+- 🛡️ **Kit de départ lié** : Vous réapparaissez avec une armure en cuir teintée aux couleurs de votre équipe et une épée en bois impossible à jeter.
+- 🌈 **Achats intelligents** : La laine achetée s'adapte automatiquement à la couleur de votre équipe et toute nouvelle épée remplace la précédente.
 - 🏆 **Conditions de Victoire** : La partie se termine automatiquement lorsque la dernière équipe en vie est déclarée vainqueur, et l'arène se réinitialise pour le prochain combat.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,5 +42,6 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 *Objectif : Ajouter les fonctionnalités spéciales, optimiser le code et préparer la version stable.*
 
 * [✔] La Construction : Ajout de la pose/destruction de blocs par les joueurs.
+* [✔] Ajout des kits de départ complets (armure liée, épée).
 * [ ] Les Objets Spéciaux (TNT, Boules de feu...).
 * [ ] Le Tableau de Bord (Scoreboard).

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -8,6 +8,7 @@ import com.heneria.bedwars.listeners.BlockPlaceListener;
 import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.listeners.ShopListener;
 import com.heneria.bedwars.listeners.UpgradeListener;
+import com.heneria.bedwars.listeners.StarterItemListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -61,6 +62,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new SetupListener(this.setupManager), this);
         getServer().getPluginManager().registerEvents(new ShopListener(), this);
         getServer().getPluginManager().registerEvents(new UpgradeListener(), this);
+        getServer().getPluginManager().registerEvents(new StarterItemListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -411,7 +411,7 @@ public class Arena {
             if (team != null && team.getSpawnLocation() != null) {
                 p.teleport(team.getSpawnLocation());
             }
-            GameUtils.giveDefaultKit(p);
+            GameUtils.giveDefaultKit(p, team);
         }
         for (Generator gen : generators) {
             HeneriaBedwars.getInstance().getGeneratorManager().registerGenerator(gen);

--- a/src/main/java/com/heneria/bedwars/arena/enums/TeamColor.java
+++ b/src/main/java/com/heneria/bedwars/arena/enums/TeamColor.java
@@ -2,28 +2,31 @@ package com.heneria.bedwars.arena.enums;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.Color;
 
 /**
  * Represents the available team colors with useful metadata.
  */
 public enum TeamColor {
-    RED("Rouge", ChatColor.RED, Material.RED_WOOL),
-    BLUE("Bleu", ChatColor.BLUE, Material.BLUE_WOOL),
-    GREEN("Vert", ChatColor.GREEN, Material.LIME_WOOL),
-    YELLOW("Jaune", ChatColor.YELLOW, Material.YELLOW_WOOL),
-    AQUA("Cyan", ChatColor.AQUA, Material.CYAN_WOOL),
-    WHITE("Blanc", ChatColor.WHITE, Material.WHITE_WOOL),
-    PINK("Rose", ChatColor.LIGHT_PURPLE, Material.PINK_WOOL),
-    GRAY("Gris", ChatColor.GRAY, Material.GRAY_WOOL);
+    RED("Rouge", ChatColor.RED, Material.RED_WOOL, Color.RED),
+    BLUE("Bleu", ChatColor.BLUE, Material.BLUE_WOOL, Color.BLUE),
+    GREEN("Vert", ChatColor.GREEN, Material.LIME_WOOL, Color.LIME),
+    YELLOW("Jaune", ChatColor.YELLOW, Material.YELLOW_WOOL, Color.YELLOW),
+    AQUA("Cyan", ChatColor.AQUA, Material.CYAN_WOOL, Color.AQUA),
+    WHITE("Blanc", ChatColor.WHITE, Material.WHITE_WOOL, Color.WHITE),
+    PINK("Rose", ChatColor.LIGHT_PURPLE, Material.PINK_WOOL, Color.FUCHSIA),
+    GRAY("Gris", ChatColor.GRAY, Material.GRAY_WOOL, Color.GRAY);
 
     private final String displayName;
     private final ChatColor chatColor;
     private final Material woolMaterial;
+    private final Color leatherColor;
 
-    TeamColor(String displayName, ChatColor chatColor, Material woolMaterial) {
+    TeamColor(String displayName, ChatColor chatColor, Material woolMaterial, Color leatherColor) {
         this.displayName = displayName;
         this.chatColor = chatColor;
         this.woolMaterial = woolMaterial;
+        this.leatherColor = leatherColor;
     }
 
     /**
@@ -51,5 +54,14 @@ public enum TeamColor {
      */
     public Material getWoolMaterial() {
         return woolMaterial;
+    }
+
+    /**
+     * Gets the leather armor color associated with the team.
+     *
+     * @return the armor color
+     */
+    public Color getLeatherColor() {
+        return leatherColor;
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -5,6 +5,9 @@ import com.heneria.bedwars.managers.ResourceManager;
 import com.heneria.bedwars.managers.ResourceType;
 import com.heneria.bedwars.managers.ShopManager;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -76,7 +79,21 @@ public class ShopItemsMenu extends Menu {
         int price = item.costAmount();
         if (ResourceManager.hasResources(player, type, price)) {
             ResourceManager.takeResources(player, type, price);
-            ItemStack give = new ItemStack(item.material(), item.amount());
+            Material material = item.material();
+            Arena arena = HeneriaBedwars.getInstance().getArenaManager().getArena(player);
+            Team team = arena != null ? arena.getTeam(player) : null;
+            if (material.toString().endsWith("_WOOL") && team != null) {
+                material = team.getColor().getWoolMaterial();
+            }
+            if (material.toString().endsWith("_SWORD")) {
+                for (int i = 0; i < player.getInventory().getSize(); i++) {
+                    ItemStack invItem = player.getInventory().getItem(i);
+                    if (invItem != null && invItem.getType().toString().endsWith("_SWORD")) {
+                        player.getInventory().setItem(i, null);
+                    }
+                }
+            }
+            ItemStack give = new ItemStack(material, item.amount());
             player.getInventory().addItem(give);
             player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
         } else {

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -14,6 +14,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.scheduler.BukkitRunnable;
+import com.heneria.bedwars.utils.GameUtils;
 
 public class GameListener implements Listener {
 
@@ -88,6 +89,7 @@ public class GameListener implements Listener {
                         this.cancel();
                         player.setGameMode(GameMode.SURVIVAL);
                         player.teleport(playerTeam.getSpawnLocation());
+                        GameUtils.giveDefaultKit(player, playerTeam);
                     }
                 }
             }.runTaskTimer(plugin, 0L, 20L);

--- a/src/main/java/com/heneria/bedwars/listeners/StarterItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/StarterItemListener.java
@@ -1,0 +1,49 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.utils.GameUtils;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Prevents players from dropping or moving starter kit items.
+ */
+public class StarterItemListener implements Listener {
+
+    private boolean isStarterItem(ItemStack item) {
+        return item != null && item.getItemMeta() != null &&
+                item.getItemMeta().getPersistentDataContainer()
+                        .has(GameUtils.STARTER_KEY, PersistentDataType.BYTE);
+    }
+
+    @EventHandler
+    public void onItemDrop(PlayerDropItemEvent event) {
+        if (isStarterItem(event.getItemDrop().getItemStack())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        ItemStack current = event.getCurrentItem();
+        ItemStack cursor = event.getCursor();
+        if (isStarterItem(current) || isStarterItem(cursor)) {
+            if (event.getClickedInventory() != player.getInventory() || event.isShiftClick()) {
+                event.setCancelled(true);
+            }
+        } else if (event.getHotbarButton() != -1) {
+            ItemStack hotbar = player.getInventory().getItem(event.getHotbarButton());
+            if (isStarterItem(hotbar) && event.getClickedInventory() != player.getInventory()) {
+                event.setCancelled(true);
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/utils/GameUtils.java
+++ b/src/main/java/com/heneria/bedwars/utils/GameUtils.java
@@ -1,8 +1,18 @@
 package com.heneria.bedwars.utils;
 
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.elements.Team;
+import org.bukkit.Color;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.Collections;
 
 /**
  * Utility methods for common game actions.
@@ -12,15 +22,49 @@ public final class GameUtils {
     private GameUtils() {
     }
 
+    /** Key used to mark starter kit items. */
+    public static final NamespacedKey STARTER_KEY =
+            new NamespacedKey(HeneriaBedwars.getInstance(), "starter-item");
+
     /**
      * Gives the default starting kit to the specified player.
      *
      * @param player the player to equip
+     * @param team   the team of the player for color information
      */
-    public static void giveDefaultKit(Player player) {
+    public static void giveDefaultKit(Player player, Team team) {
         player.getInventory().clear();
-        player.getInventory().addItem(new ItemStack(Material.WOODEN_SWORD));
+        if (team != null) {
+            Color color = team.getColor().getLeatherColor();
+            player.getInventory().setArmorContents(new ItemStack[]{
+                    createArmor(Material.LEATHER_BOOTS, color),
+                    createArmor(Material.LEATHER_LEGGINGS, color),
+                    createArmor(Material.LEATHER_CHESTPLATE, color),
+                    createArmor(Material.LEATHER_HELMET, color)
+            });
+        }
+        player.getInventory().addItem(createStarterSword());
         player.setLevel(0);
         player.setExp(0f);
+    }
+
+    private static ItemStack createArmor(Material material, Color color) {
+        ItemStack item = new ItemStack(material);
+        LeatherArmorMeta meta = (LeatherArmorMeta) item.getItemMeta();
+        meta.setColor(color);
+        meta.addEnchant(Enchantment.BINDING_CURSE, 1, true);
+        meta.setLore(Collections.singletonList("§7Objet de départ"));
+        meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+        item.setItemMeta(meta);
+        return item;
+        }
+
+    private static ItemStack createStarterSword() {
+        ItemStack item = new ItemStack(Material.WOODEN_SWORD);
+        ItemMeta meta = item.getItemMeta();
+        meta.setLore(Collections.singletonList("§7Objet de départ"));
+        meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+        item.setItemMeta(meta);
+        return item;
     }
 }


### PR DESCRIPTION
## Summary
- Give players a bound starter kit on game start and respawn
- Add team-colored wool and sword replacement logic to shop purchases
- Document starter kits and shop improvements

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a3933b7bb8832996143d856ae42eee