### PR TITLE
feat(game): Implement special items (fireball, tnt, bridge egg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Ajouté
 - Ajout de la mécanique de construction : les joueurs peuvent maintenant acheter, poser et casser des blocs.
 - Amélioration des kits de départ (armure colorée liée, épée non-jetable). La laine achetée est désormais de la couleur de l'équipe et les nouvelles épées remplacent les anciennes.
+- Ajout d'objets spéciaux avec des comportements uniques : Boule de Feu, TNT instantanée, et Pont en Œuf.
 
 ## [0.5.1] - En développement
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
 - ⚙️ **Haute Personnalisation** : Prenez le contrôle total du gameplay en modifiant les fichiers de configuration dédiés :
   - `generators.yml` : Réglez la vitesse et la quantité de chaque générateur de ressources.
   - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
+    - Utilisez le champ `action` pour ajouter des objets spéciaux (`FIREBALL`, `BEDWARS_TNT`, `BRIDGE_EGG`).
   - `upgrades.yml` : Définissez les améliorations d'équipe, leurs niveaux et leurs coûts en diamants.
 
 ### Pour les Joueurs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,5 +43,5 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 
 * [✔] La Construction : Ajout de la pose/destruction de blocs par les joueurs.
 * [✔] Ajout des kits de départ complets (armure liée, épée).
-* [ ] Les Objets Spéciaux (TNT, Boules de feu...).
+* [✔] Les Objets Spéciaux (TNT, Boules de feu...).
 * [ ] Le Tableau de Bord (Scoreboard).

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -9,6 +9,7 @@ import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.listeners.ShopListener;
 import com.heneria.bedwars.listeners.UpgradeListener;
 import com.heneria.bedwars.listeners.StarterItemListener;
+import com.heneria.bedwars.listeners.SpecialItemListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -63,6 +64,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ShopListener(), this);
         getServer().getPluginManager().registerEvents(new UpgradeListener(), this);
         getServer().getPluginManager().registerEvents(new StarterItemListener(), this);
+        getServer().getPluginManager().registerEvents(new SpecialItemListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -5,6 +5,7 @@ import com.heneria.bedwars.managers.ResourceManager;
 import com.heneria.bedwars.managers.ResourceType;
 import com.heneria.bedwars.managers.ShopManager;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.GameUtils;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.elements.Team;
@@ -14,6 +15,8 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -94,6 +97,12 @@ public class ShopItemsMenu extends Menu {
                 }
             }
             ItemStack give = new ItemStack(material, item.amount());
+            if (item.action() != null) {
+                ItemMeta meta = give.getItemMeta();
+                meta.getPersistentDataContainer().set(GameUtils.SPECIAL_ITEM_KEY,
+                        PersistentDataType.STRING, item.action());
+                give.setItemMeta(meta);
+            }
             player.getInventory().addItem(give);
             player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
         } else {

--- a/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
@@ -17,7 +17,7 @@ public class BlockPlaceListener implements Listener {
 
     private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent event) {
         Player player = event.getPlayer();
         Arena arena = arenaManager.getArena(player);

--- a/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
@@ -1,0 +1,201 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.utils.GameUtils;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Egg;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.projectiles.ProjectileSource;
+import org.bukkit.util.Vector;
+
+import java.util.Iterator;
+
+/**
+ * Handles special shop items such as fireballs, instant TNT and bridge eggs.
+ */
+public class SpecialItemListener implements Listener {
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (!event.getAction().isRightClick()) {
+            return;
+        }
+        ItemStack stack = event.getItem();
+        if (stack == null) {
+            return;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        String action = meta.getPersistentDataContainer()
+                .get(GameUtils.SPECIAL_ITEM_KEY, PersistentDataType.STRING);
+        if (action == null) {
+            return;
+        }
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+
+        switch (action) {
+            case "FIREBALL" -> {
+                event.setCancelled(true);
+                player.launchProjectile(Fireball.class);
+                consumeItem(player, event.getHand());
+            }
+            case "BRIDGE_EGG" -> {
+                event.setCancelled(true);
+                Egg egg = player.launchProjectile(Egg.class);
+                egg.addScoreboardTag("bridge_egg");
+                consumeItem(player, event.getHand());
+            }
+            default -> {
+            }
+        }
+    }
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        ItemStack stack = event.getItemInHand();
+        if (stack == null || stack.getType() != Material.TNT) {
+            return;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        String action = meta.getPersistentDataContainer()
+                .get(GameUtils.SPECIAL_ITEM_KEY, PersistentDataType.STRING);
+        if (action == null || !action.equals("BEDWARS_TNT")) {
+            return;
+        }
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        event.setCancelled(true);
+        consumeItem(player, event.getHand());
+        TNTPrimed tnt = event.getBlock().getWorld()
+                .spawn(event.getBlock().getLocation().add(0.5, 0, 0.5), TNTPrimed.class);
+        tnt.setFuseTicks(60);
+        tnt.addScoreboardTag("bedwars_tnt");
+        tnt.setSource(player);
+    }
+
+    @EventHandler
+    public void onEntityExplode(EntityExplodeEvent event) {
+        Entity entity = event.getEntity();
+        Player source = null;
+        boolean special = false;
+
+        if (entity instanceof Fireball fireball) {
+            ProjectileSource shooter = fireball.getShooter();
+            if (shooter instanceof Player player) {
+                source = player;
+                special = true;
+            }
+        } else if (entity instanceof TNTPrimed tnt && entity.getScoreboardTags().contains("bedwars_tnt")) {
+            if (tnt.getSource() instanceof Player player) {
+                source = player;
+            }
+            special = true;
+        }
+
+        if (!special) {
+            return;
+        }
+
+        Arena arena = source != null ? arenaManager.getArena(source) : null;
+        if (arena == null) {
+            event.blockList().clear();
+            return;
+        }
+        Iterator<Block> iterator = event.blockList().iterator();
+        while (iterator.hasNext()) {
+            Block block = iterator.next();
+            if (!arena.getPlacedBlocks().remove(block)) {
+                iterator.remove();
+            }
+        }
+    }
+
+    @EventHandler
+    public void onProjectileHit(ProjectileHitEvent event) {
+        if (!(event.getEntity() instanceof Egg egg)) {
+            return;
+        }
+        if (!egg.getScoreboardTags().contains("bridge_egg")) {
+            return;
+        }
+        if (!(egg.getShooter() instanceof Player player)) {
+            return;
+        }
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        Team team = arena.getTeam(player);
+        if (team == null) {
+            return;
+        }
+        Vector direction = egg.getVelocity().clone();
+        direction.setY(0);
+        if (direction.lengthSquared() == 0) {
+            direction = player.getLocation().getDirection().setY(0);
+        }
+        direction.normalize();
+        Location loc = egg.getLocation().getBlock().getLocation();
+        Material wool = team.getColor().getWoolMaterial();
+        for (int i = 0; i < 12; i++) {
+            loc = loc.add(direction);
+            Block block = loc.getBlock();
+            if (block.getType() == Material.AIR) {
+                block.setType(wool);
+                arena.getPlacedBlocks().add(block);
+            }
+        }
+    }
+
+    private void consumeItem(Player player, EquipmentSlot slot) {
+        ItemStack current = slot == EquipmentSlot.HAND
+                ? player.getInventory().getItemInMainHand()
+                : player.getInventory().getItemInOffHand();
+        if (current == null) {
+            return;
+        }
+        if (current.getAmount() <= 1) {
+            if (slot == EquipmentSlot.HAND) {
+                player.getInventory().setItemInMainHand(null);
+            } else {
+                player.getInventory().setItemInOffHand(null);
+            }
+        } else {
+            current.setAmount(current.getAmount() - 1);
+        }
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/managers/ShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ShopManager.java
@@ -68,7 +68,8 @@ public class ShopManager {
                             ResourceType resource = ResourceType.valueOf(config.getString(path + ".cost.resource", "IRON"));
                             int cost = config.getInt(path + ".cost.amount", 1);
                             int slot = config.getInt(path + ".slot", 0);
-                            items.put(slot, new ShopItem(material, name, amount, resource, cost, slot));
+                            String action = config.getString(path + ".action");
+                            items.put(slot, new ShopItem(material, name, amount, resource, cost, slot, action));
                         } catch (IllegalArgumentException ex) {
                             plugin.getLogger().warning("Invalid item configuration for category " + id + ": " + itemKey);
                         }
@@ -98,7 +99,8 @@ public class ShopManager {
     public record MainMenuItem(Material material, String name, List<String> lore, int slot, String category) {
     }
 
-    public record ShopItem(Material material, String name, int amount, ResourceType costResource, int costAmount, int slot) {
+    public record ShopItem(Material material, String name, int amount, ResourceType costResource, int costAmount, int slot,
+                           String action) {
     }
 
     public record ShopCategory(String id, String title, int rows, Map<Integer, ShopItem> items) {

--- a/src/main/java/com/heneria/bedwars/utils/GameUtils.java
+++ b/src/main/java/com/heneria/bedwars/utils/GameUtils.java
@@ -26,6 +26,10 @@ public final class GameUtils {
     public static final NamespacedKey STARTER_KEY =
             new NamespacedKey(HeneriaBedwars.getInstance(), "starter-item");
 
+    /** Key used to tag special shop items with custom actions. */
+    public static final NamespacedKey SPECIAL_ITEM_KEY =
+            new NamespacedKey(HeneriaBedwars.getInstance(), "special-action");
+
     /**
      * Gives the default starting kit to the specified player.
      *

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -17,6 +17,13 @@ main-menu:
         - "&7Pour construire et défendre"
       slot: 11
       category: 'blocks_category'
+    'special':
+      material: BLAZE_POWDER
+      name: "&cObjets Spéciaux"
+      lore:
+        - "&7Utilitaires stratégiques"
+      slot: 12
+      category: 'special_category'
 
 # Définition d'une catégorie d'objets
 shop-categories:
@@ -68,3 +75,42 @@ shop-categories:
           resource: IRON
           amount: 24
         slot: 12
+  'special_category':
+    title: "Objets Spéciaux"
+    rows: 5
+    items:
+      'fireball':
+        material: FIRE_CHARGE
+        name: "&6Boule de Feu"
+        amount: 1
+        cost:
+          resource: IRON
+          amount: 40
+        slot: 10
+        action: FIREBALL
+      'tnt':
+        material: TNT
+        name: "&cTNT de BedWars"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 4
+        slot: 11
+        action: BEDWARS_TNT
+      'ender_pearl':
+        material: ENDER_PEARL
+        name: "&5Perle de l'End"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 4
+        slot: 12
+      'bridge_egg':
+        material: EGG
+        name: "&aPont en Œuf"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 1
+        slot: 13
+        action: BRIDGE_EGG


### PR DESCRIPTION
## Summary
- expand shop configuration with a new "Objets Spéciaux" category and actions
- tag special items and add listener handling fireballs, instant TNT and bridge eggs
- document special items in README, roadmap and changelog

## Testing
- `mvn -e -q test` *(fails: Could not transfer artifact maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a39af6c8c88329ab9d585841e3c374