### PR TITLE
feat(game): Implement special items and fix interact event API usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Ajouté
 - Ajout de la mécanique de construction : les joueurs peuvent maintenant acheter, poser et casser des blocs.
 - Amélioration des kits de départ (armure colorée liée, épée non-jetable). La laine achetée est désormais de la couleur de l'équipe et les nouvelles épées remplacent les anciennes.
+- Ajout des objets spéciaux : Boule de Feu, TNT à allumage rapide, Pont en œuf et Perle de l'End.
+
+### Corrigé
+- Correction de l'utilisation de l'API de détection des clics pour la Boule de Feu (remplacement de `isRightClick()` par la vérification de `Action.RIGHT_CLICK_AIR`/`BLOCK`).
 
 ## [0.5.1] - En développement
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,5 +43,5 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 
 * [✔] La Construction : Ajout de la pose/destruction de blocs par les joueurs.
 * [✔] Ajout des kits de départ complets (armure liée, épée).
-* [ ] Les Objets Spéciaux (TNT, Boules de feu...).
+ * [✔] Les Objets Spéciaux (TNT, Boules de feu...).
 * [ ] Le Tableau de Bord (Scoreboard).

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -9,6 +9,7 @@ import com.heneria.bedwars.listeners.SetupListener;
 import com.heneria.bedwars.listeners.ShopListener;
 import com.heneria.bedwars.listeners.UpgradeListener;
 import com.heneria.bedwars.listeners.StarterItemListener;
+import com.heneria.bedwars.listeners.SpecialItemListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -63,6 +64,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ShopListener(), this);
         getServer().getPluginManager().registerEvents(new UpgradeListener(), this);
         getServer().getPluginManager().registerEvents(new StarterItemListener(), this);
+        getServer().getPluginManager().registerEvents(new SpecialItemListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
@@ -17,7 +17,7 @@ public class BlockPlaceListener implements Listener {
 
     private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent event) {
         Player player = event.getPlayer();
         Arena arena = arenaManager.getArena(player);

--- a/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
@@ -1,0 +1,144 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Egg;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles special gameplay items like fireballs, instant TNT and bridge eggs.
+ */
+public class SpecialItemListener implements Listener {
+
+    private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+    private final ArenaManager arenaManager = plugin.getArenaManager();
+    private final Map<Egg, Location> eggStarts = new HashMap<>();
+
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        Player player = event.getPlayer();
+        ItemStack item = event.getItem();
+        if (item == null) {
+            return;
+        }
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        Material type = item.getType();
+        if (type == Material.FIRE_CHARGE) {
+            event.setCancelled(true);
+            item.setAmount(item.getAmount() - 1);
+            player.getWorld().spawn(player.getEyeLocation().add(player.getLocation().getDirection()), org.bukkit.entity.Fireball.class, fireball -> {
+                fireball.setVelocity(player.getLocation().getDirection().multiply(1.5));
+                fireball.setShooter(player);
+                fireball.setIsIncendiary(false);
+                fireball.setYield(0f);
+            });
+        } else if (type == Material.EGG) {
+            event.setCancelled(true);
+            item.setAmount(item.getAmount() - 1);
+            Egg egg = player.launchProjectile(Egg.class);
+            egg.setVelocity(player.getLocation().getDirection().multiply(1.5));
+            eggStarts.put(egg, player.getLocation());
+        }
+    }
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if (event.getBlockPlaced().getType() != Material.TNT) {
+            return;
+        }
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        event.setCancelled(true);
+        Block block = event.getBlockPlaced();
+        block.setType(Material.AIR);
+        TNTPrimed tnt = player.getWorld().spawn(block.getLocation().add(0.5, 0, 0.5), TNTPrimed.class);
+        tnt.setFuseTicks(40);
+        tnt.setSource(player);
+    }
+
+    @EventHandler
+    public void onTntExplode(EntityExplodeEvent event) {
+        if (!(event.getEntity() instanceof TNTPrimed tnt)) {
+            return;
+        }
+        if (!(tnt.getSource() instanceof Player player)) {
+            return;
+        }
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null) {
+            return;
+        }
+        event.blockList().removeIf(b -> !arena.getPlacedBlocks().contains(b));
+        arena.getPlacedBlocks().removeAll(event.blockList());
+    }
+
+    @EventHandler
+    public void onEggHit(ProjectileHitEvent event) {
+        if (!(event.getEntity() instanceof Egg egg)) {
+            return;
+        }
+        Location start = eggStarts.remove(egg);
+        if (start == null) {
+            return;
+        }
+        if (!(egg.getShooter() instanceof Player player)) {
+            return;
+        }
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        Team team = arena.getTeam(player);
+        if (team == null) {
+            return;
+        }
+        Location end = egg.getLocation();
+        double startY = start.getBlockY();
+        Vector direction = end.toVector().subtract(start.toVector());
+        direction.setY(0);
+        double length = direction.length();
+        if (length == 0) {
+            return;
+        }
+        Vector step = direction.normalize();
+        Location current = start.clone();
+        for (double i = 0; i < length; i += 1) {
+            current.add(step);
+            current.setY(startY);
+            Block block = current.getBlock();
+            if (block.getType() == Material.AIR) {
+                block.setType(team.getColor().getWoolMaterial());
+                arena.getPlacedBlocks().add(block);
+            }
+        }
+    }
+}

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -17,6 +17,13 @@ main-menu:
         - "&7Pour construire et défendre"
       slot: 11
       category: 'blocks_category'
+    'utilities':
+      material: FIRE_CHARGE
+      name: "&6Utilitaires"
+      lore:
+        - "&7Objets spéciaux"
+      slot: 12
+      category: 'utilities_category'
 
 # Définition d'une catégorie d'objets
 shop-categories:
@@ -68,3 +75,39 @@ shop-categories:
           resource: IRON
           amount: 24
         slot: 12
+  'utilities_category':
+    title: "Utilitaires"
+    rows: 5
+    items:
+      'fireball':
+        material: FIRE_CHARGE
+        name: "&cBoule de Feu"
+        amount: 1
+        cost:
+          resource: IRON
+          amount: 40
+        slot: 10
+      'tnt':
+        material: TNT
+        name: "&cTNT"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 8
+        slot: 11
+      'ender_pearl':
+        material: ENDER_PEARL
+        name: "&dPerle de l'End"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 4
+        slot: 12
+      'bridge_egg':
+        material: EGG
+        name: "&aPont en œuf"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 1
+        slot: 13


### PR DESCRIPTION
## Summary
- add fireball, instant TNT, and bridge egg mechanics with proper right-click detection
- track only successful block placements and hook new listener
- expand shop with utility category
- document special items and API fix

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a39d1e23448329aaa92dcb3736f91e