### PR TITLE
fix(gameplay): Fix TNT duplication and bind purchased swords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - HeneriaBedwars
 
+## [0.6.1] - En développement
+
+### Corrigé
+- Correction d'un bug de duplication de la TNT.
+- Les épées achetées dans la boutique sont maintenant liées au joueur et ne peuvent plus être jetées.
+
 ## [0.6.0] - En développement
 
 ### Ajouté

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -5,6 +5,7 @@ import com.heneria.bedwars.managers.ResourceManager;
 import com.heneria.bedwars.managers.ResourceType;
 import com.heneria.bedwars.managers.ShopManager;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.GameUtils;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.elements.Team;
@@ -14,6 +15,8 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -85,15 +88,23 @@ public class ShopItemsMenu extends Menu {
             if (material.toString().endsWith("_WOOL") && team != null) {
                 material = team.getColor().getWoolMaterial();
             }
-            if (material.toString().endsWith("_SWORD")) {
+            boolean isSword = material.name().endsWith("_SWORD");
+            if (isSword) {
                 for (int i = 0; i < player.getInventory().getSize(); i++) {
                     ItemStack invItem = player.getInventory().getItem(i);
-                    if (invItem != null && invItem.getType().toString().endsWith("_SWORD")) {
+                    if (invItem != null && invItem.getType().name().endsWith("_SWORD")) {
                         player.getInventory().setItem(i, null);
                     }
                 }
             }
             ItemStack give = new ItemStack(material, item.amount());
+            if (isSword) {
+                ItemMeta meta = give.getItemMeta();
+                if (meta != null) {
+                    meta.getPersistentDataContainer().set(GameUtils.STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+                    give.setItemMeta(meta);
+                }
+            }
             player.getInventory().addItem(give);
             player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
         } else {

--- a/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
@@ -83,6 +83,8 @@ public class SpecialItemListener implements Listener {
         TNTPrimed tnt = player.getWorld().spawn(block.getLocation().add(0.5, 0, 0.5), TNTPrimed.class);
         tnt.setFuseTicks(40);
         tnt.setSource(player);
+        ItemStack itemInHand = player.getInventory().getItemInMainHand();
+        itemInHand.setAmount(itemInHand.getAmount() - 1);
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- Consume TNT item when placed to prevent duplication
- Tag purchased swords as starter items so they can't be dropped
- Document fixes in changelog

## Testing
- `mvn -q test` *(fails: could not resolve maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a1ffd4a08329a8e55d0f9d989cd6