### PR TITLE
HBW-060: Étape 4 - Sauvegarde des Statistiques des Joueurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [0.8.0] - En développement
+
+### Ajouté
+- Ajout d'un système de statistiques joueurs avec support SQLite et MySQL.
+
 ## [0.7.0] - En développement
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - `/bw leave`
   - Permet de quitter l'arène actuelle.
   - **Permission :** `heneriabw.player.leave`
+- `/bw stats [joueur]`
+  - Affiche vos statistiques ou celles d'un autre joueur.
+  - **Permission :** `heneriabw.admin.stats` pour consulter celles d'un autre joueur.
 
 ### Créer et Configurer une Arène (Flux de travail)
 
@@ -89,6 +92,24 @@ traps:
       duration: 10
       amplifier: 1
 ```
+
+### Configuration de la Base de Données
+
+Les statistiques des joueurs sont sauvegardées dans une base de données configurée via `config.yml` :
+
+```yaml
+database:
+  type: sqlite # sqlite ou mysql
+  save-interval: 5 # minutes entre chaque sauvegarde automatique
+  mysql:
+    host: localhost
+    port: 3306
+    database: bedwars
+    username: root
+    password: ""
+    useSSL: false
+```
+
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,5 +46,6 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
  * [✔] Les Objets Spéciaux (TNT, Boules de feu...).
 * [✔] Le Tableau de Bord (Scoreboard).
 * [✔] Les Pièges d'Équipe.
-* [✔] Un Fichier de Langue Complet (messages.yml).
-* [ ] Sauvegarde des Statistiques des Joueurs.
+  * [✔] Un Fichier de Langue Complet (messages.yml).
+  * [✔] Sauvegarde des Statistiques des Joueurs.
+  * [ ] Compatibilité avec PlaceholderAPI.

--- a/pom.xml
+++ b/pom.xml
@@ -62,5 +62,15 @@
             <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -11,12 +11,15 @@ import com.heneria.bedwars.listeners.UpgradeListener;
 import com.heneria.bedwars.listeners.StarterItemListener;
 import com.heneria.bedwars.listeners.SpecialItemListener;
 import com.heneria.bedwars.listeners.TrapListener;
+import com.heneria.bedwars.listeners.StatsListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
 import com.heneria.bedwars.managers.ShopManager;
 import com.heneria.bedwars.managers.UpgradeManager;
 import com.heneria.bedwars.managers.ScoreboardManager;
+import com.heneria.bedwars.managers.DatabaseManager;
+import com.heneria.bedwars.managers.StatsManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -29,6 +32,8 @@ public final class HeneriaBedwars extends JavaPlugin {
     private ShopManager shopManager;
     private UpgradeManager upgradeManager;
     private ScoreboardManager scoreboardManager;
+    private DatabaseManager databaseManager;
+    private StatsManager statsManager;
 
     @Override
     public void onEnable() {
@@ -45,6 +50,8 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.shopManager = new ShopManager(this);
         this.upgradeManager = new UpgradeManager(this);
         this.scoreboardManager = new ScoreboardManager(this);
+        this.databaseManager = new DatabaseManager(this);
+        this.statsManager = new StatsManager(this, this.databaseManager);
 
         // Enregistrement des commandes
         CommandManager commandManager = new CommandManager(this);
@@ -58,6 +65,9 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        if (statsManager != null) {
+            statsManager.saveAll();
+        }
         getLogger().info("HeneriaBedwars a été désactivé.");
     }
 
@@ -72,6 +82,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new StarterItemListener(), this);
         getServer().getPluginManager().registerEvents(new SpecialItemListener(), this);
         getServer().getPluginManager().registerEvents(new TrapListener(), this);
+        getServer().getPluginManager().registerEvents(new StatsListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {
@@ -100,5 +111,13 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public ScoreboardManager getScoreboardManager() {
         return scoreboardManager;
+    }
+
+    public StatsManager getStatsManager() {
+        return statsManager;
+    }
+
+    public DatabaseManager getDatabaseManager() {
+        return databaseManager;
     }
 }

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -8,6 +8,8 @@ import com.heneria.bedwars.arena.enums.TeamColor;
 import com.heneria.bedwars.events.GameStateChangeEvent;
 import com.heneria.bedwars.utils.GameUtils;
 import com.heneria.bedwars.utils.MessageManager;
+import com.heneria.bedwars.managers.StatsManager;
+import com.heneria.bedwars.stats.PlayerStats;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -506,13 +508,32 @@ public class Arena {
             return;
         }
         state = GameState.ENDING;
+        StatsManager statsManager = HeneriaBedwars.getInstance().getStatsManager();
         if (winner != null) {
             String teamName = winner.getColor().getChatColor() + winner.getColor().getDisplayName() + ChatColor.RESET;
             broadcast("game.team-win", "team", teamName);
             broadcastTitle("game.win-title", "game.win-subtitle", 10, 70, 20, "team", teamName);
+            for (UUID uuid : players) {
+                PlayerStats stats = statsManager.getStats(uuid);
+                if (stats != null) {
+                    stats.incrementGamesPlayed();
+                    if (winner.getMembers().contains(uuid)) {
+                        stats.incrementWins();
+                    } else {
+                        stats.incrementLosses();
+                    }
+                }
+            }
         } else {
             broadcast("game.no-winner");
             broadcastTitle("game.no-winner-title", "game.no-winner-subtitle", 10, 70, 20);
+            for (UUID uuid : players) {
+                PlayerStats stats = statsManager.getStats(uuid);
+                if (stats != null) {
+                    stats.incrementGamesPlayed();
+                    stats.incrementLosses();
+                }
+            }
         }
         for (Generator gen : generators) {
             HeneriaBedwars.getInstance().getGeneratorManager().unregisterGenerator(gen);

--- a/src/main/java/com/heneria/bedwars/commands/CommandManager.java
+++ b/src/main/java/com/heneria/bedwars/commands/CommandManager.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.commands.subcommands.AdminCommand;
 import com.heneria.bedwars.commands.subcommands.JoinCommand;
 import com.heneria.bedwars.commands.subcommands.LeaveCommand;
+import com.heneria.bedwars.commands.subcommands.StatsCommand;
 import com.heneria.bedwars.commands.subcommands.SubCommand;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.command.Command;
@@ -30,6 +31,7 @@ public class CommandManager implements CommandExecutor, TabCompleter {
         registerSubCommand(new AdminCommand());
         registerSubCommand(new JoinCommand());
         registerSubCommand(new LeaveCommand());
+        registerSubCommand(new StatsCommand());
     }
 
     private void registerSubCommand(SubCommand subCommand) {

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/StatsCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/StatsCommand.java
@@ -1,0 +1,73 @@
+package com.heneria.bedwars.commands.subcommands;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.managers.StatsManager;
+import com.heneria.bedwars.stats.PlayerStats;
+import com.heneria.bedwars.utils.MessageManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Command allowing players to view their statistics.
+ */
+public class StatsCommand implements SubCommand {
+
+    private final StatsManager statsManager = HeneriaBedwars.getInstance().getStatsManager();
+
+    @Override
+    public String getName() {
+        return "stats";
+    }
+
+    @Override
+    public void execute(Player player, String[] args) {
+        Player target = player;
+        if (args.length > 0) {
+            if (!player.hasPermission("heneriabw.admin.stats")) {
+                MessageManager.sendMessage(player, "errors.no-permission");
+                return;
+            }
+            target = Bukkit.getPlayer(args[0]);
+            if (target == null) {
+                MessageManager.sendMessage(player, "errors.player-not-found");
+                return;
+            }
+        }
+
+        PlayerStats stats = statsManager.getStats(target.getUniqueId());
+        if (stats == null) {
+            MessageManager.sendMessage(player, "errors.player-not-found");
+            return;
+        }
+
+        for (String line : MessageManager.getList("stats.format")) {
+            String formatted = line
+                    .replace("{player}", target.getName())
+                    .replace("{kills}", String.valueOf(stats.getKills()))
+                    .replace("{deaths}", String.valueOf(stats.getDeaths()))
+                    .replace("{wins}", String.valueOf(stats.getWins()))
+                    .replace("{losses}", String.valueOf(stats.getLosses()))
+                    .replace("{beds_broken}", String.valueOf(stats.getBedsBroken()))
+                    .replace("{games_played}", String.valueOf(stats.getGamesPlayed()));
+            player.sendMessage(formatted);
+        }
+    }
+
+    @Override
+    public List<String> tabComplete(Player player, String[] args) {
+        if (args.length == 1 && player.hasPermission("heneriabw.admin.stats")) {
+            List<String> names = new ArrayList<>();
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getName().toLowerCase().startsWith(args[0].toLowerCase())) {
+                    names.add(p.getName());
+                }
+            }
+            return names;
+        }
+        return new ArrayList<>();
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/listeners/StatsListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/StatsListener.java
@@ -1,0 +1,28 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.managers.StatsManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Handles loading and saving of player statistics on join/quit.
+ */
+public class StatsListener implements Listener {
+
+    private final StatsManager statsManager = HeneriaBedwars.getInstance().getStatsManager();
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        statsManager.loadPlayer(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        statsManager.savePlayer(event.getPlayer().getUniqueId());
+        statsManager.unloadPlayer(event.getPlayer().getUniqueId());
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/managers/DatabaseManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/DatabaseManager.java
@@ -1,0 +1,123 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.stats.PlayerStats;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.io.File;
+import java.sql.*;
+import java.util.UUID;
+import java.util.logging.Level;
+
+/**
+ * Handles the connection to the configured database and basic CRUD
+ * operations for {@link PlayerStats}.
+ */
+public class DatabaseManager {
+
+    private final HeneriaBedwars plugin;
+    private Connection connection;
+
+    public DatabaseManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        connect();
+        createTable();
+    }
+
+    private void connect() {
+        FileConfiguration config = plugin.getConfig();
+        String type = config.getString("database.type", "sqlite");
+        try {
+            if ("mysql".equalsIgnoreCase(type)) {
+                String host = config.getString("database.mysql.host", "localhost");
+                int port = config.getInt("database.mysql.port", 3306);
+                String database = config.getString("database.mysql.database", "bedwars");
+                String username = config.getString("database.mysql.username", "root");
+                String password = config.getString("database.mysql.password", "");
+                boolean useSSL = config.getBoolean("database.mysql.useSSL", false);
+                String url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + useSSL;
+                connection = DriverManager.getConnection(url, username, password);
+            } else {
+                File dbFile = new File(plugin.getDataFolder(), "stats.db");
+                connection = DriverManager.getConnection("jdbc:sqlite:" + dbFile.getAbsolutePath());
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Unable to connect to the database", e);
+        }
+    }
+
+    private void createTable() {
+        String sql = "CREATE TABLE IF NOT EXISTS player_stats (" +
+                "uuid VARCHAR(36) PRIMARY KEY," +
+                "username VARCHAR(16)," +
+                "kills INT," +
+                "deaths INT," +
+                "wins INT," +
+                "losses INT," +
+                "beds_broken INT," +
+                "games_played INT" +
+                ")";
+        try (Statement st = connection.createStatement()) {
+            st.executeUpdate(sql);
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to create player_stats table", e);
+        }
+    }
+
+    /**
+     * Loads the statistics for the given player, creating a new entry if necessary.
+     *
+     * @param uuid     player UUID
+     * @param username current username
+     * @return loaded stats
+     */
+    public PlayerStats loadStats(UUID uuid, String username) {
+        String select = "SELECT * FROM player_stats WHERE uuid=?";
+        try (PreparedStatement ps = connection.prepareStatement(select)) {
+            ps.setString(1, uuid.toString());
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                return new PlayerStats(
+                        uuid,
+                        rs.getString("username"),
+                        rs.getInt("kills"),
+                        rs.getInt("deaths"),
+                        rs.getInt("wins"),
+                        rs.getInt("losses"),
+                        rs.getInt("beds_broken"),
+                        rs.getInt("games_played")
+                );
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to load stats for " + uuid, e);
+        }
+
+        PlayerStats stats = new PlayerStats(uuid, username);
+        saveStats(stats);
+        return stats;
+    }
+
+    /**
+     * Saves the given statistics to the database.
+     *
+     * @param stats stats to save
+     */
+    public void saveStats(PlayerStats stats) {
+        String sql = "REPLACE INTO player_stats (uuid, username, kills, deaths, wins, losses, beds_broken, games_played) " +
+                "VALUES (?,?,?,?,?,?,?,?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, stats.getUuid().toString());
+            ps.setString(2, stats.getUsername());
+            ps.setInt(3, stats.getKills());
+            ps.setInt(4, stats.getDeaths());
+            ps.setInt(5, stats.getWins());
+            ps.setInt(6, stats.getLosses());
+            ps.setInt(7, stats.getBedsBroken());
+            ps.setInt(8, stats.getGamesPlayed());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to save stats for " + stats.getUuid(), e);
+        }
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/managers/StatsManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/StatsManager.java
@@ -1,0 +1,67 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.stats.PlayerStats;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages loading, caching and saving of player statistics.
+ */
+public class StatsManager {
+
+    private final HeneriaBedwars plugin;
+    private final DatabaseManager databaseManager;
+    private final Map<UUID, PlayerStats> cache = new ConcurrentHashMap<>();
+
+    public StatsManager(HeneriaBedwars plugin, DatabaseManager databaseManager) {
+        this.plugin = plugin;
+        this.databaseManager = databaseManager;
+
+        long minutes = plugin.getConfig().getLong("database.save-interval", 5L);
+        long interval = 20L * 60L * Math.max(1L, minutes);
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                saveAll();
+            }
+        }.runTaskTimerAsynchronously(plugin, interval, interval);
+    }
+
+    public void loadPlayer(Player player) {
+        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+            PlayerStats stats = databaseManager.loadStats(player.getUniqueId(), player.getName());
+            stats.setUsername(player.getName());
+            cache.put(player.getUniqueId(), stats);
+        });
+    }
+
+    public void savePlayer(UUID uuid) {
+        PlayerStats stats = cache.get(uuid);
+        if (stats == null) return;
+        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> databaseManager.saveStats(stats));
+    }
+
+    public PlayerStats getStats(UUID uuid) {
+        return cache.get(uuid);
+    }
+
+    public PlayerStats getStats(Player player) {
+        return getStats(player.getUniqueId());
+    }
+
+    public void unloadPlayer(UUID uuid) {
+        cache.remove(uuid);
+    }
+
+    public void saveAll() {
+        for (PlayerStats stats : cache.values()) {
+            databaseManager.saveStats(stats);
+        }
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/stats/PlayerStats.java
+++ b/src/main/java/com/heneria/bedwars/stats/PlayerStats.java
@@ -1,0 +1,95 @@
+package com.heneria.bedwars.stats;
+
+import java.util.UUID;
+
+/**
+ * Simple data holder for player statistics kept in memory.
+ */
+public class PlayerStats {
+
+    private final UUID uuid;
+    private String username;
+    private int kills;
+    private int deaths;
+    private int wins;
+    private int losses;
+    private int bedsBroken;
+    private int gamesPlayed;
+
+    public PlayerStats(UUID uuid, String username) {
+        this(uuid, username, 0, 0, 0, 0, 0, 0);
+    }
+
+    public PlayerStats(UUID uuid, String username, int kills, int deaths, int wins,
+                       int losses, int bedsBroken, int gamesPlayed) {
+        this.uuid = uuid;
+        this.username = username;
+        this.kills = kills;
+        this.deaths = deaths;
+        this.wins = wins;
+        this.losses = losses;
+        this.bedsBroken = bedsBroken;
+        this.gamesPlayed = gamesPlayed;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public int getKills() {
+        return kills;
+    }
+
+    public void incrementKills() {
+        this.kills++;
+    }
+
+    public int getDeaths() {
+        return deaths;
+    }
+
+    public void incrementDeaths() {
+        this.deaths++;
+    }
+
+    public int getWins() {
+        return wins;
+    }
+
+    public void incrementWins() {
+        this.wins++;
+    }
+
+    public int getLosses() {
+        return losses;
+    }
+
+    public void incrementLosses() {
+        this.losses++;
+    }
+
+    public int getBedsBroken() {
+        return bedsBroken;
+    }
+
+    public void incrementBedsBroken() {
+        this.bedsBroken++;
+    }
+
+    public int getGamesPlayed() {
+        return gamesPlayed;
+    }
+
+    public void incrementGamesPlayed() {
+        this.gamesPlayed++;
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/utils/MessageManager.java
+++ b/src/main/java/com/heneria/bedwars/utils/MessageManager.java
@@ -76,6 +76,21 @@ public final class MessageManager {
     }
 
     /**
+     * Retrieves a list of formatted messages.
+     *
+     * @param path config path
+     * @return list of formatted strings
+     */
+    public static java.util.List<String> getList(String path) {
+        java.util.List<String> list = messages.getStringList(path);
+        java.util.List<String> formatted = new java.util.ArrayList<>();
+        for (String line : list) {
+            formatted.add(ChatColor.translateAlternateColorCodes('&', line));
+        }
+        return formatted;
+    }
+
+    /**
      * Sends a title to the player using messages from the file.
      *
      * @param player the player

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,13 @@
 void-kill-height: 0
 trap-radius: 10
+
+database:
+  type: sqlite # sqlite or mysql
+  save-interval: 5 # minutes between automatic saves
+  mysql:
+    host: localhost
+    port: 3306
+    database: bedwars
+    username: root
+    password: ""
+    useSSL: false

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -3,6 +3,7 @@ prefix: "&8[&bHeneriaBedwars&8] &r"
 errors:
   no-permission: "&cVous n'avez pas la permission d'exécuter cette commande."
   not-a-player: "&cCette commande est réservée aux joueurs."
+  player-not-found: "&cJoueur introuvable."
   arena-not-found: "&cArène introuvable."
   arena-not-available: "&cCette arène n'est pas disponible."
   already-in-arena: "&cVous êtes déjà dans une arène."
@@ -92,3 +93,13 @@ scoreboard:
   bed-alive: "&a✔"
   bed-destroyed: "&c❌"
   you-marker: "&e(VOUS)"
+
+stats:
+  format:
+    - "&aStatistiques de {player}:"
+    - "&7Kills: &e{kills}"
+    - "&7Morts: &e{deaths}"
+    - "&7Victoires: &e{wins}"
+    - "&7Défaites: &e{losses}"
+    - "&7Lits détruits: &e{beds_broken}"
+    - "&7Parties jouées: &e{games_played}"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,3 +13,6 @@ permissions:
   heneriabw.admin:
     description: Donne accès à toutes les commandes d'administration de HeneriaBedwars.
     default: op
+  heneriabw.admin.stats:
+    description: Permet de voir les statistiques des autres joueurs.
+    default: op


### PR DESCRIPTION
## Summary
- add database manager with SQLite and MySQL support
- track and cache player statistics with periodic saving
- expose `/bw stats` command and update docs/config

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b03b8dcc8329a7a29db6a9d60adc