### PR TITLE
feat(integrations): Add PlaceholderAPI support for stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Ajouté
 - Ajout d'un système de statistiques joueurs avec support SQLite et MySQL.
+- Intégration avec PlaceholderAPI pour afficher les statistiques dans d'autres plugins.
 
 ## [0.7.0] - En développement
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ database:
 ```
 
 
+
+## 📌 Placeholders
+
+Si [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/) est installé, HeneriaBedwars enregistre automatiquement les placeholders suivants :
+
+- `%heneriabw_kills%`
+- `%heneriabw_deaths%`
+- `%heneriabw_wins%`
+- `%heneriabw_losses%`
+- `%heneriabw_beds_broken%`
+- `%heneriabw_games_played%`
+- `%heneriabw_kdr%`
+
+Vous pouvez les utiliser dans n'importe quel plugin compatible avec PlaceholderAPI pour afficher les statistiques des joueurs.
+
 ---
 
 ## 🔧 Compilation (pour les développeurs)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,4 +48,5 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 * [✔] Les Pièges d'Équipe.
   * [✔] Un Fichier de Langue Complet (messages.yml).
   * [✔] Sauvegarde des Statistiques des Joueurs.
-  * [ ] Compatibilité avec PlaceholderAPI.
+  * [✔] Compatibilité avec PlaceholderAPI.
+  * [ ] Optimisation et Finitions.

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>ecloud-repo</id>
+            <url>https://ecloud.e-verse.com/repositories/public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -60,6 +64,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.21-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -22,6 +22,8 @@ import com.heneria.bedwars.managers.DatabaseManager;
 import com.heneria.bedwars.managers.StatsManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Bukkit;
+import com.heneria.bedwars.placeholders.HeneriaPlaceholders;
 
 public final class HeneriaBedwars extends JavaPlugin {
 
@@ -52,6 +54,10 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.scoreboardManager = new ScoreboardManager(this);
         this.databaseManager = new DatabaseManager(this);
         this.statsManager = new StatsManager(this, this.databaseManager);
+
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new HeneriaPlaceholders(this).register();
+        }
 
         // Enregistrement des commandes
         CommandManager commandManager = new CommandManager(this);

--- a/src/main/java/com/heneria/bedwars/placeholders/HeneriaPlaceholders.java
+++ b/src/main/java/com/heneria/bedwars/placeholders/HeneriaPlaceholders.java
@@ -1,0 +1,76 @@
+package com.heneria.bedwars.placeholders;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.stats.PlayerStats;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+
+import java.util.Locale;
+
+/**
+ * PlaceholderAPI expansion to expose player statistics.
+ */
+public class HeneriaPlaceholders extends PlaceholderExpansion {
+
+    private final HeneriaBedwars plugin;
+
+    public HeneriaPlaceholders(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "heneriabw";
+    }
+
+    @Override
+    public String getAuthor() {
+        return String.join(", ", plugin.getDescription().getAuthors());
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer player, String params) {
+        if (player == null) {
+            return "0";
+        }
+
+        PlayerStats stats = plugin.getStatsManager().getStats(player.getUniqueId());
+        if (stats == null) {
+            return "0";
+        }
+
+        switch (params.toLowerCase(Locale.ROOT)) {
+            case "kills":
+                return String.valueOf(stats.getKills());
+            case "deaths":
+                return String.valueOf(stats.getDeaths());
+            case "wins":
+                return String.valueOf(stats.getWins());
+            case "losses":
+                return String.valueOf(stats.getLosses());
+            case "beds_broken":
+                return String.valueOf(stats.getBedsBroken());
+            case "games_played":
+                return String.valueOf(stats.getGamesPlayed());
+            case "kdr":
+                int deaths = stats.getDeaths();
+                if (deaths == 0) {
+                    return String.valueOf(stats.getKills());
+                }
+                double kdr = (double) stats.getKills() / deaths;
+                return String.format(Locale.US, "%.2f", kdr);
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: ${project.version}
 main: com.heneria.bedwars.HeneriaBedwars
 api-version: '1.21'
 author: tomashb
+softdepend: [PlaceholderAPI]
 
 commands:
   bedwars:


### PR DESCRIPTION
## Summary
- expose player stats through PlaceholderAPI expansion
- register placeholders when PlaceholderAPI is present
- document new placeholders and roadmap updates

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b23bf3a083299e2172436a1fe41a