### PR TITLE
HBW-063: Timed generator upgrades and Maven repo fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - HeneriaBedwars
 
+## [0.9.0] - En développement
+
+### Corrigé
+- Correction de l'URL du dépôt Maven pour PlaceholderAPI, résolvant les erreurs de build.
+
+### Ajouté
+- Système d'événements temporisés améliorant automatiquement les générateurs de Diamants et d'Émeraudes avec annonces et intégration au scoreboard.
+
 ## [0.8.0] - En développement
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
   - `scoreboard.yml` : Personnalisez le titre et les lignes du tableau de bord en jeu.
+  - `events.yml` : Planifiez les événements automatiques (ex : amélioration des générateurs).
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
 
 Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le plugin à n'importe quelle langue ou style.
@@ -92,6 +93,21 @@ traps:
       duration: 10
       amplifier: 1
 ```
+
+### Configuration des Événements de Jeu
+
+Le fichier `events.yml` permet de définir une chronologie d'événements pendant une partie, comme l'amélioration automatique des générateurs :
+
+```yaml
+game-events:
+  - time: '6m'
+    type: 'UPGRADE_GENERATORS'
+    targets: [DIAMOND]
+    new-tier: 2
+    broadcast-message: "&bLes générateurs de Diamants ont été améliorés au Niveau II !"
+```
+
+Chaque entrée peut préciser un temps (`time`), le type d'événement (`type`), les cibles (`targets`), le nouveau niveau (`new-tier`) et le message diffusé aux joueurs.
 
 ### Configuration de la Base de Données
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -71,6 +75,12 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>8.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.5</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -20,6 +20,7 @@ import com.heneria.bedwars.managers.UpgradeManager;
 import com.heneria.bedwars.managers.ScoreboardManager;
 import com.heneria.bedwars.managers.DatabaseManager;
 import com.heneria.bedwars.managers.StatsManager;
+import com.heneria.bedwars.managers.EventManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -32,6 +33,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private ShopManager shopManager;
     private UpgradeManager upgradeManager;
     private ScoreboardManager scoreboardManager;
+    private EventManager eventManager;
     private DatabaseManager databaseManager;
     private StatsManager statsManager;
 
@@ -49,6 +51,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.generatorManager = new GeneratorManager(this);
         this.shopManager = new ShopManager(this);
         this.upgradeManager = new UpgradeManager(this);
+        this.eventManager = new EventManager(this);
         this.scoreboardManager = new ScoreboardManager(this);
         this.databaseManager = new DatabaseManager(this);
         this.statsManager = new StatsManager(this, this.databaseManager);
@@ -111,6 +114,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public ScoreboardManager getScoreboardManager() {
         return scoreboardManager;
+    }
+
+    public EventManager getEventManager() {
+        return eventManager;
     }
 
     public StatsManager getStatsManager() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -421,6 +421,7 @@ public class Arena {
         for (Generator gen : generators) {
             HeneriaBedwars.getInstance().getGeneratorManager().registerGenerator(gen);
         }
+        HeneriaBedwars.getInstance().getEventManager().startTimeline(this);
         for (Team team : this.getTeams().values()) {
             if (team.getItemShopNpcLocation() != null) {
                 Villager npc = (Villager) team.getItemShopNpcLocation().getWorld().spawnEntity(team.getItemShopNpcLocation(), EntityType.VILLAGER);
@@ -547,6 +548,7 @@ public class Arena {
     }
 
     public void reset() {
+        HeneriaBedwars.getInstance().getEventManager().stopTimeline(this);
         for (UUID id : new ArrayList<>(players)) {
             Player p = Bukkit.getPlayer(id);
             if (p != null) {

--- a/src/main/java/com/heneria/bedwars/events/GameEventType.java
+++ b/src/main/java/com/heneria/bedwars/events/GameEventType.java
@@ -1,0 +1,12 @@
+package com.heneria.bedwars.events;
+
+/**
+ * Types of timed game events that can occur during a match.
+ */
+public enum GameEventType {
+    /**
+     * Upgrade the tier of specific generators in the arena.
+     */
+    UPGRADE_GENERATORS
+}
+

--- a/src/main/java/com/heneria/bedwars/events/TimedEvent.java
+++ b/src/main/java/com/heneria/bedwars/events/TimedEvent.java
@@ -1,0 +1,46 @@
+package com.heneria.bedwars.events;
+
+import com.heneria.bedwars.arena.enums.GeneratorType;
+
+import java.util.List;
+
+/**
+ * Represents a scheduled event in the game's timeline.
+ */
+public class TimedEvent {
+
+    private final int time; // in seconds
+    private final GameEventType type;
+    private final List<GeneratorType> targets;
+    private final int newTier;
+    private final String message;
+
+    public TimedEvent(int time, GameEventType type, List<GeneratorType> targets, int newTier, String message) {
+        this.time = time;
+        this.type = type;
+        this.targets = targets;
+        this.newTier = newTier;
+        this.message = message;
+    }
+
+    public int getTime() {
+        return time;
+    }
+
+    public GameEventType getType() {
+        return type;
+    }
+
+    public List<GeneratorType> getTargets() {
+        return targets;
+    }
+
+    public int getNewTier() {
+        return newTier;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/managers/EventManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/EventManager.java
@@ -1,0 +1,175 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import com.heneria.bedwars.events.GameEventType;
+import com.heneria.bedwars.events.TimedEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Loads the game event configuration and manages timelines for active arenas.
+ */
+public class EventManager {
+
+    private final HeneriaBedwars plugin;
+    private final List<TimedEvent> templateEvents = new ArrayList<>();
+    private final Map<Arena, ArenaTimeline> timelines = new HashMap<>();
+
+    public EventManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        loadConfig();
+    }
+
+    private void loadConfig() {
+        File file = new File(plugin.getDataFolder(), "events.yml");
+        if (!file.exists()) {
+            plugin.saveResource("events.yml", false);
+        }
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        templateEvents.clear();
+        if (config.contains("game-events")) {
+            for (Map<?, ?> map : config.getMapList("game-events")) {
+                String timeStr = String.valueOf(map.get("time"));
+                int time = parseTime(timeStr);
+                GameEventType type = GameEventType.valueOf(String.valueOf(map.get("type")).toUpperCase());
+                List<GeneratorType> targets = new ArrayList<>();
+                Object targetsObj = map.get("targets");
+                if (targetsObj instanceof List<?> list) {
+                    for (Object o : list) {
+                        targets.add(GeneratorType.valueOf(String.valueOf(o).toUpperCase()));
+                    }
+                }
+                int tier = map.get("new-tier") instanceof Number n ? n.intValue() : 1;
+                String message = map.get("broadcast-message") == null ? "" : String.valueOf(map.get("broadcast-message"));
+                templateEvents.add(new TimedEvent(time, type, targets, tier, message));
+            }
+            templateEvents.sort(Comparator.comparingInt(TimedEvent::getTime));
+        }
+    }
+
+    private int parseTime(String time) {
+        String t = time.trim().toLowerCase();
+        if (t.endsWith("m")) {
+            return Integer.parseInt(t.substring(0, t.length() - 1)) * 60;
+        }
+        if (t.endsWith("s")) {
+            return Integer.parseInt(t.substring(0, t.length() - 1));
+        }
+        return Integer.parseInt(t);
+    }
+
+    public void startTimeline(Arena arena) {
+        ArenaTimeline task = new ArenaTimeline(arena, templateEvents);
+        task.runTaskTimer(plugin, 20L, 20L);
+        timelines.put(arena, task);
+    }
+
+    public void stopTimeline(Arena arena) {
+        ArenaTimeline task = timelines.remove(arena);
+        if (task != null) {
+            task.cancel();
+        }
+    }
+
+    public String getNextEventName(Arena arena) {
+        ArenaTimeline task = timelines.get(arena);
+        if (task == null) {
+            return "N/A";
+        }
+        TimedEvent ev = task.next;
+        if (ev == null) {
+            return "N/A";
+        }
+        if (ev.getType() == GameEventType.UPGRADE_GENERATORS && !ev.getTargets().isEmpty()) {
+            GeneratorType type = ev.getTargets().get(0);
+            String name = type.name().substring(0, 1) + type.name().substring(1).toLowerCase();
+            return name + " " + toRoman(ev.getNewTier());
+        }
+        return ev.getType().name();
+    }
+
+    public String getNextEventTime(Arena arena) {
+        ArenaTimeline task = timelines.get(arena);
+        if (task == null) {
+            return "--";
+        }
+        int remaining = task.getRemaining();
+        if (remaining < 0) {
+            return "--";
+        }
+        int minutes = remaining / 60;
+        int seconds = remaining % 60;
+        return String.format("%02d:%02d", minutes, seconds);
+    }
+
+    private String toRoman(int value) {
+        return switch (value) {
+            case 1 -> "I";
+            case 2 -> "II";
+            case 3 -> "III";
+            case 4 -> "IV";
+            case 5 -> "V";
+            default -> String.valueOf(value);
+        };
+    }
+
+    private class ArenaTimeline extends BukkitRunnable {
+        private final Arena arena;
+        private final Queue<TimedEvent> events;
+        private TimedEvent next;
+        private int elapsed = 0;
+
+        ArenaTimeline(Arena arena, List<TimedEvent> template) {
+            this.arena = arena;
+            this.events = new LinkedList<>(template);
+            this.next = events.poll();
+        }
+
+        @Override
+        public void run() {
+            elapsed++;
+            if (next != null && elapsed >= next.getTime()) {
+                trigger(next);
+                next = events.poll();
+            }
+        }
+
+        private void trigger(TimedEvent event) {
+            if (event.getType() == GameEventType.UPGRADE_GENERATORS) {
+                for (GeneratorType type : event.getTargets()) {
+                    for (Generator gen : arena.getGenerators()) {
+                        if (gen.getType() == type) {
+                            gen.setTier(event.getNewTier());
+                            plugin.getGeneratorManager().registerGenerator(gen);
+                        }
+                    }
+                }
+            }
+            String msg = ChatColor.translateAlternateColorCodes('&', event.getMessage());
+            for (UUID id : arena.getPlayers()) {
+                Player p = Bukkit.getPlayer(id);
+                if (p != null) {
+                    p.sendMessage(msg);
+                    p.sendTitle("", msg, 10, 70, 20);
+                }
+            }
+        }
+
+        private int getRemaining() {
+            if (next == null) {
+                return -1;
+            }
+            return next.getTime() - elapsed;
+        }
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/managers/ScoreboardManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ScoreboardManager.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.elements.Team;
 import com.heneria.bedwars.arena.enums.TeamColor;
+import com.heneria.bedwars.managers.EventManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -156,12 +157,18 @@ public class ScoreboardManager {
     }
 
     private String getNextEventName(Arena arena) {
-        // Placeholder for future event system
-        return "N/A";
+        EventManager em = plugin.getEventManager();
+        if (em == null) {
+            return "N/A";
+        }
+        return em.getNextEventName(arena);
     }
 
     private String getNextEventTime(Arena arena) {
-        // Placeholder for future event system
-        return "--";
+        EventManager em = plugin.getEventManager();
+        if (em == null) {
+            return "--";
+        }
+        return em.getNextEventTime(arena);
     }
 }

--- a/src/main/resources/events.yml
+++ b/src/main/resources/events.yml
@@ -1,0 +1,13 @@
+game-events:
+  - time: '6m'
+    type: 'UPGRADE_GENERATORS'
+    targets: [DIAMOND]
+    new-tier: 2
+    broadcast-message: "&bLes générateurs de Diamants ont été améliorés au Niveau II !"
+
+  - time: '12m'
+    type: 'UPGRADE_GENERATORS'
+    targets: [EMERALD]
+    new-tier: 2
+    broadcast-message: "&2Les générateurs d'Émeraudes ont été améliorés au Niveau II !"
+


### PR DESCRIPTION
## Summary
- fix build failure by pointing PlaceholderAPI repository to official URL
- add configurable timed events that upgrade diamond and emerald generators with announcements and scoreboard integration
- document new events.yml and bump changelog for v0.9.0

## Testing
- `mvn -B package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b48f940c8329b76e3f88dd67ddf2