### PR TITLE
fix(core): Initialize default GameState in Arena constructor to prevent NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [0.9.1] - En développement
+
+### Corrigé
+- Correction d'une `NullPointerException` en initialisant l'état par défaut des arènes à leur création.
+
 ## [0.9.0] - En développement
 
 ### Corrigé

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -31,7 +31,7 @@ import java.util.*;
 public class Arena {
 
     private final String name;
-    private GameState state = GameState.WAITING;
+    private GameState state;
     private String worldName;
     private boolean enabled;
     private int minPlayers;
@@ -61,6 +61,7 @@ public class Arena {
      */
     public Arena(String name) {
         this.name = name;
+        this.state = GameState.WAITING;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure `Arena` instances start in `GameState.WAITING`
- document the fix for version 0.9.1

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b7a17af883298aa1079eac73dc4b