### PR TITLE
feat: add Pop-up Tower item with BlockFace fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@
 
 ### Corrigé
 - Correction de l'URL du dépôt Maven pour PlaceholderAPI, résolvant les erreurs de build.
+- Correction d'une erreur de compilation due à une mauvaise utilisation de l'API `BlockFace` pour la Tour Instantanée.
 
 ### Ajouté
 - Système d'événements temporisés améliorant automatiquement les générateurs de Diamants et d'Émeraudes avec annonces et intégration au scoreboard.
 - Ajout des événements de Mort Subite (destruction des lits) et d'apparition de Dragons.
+- Ajout de l'objet spécial "Tour Instantanée".
 
 ## [0.8.0] - En développement
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,7 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 * [✔] La Construction : Ajout de la pose/destruction de blocs par les joueurs.
 * [✔] Ajout des kits de départ complets (armure liée, épée).
  * [✔] Les Objets Spéciaux (TNT, Boules de feu...).
+* [✔] Tour Instantanée (Pop-up Tower).
 * [✔] Le Tableau de Bord (Scoreboard).
 * [✔] Les Pièges d'Équipe.
   * [✔] Un Fichier de Langue Complet (messages.yml).

--- a/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
@@ -8,6 +8,7 @@ import com.heneria.bedwars.managers.ArenaManager;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Egg;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
@@ -64,6 +65,27 @@ public class SpecialItemListener implements Listener {
             Egg egg = player.launchProjectile(Egg.class);
             egg.setVelocity(player.getLocation().getDirection().multiply(1.5));
             eggStarts.put(egg, player.getLocation());
+        } else if (type == Material.CHEST) {
+            event.setCancelled(true);
+            Team team = arena.getTeam(player);
+            if (team == null) {
+                return;
+            }
+            Block currentBlock = player.getLocation().getBlock();
+            for (int i = 0; i < 4; i++) {
+                Block blockToPlace = currentBlock.getRelative(BlockFace.DOWN, i);
+                if (blockToPlace.getType() != Material.AIR) {
+                    return;
+                }
+            }
+            item.setAmount(item.getAmount() - 1);
+            Material teamWoolMaterial = team.getColor().getWoolMaterial();
+            for (int i = 0; i < 4; i++) {
+                Block blockToPlace = currentBlock.getRelative(BlockFace.DOWN, i);
+                blockToPlace.setType(teamWoolMaterial);
+                arena.getPlacedBlocks().add(blockToPlace);
+            }
+            player.teleport(currentBlock.getRelative(BlockFace.UP, 1).getLocation().add(0.5, 0, 0.5));
         }
     }
 

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -111,3 +111,12 @@ shop-categories:
           resource: EMERALD
           amount: 1
         slot: 13
+      'popup_tower':
+        material: CHEST
+        name: "&6Tour instantanée"
+        amount: 1
+        cost:
+          resource: IRON
+          amount: 24
+        slot: 14
+        action: 'POPUP_TOWER'


### PR DESCRIPTION
## Summary
- add Pop-up Tower utility item to shop
- build team-colored wool pillar on use and register placed blocks
- document Pop-up Tower addition and BlockFace fix

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4325626a083298d28fea9194a045c