### PR TITLE
feat(game): Implement special mid-game NPC merchant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Correction d'une `NullPointerException` en initialisant l'état par défaut des arènes à leur création.
 - Correction d'un bug dans l'algorithme de vérification d'espace qui empêchait la Tour Instantanée de fonctionner.
 
+### Ajouté
+- Apparition d'un PNJ spécial de milieu de partie et ajout de l'objet "Golem de Fer de Poche".
+
 ## [0.9.0] - En développement
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
   - `scoreboard.yml` : Personnalisez le titre et les lignes du tableau de bord en jeu.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons).
+  - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie.
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
 
 Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le plugin à n'importe quelle langue ou style.
@@ -33,6 +34,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🛡️ **Kit de départ lié** : Vous réapparaissez avec une armure en cuir teintée aux couleurs de votre équipe et une épée en bois impossible à jeter.
 - 🌈 **Achats intelligents** : La laine achetée s'adapte automatiquement à la couleur de votre équipe et toute nouvelle épée remplace la précédente.
 - 📊 **Tableau de Bord Dynamique** : Consultez en un coup d'œil l'état des équipes et le prochain événement.
+- 🛍️ **Marchand Mystérieux** : Un PNJ spécial apparaît au centre en milieu de partie pour vendre des objets uniques comme le Golem de Fer de Poche.
 - 🏆 **Conditions de Victoire** : La partie se termine automatiquement lorsque la dernière équipe en vie est déclarée vainqueur, et l'arène se réinitialise pour le prochain combat.
 
 ---
@@ -114,6 +116,8 @@ Les types disponibles incluent :
 - `UPGRADE_GENERATORS` : améliore le niveau de certains générateurs.
 - `SUDDEN_DEATH` : détruit tous les lits restants et empêche toute réapparition.
 - `SPAWN_DRAGONS` : fait apparaître un ou plusieurs dragons pour accélérer la fin de partie.
+- `SPAWN_SPECIAL_NPC` : fait apparaître temporairement le Marchand Mystérieux au centre.
+- `DESPAWN_SPECIAL_NPC` : retire le Marchand Mystérieux de l'arène.
 
 Exemple incluant ces nouveaux événements :
 
@@ -126,6 +130,35 @@ game-events:
   - time: '31m'
     type: 'SPAWN_DRAGONS'
     broadcast-message: "&c&lLES DRAGONS ARRIVENT !"
+
+  - time: '15m'
+    type: 'SPAWN_SPECIAL_NPC'
+    broadcast-message: "&d&lUn Marchand Mystérieux est apparu au centre !"
+
+  - time: '18m'
+    type: 'DESPAWN_SPECIAL_NPC'
+    broadcast-message: "&dLe Marchand Mystérieux est parti !"
+```
+
+### Configuration du Marchand Mystérieux
+
+Le contenu de la boutique du PNJ spécial est défini dans le fichier `special_shop.yml` :
+
+```yaml
+title: "&5Marchand Mystérieux"
+rows: 3
+items:
+  iron-golem:
+    material: IRON_BLOCK
+    name: "&fGolem de Fer de Poche"
+    lore:
+      - "&7Posez ce bloc pour faire apparaître"
+      - "&7un Golem de Fer qui défendra votre île."
+    cost:
+      resource: DIAMOND
+      amount: 8
+    slot: 11
+    action: 'SPAWN_IRON_GOLEM'
 ```
 
 ### Configuration de la Base de Données

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -10,12 +10,15 @@ import com.heneria.bedwars.listeners.ShopListener;
 import com.heneria.bedwars.listeners.UpgradeListener;
 import com.heneria.bedwars.listeners.StarterItemListener;
 import com.heneria.bedwars.listeners.SpecialItemListener;
+import com.heneria.bedwars.listeners.SpecialNpcListener;
+import com.heneria.bedwars.listeners.GolemListener;
 import com.heneria.bedwars.listeners.TrapListener;
 import com.heneria.bedwars.listeners.StatsListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
 import com.heneria.bedwars.managers.ShopManager;
+import com.heneria.bedwars.managers.SpecialShopManager;
 import com.heneria.bedwars.managers.UpgradeManager;
 import com.heneria.bedwars.managers.ScoreboardManager;
 import com.heneria.bedwars.managers.DatabaseManager;
@@ -32,6 +35,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private SetupManager setupManager;
     private GeneratorManager generatorManager;
     private ShopManager shopManager;
+    private SpecialShopManager specialShopManager;
     private UpgradeManager upgradeManager;
     private ScoreboardManager scoreboardManager;
     private EventManager eventManager;
@@ -53,6 +57,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.arenaManager.loadArenas();
         this.generatorManager = new GeneratorManager(this);
         this.shopManager = new ShopManager(this);
+        this.specialShopManager = new SpecialShopManager(this);
         this.upgradeManager = new UpgradeManager(this);
         this.eventManager = new EventManager(this);
         this.scoreboardManager = new ScoreboardManager(this);
@@ -87,6 +92,8 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new UpgradeListener(), this);
         getServer().getPluginManager().registerEvents(new StarterItemListener(), this);
         getServer().getPluginManager().registerEvents(new SpecialItemListener(), this);
+        getServer().getPluginManager().registerEvents(new SpecialNpcListener(), this);
+        getServer().getPluginManager().registerEvents(new GolemListener(), this);
         getServer().getPluginManager().registerEvents(new TrapListener(), this);
         getServer().getPluginManager().registerEvents(new StatsListener(), this);
     }
@@ -109,6 +116,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public ShopManager getShopManager() {
         return shopManager;
+    }
+
+    public SpecialShopManager getSpecialShopManager() {
+        return specialShopManager;
     }
 
     public UpgradeManager getUpgradeManager() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -43,6 +43,8 @@ public class Arena {
     private final Map<TeamColor, Team> teams = new EnumMap<>(TeamColor.class);
     private final List<Generator> generators = new ArrayList<>();
     private Location lobbyLocation;
+    private Location specialNpcLocation;
+    private Entity specialNpc;
     /**
      * Stores all NPC entities spawned for this arena so they can be removed
      * without affecting NPCs of other arenas.
@@ -276,6 +278,42 @@ public class Arena {
 
     public List<EnderDragon> getDragons() {
         return dragons;
+    }
+
+    public void addNpc(Entity entity) {
+        liveNpcs.add(entity);
+    }
+
+    public Location getSpecialNpcLocation() {
+        return specialNpcLocation;
+    }
+
+    public void setSpecialNpcLocation(Location specialNpcLocation) {
+        this.specialNpcLocation = specialNpcLocation;
+    }
+
+    public void spawnSpecialNpc() {
+        if (specialNpcLocation == null || specialNpc != null) {
+            return;
+        }
+        Villager npc = (Villager) specialNpcLocation.getWorld().spawnEntity(specialNpcLocation, EntityType.VILLAGER);
+        npc.setAI(false);
+        npc.setInvulnerable(true);
+        npc.setSilent(true);
+        npc.setCollidable(false);
+        npc.addScoreboardTag("special_npc");
+        npc.setCustomName(ChatColor.translateAlternateColorCodes('&', "&5Marchand Mystérieux"));
+        npc.setCustomNameVisible(true);
+        liveNpcs.add(npc);
+        specialNpc = npc;
+    }
+
+    public void despawnSpecialNpc() {
+        if (specialNpc != null) {
+            specialNpc.remove();
+            liveNpcs.remove(specialNpc);
+            specialNpc = null;
+        }
     }
 
     public void registerBeds() {
@@ -621,6 +659,7 @@ public class Arena {
         state = GameState.WAITING;
         liveNpcs.forEach(Entity::remove);
         liveNpcs.clear();
+        specialNpc = null;
         dragons.forEach(Entity::remove);
         dragons.clear();
         for (Block block : placedBlocks) {

--- a/src/main/java/com/heneria/bedwars/events/GameEventType.java
+++ b/src/main/java/com/heneria/bedwars/events/GameEventType.java
@@ -17,6 +17,15 @@ public enum GameEventType {
     /**
      * Spawn one or more Ender Dragons to pressure players.
      */
-    SPAWN_DRAGONS
+    SPAWN_DRAGONS,
+    /**
+     * Spawn the special mid-game merchant NPC.
+     */
+    SPAWN_SPECIAL_NPC,
+
+    /**
+     * Remove the special mid-game merchant NPC.
+     */
+    DESPAWN_SPECIAL_NPC
 }
 

--- a/src/main/java/com/heneria/bedwars/gui/admin/ArenaConfigMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/ArenaConfigMenu.java
@@ -23,6 +23,7 @@ public class ArenaConfigMenu extends Menu {
     private static final int SET_LOBBY_SLOT = 10;
     private static final int TEAMS_SLOT = 12;
     private static final int GENERATORS_SLOT = 14;
+    private static final int SPECIAL_NPC_SLOT = 16;
     private static final int TOGGLE_SLOT = 22;
 
     public ArenaConfigMenu(Arena arena) {
@@ -54,6 +55,11 @@ public class ArenaConfigMenu extends Menu {
         inventory.setItem(GENERATORS_SLOT, new ItemBuilder(Material.FURNACE)
                 .setName("&eGestion des Générateurs")
                 .addLore("&7Ajouter ou supprimer des générateurs")
+                .build());
+
+        inventory.setItem(SPECIAL_NPC_SLOT, new ItemBuilder(Material.NETHER_STAR)
+                .setName("&eDéfinir Emplacement PNJ Spécial")
+                .addLore("&7Cliquez pour définir la position")
                 .build());
 
         Material toggleMaterial = arena.isEnabled() ? Material.REDSTONE_BLOCK : Material.EMERALD_BLOCK;
@@ -91,6 +97,11 @@ public class ArenaConfigMenu extends Menu {
             new TeamListMenu(arena).open(player, this);
         } else if (slot == GENERATORS_SLOT) {
             new GeneratorConfigMenu(arena).open(player, this);
+        } else if (slot == SPECIAL_NPC_SLOT) {
+            HeneriaBedwars.getInstance().getSetupManager().startSetup(player,
+                    new SetupAction(arena, SetupType.SPECIAL_NPC));
+            MessageManager.sendMessage(player, "setup.start-special-npc-setup");
+            player.closeInventory();
         } else if (slot == TOGGLE_SLOT) {
             if (!arena.isEnabled()) {
                 if (arena.getLobbyLocation() == null) {

--- a/src/main/java/com/heneria/bedwars/gui/special/SpecialShopMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/special/SpecialShopMenu.java
@@ -1,0 +1,93 @@
+package com.heneria.bedwars.gui.special;
+
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.managers.ResourceManager;
+import com.heneria.bedwars.managers.ResourceType;
+import com.heneria.bedwars.managers.SpecialShopManager;
+import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.HeneriaBedwars;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Inventory GUI for the special mid-game merchant.
+ */
+public class SpecialShopMenu extends Menu {
+
+    private final SpecialShopManager manager;
+    private final Map<Integer, SpecialShopManager.SpecialItem> slotItems = new HashMap<>();
+
+    public SpecialShopMenu(SpecialShopManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public String getTitle() {
+        return manager.getTitle();
+    }
+
+    @Override
+    public int getSize() {
+        return manager.getRows() * 9;
+    }
+
+    @Override
+    public void setupItems() {
+        for (SpecialShopManager.SpecialItem item : manager.getItems().values()) {
+            ItemBuilder builder = new ItemBuilder(item.material())
+                    .setName(item.name());
+            for (String line : item.lore()) {
+                builder.addLore(line);
+            }
+            builder.addLore("&7Coût: &f" + item.costAmount() + " " + item.costResource().getDisplayName());
+            ItemStack stack = builder.build();
+            inventory.setItem(item.slot(), stack);
+            slotItems.put(item.slot(), item);
+        }
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler);
+            }
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        SpecialShopManager.SpecialItem item = slotItems.get(event.getRawSlot());
+        if (item == null) {
+            return;
+        }
+        ResourceType type = item.costResource();
+        int price = item.costAmount();
+        if (ResourceManager.hasResources(player, type, price)) {
+            ResourceManager.takeResources(player, type, price);
+            ItemStack give = new ItemStack(item.material(), 1);
+            ItemMeta meta = give.getItemMeta();
+            if (meta != null && item.action() != null) {
+                meta.getPersistentDataContainer().set(HeneriaBedwars.getItemTypeKey(), PersistentDataType.STRING, item.action());
+                give.setItemMeta(meta);
+            }
+            player.getInventory().addItem(give);
+            player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
+        } else {
+            player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 1f, 1f);
+        }
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/listeners/GolemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GolemListener.java
@@ -1,0 +1,40 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import org.bukkit.entity.IronGolem;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
+
+/**
+ * Prevents team-owned golems from targeting their owners.
+ */
+public class GolemListener implements Listener {
+
+    @EventHandler
+    public void onTarget(EntityTargetLivingEntityEvent event) {
+        if (!(event.getEntity() instanceof IronGolem golem)) {
+            return;
+        }
+        if (!(event.getTarget() instanceof Player player)) {
+            return;
+        }
+        HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+        Arena arena = plugin.getArenaManager().getArenaByPlayer(player.getUniqueId());
+        if (arena == null) {
+            return;
+        }
+        Team team = arena.getTeam(player);
+        if (team == null) {
+            return;
+        }
+        String tag = "team_" + team.getColor().name();
+        if (golem.getScoreboardTags().contains(tag)) {
+            event.setCancelled(true);
+        }
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/listeners/SetupListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SetupListener.java
@@ -131,6 +131,20 @@ public class SetupListener implements Listener {
             Team team = arena.getTeams().computeIfAbsent(action.getTeamColor(), Team::new);
             team.setUpgradeShopNpcLocation(npcLocation);
             MessageManager.sendMessage(player, "setup.upgrade-npc-set", "team", action.getTeamColor().getDisplayName());
+        } else if (action.getType() == SetupType.SPECIAL_NPC) {
+            Block clickedBlock = event.getClickedBlock();
+            if (clickedBlock == null) {
+                MessageManager.sendMessage(player, "setup.npc-click-block");
+                return;
+            }
+            double x = clickedBlock.getX() + 0.5;
+            double y = clickedBlock.getY() + 1.0;
+            double z = clickedBlock.getZ() + 0.5;
+            float yaw = player.getLocation().getYaw();
+            float pitch = 0.0f;
+            Location npcLocation = new Location(player.getWorld(), x, y, z, yaw, pitch);
+            arena.setSpecialNpcLocation(npcLocation);
+            MessageManager.sendMessage(player, "setup.special-npc-set");
         }
 
         HeneriaBedwars.getInstance().getArenaManager().saveArena(arena);

--- a/src/main/java/com/heneria/bedwars/listeners/SpecialNpcListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SpecialNpcListener.java
@@ -1,0 +1,31 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.gui.special.SpecialShopMenu;
+import com.heneria.bedwars.managers.SpecialShopManager;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+
+/**
+ * Opens the special shop menu when interacting with the special NPC.
+ */
+public class SpecialNpcListener implements Listener {
+
+    @EventHandler
+    public void onInteract(PlayerInteractEntityEvent event) {
+        if (!(event.getRightClicked() instanceof Villager villager)) {
+            return;
+        }
+        if (!villager.getScoreboardTags().contains("special_npc")) {
+            return;
+        }
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        SpecialShopManager manager = HeneriaBedwars.getInstance().getSpecialShopManager();
+        new SpecialShopMenu(manager).open(player);
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -69,6 +69,18 @@ public class ArenaManager {
                     arena.setLobbyLocation(loc);
                 }
             }
+            if (config.contains("special-npc.world")) {
+                World w = Bukkit.getWorld(config.getString("special-npc.world"));
+                if (w != null) {
+                    Location loc = new Location(w,
+                            config.getDouble("special-npc.x"),
+                            config.getDouble("special-npc.y"),
+                            config.getDouble("special-npc.z"),
+                            (float) config.getDouble("special-npc.yaw"),
+                            (float) config.getDouble("special-npc.pitch"));
+                    arena.setSpecialNpcLocation(loc);
+                }
+            }
             if (config.contains("teams")) {
                 for (String key : Objects.requireNonNull(config.getConfigurationSection("teams")).getKeys(false)) {
                     TeamColor color = TeamColor.valueOf(key.toUpperCase());
@@ -176,6 +188,15 @@ public class ArenaManager {
             config.set("lobby.z", loc.getZ());
             config.set("lobby.yaw", loc.getYaw());
             config.set("lobby.pitch", loc.getPitch());
+        }
+        if (arena.getSpecialNpcLocation() != null) {
+            Location loc = arena.getSpecialNpcLocation();
+            config.set("special-npc.world", Objects.requireNonNull(loc.getWorld()).getName());
+            config.set("special-npc.x", loc.getX());
+            config.set("special-npc.y", loc.getY());
+            config.set("special-npc.z", loc.getZ());
+            config.set("special-npc.yaw", loc.getYaw());
+            config.set("special-npc.pitch", loc.getPitch());
         }
         if (!arena.getTeams().isEmpty()) {
             for (Map.Entry<TeamColor, Team> entry : arena.getTeams().entrySet()) {

--- a/src/main/java/com/heneria/bedwars/managers/EventManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/EventManager.java
@@ -168,6 +168,10 @@ public class EventManager {
                         arena.getDragons().add(dragon);
                     }
                 }
+            } else if (event.getType() == GameEventType.SPAWN_SPECIAL_NPC) {
+                arena.spawnSpecialNpc();
+            } else if (event.getType() == GameEventType.DESPAWN_SPECIAL_NPC) {
+                arena.despawnSpecialNpc();
             }
             String msg = ChatColor.translateAlternateColorCodes('&', event.getMessage());
             for (UUID id : arena.getPlayers()) {

--- a/src/main/java/com/heneria/bedwars/managers/SpecialShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/SpecialShopManager.java
@@ -1,0 +1,77 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Loads and provides access to the special mid-game shop configuration
+ * defined in {@code special_shop.yml}.
+ */
+public class SpecialShopManager {
+
+    private final HeneriaBedwars plugin;
+    private String title = "Special Shop";
+    private int rows = 3;
+    private final Map<Integer, SpecialItem> items = new HashMap<>();
+
+    public SpecialShopManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        load();
+    }
+
+    private void load() {
+        File file = new File(plugin.getDataFolder(), "special_shop.yml");
+        if (!file.exists()) {
+            plugin.saveResource("special_shop.yml", false);
+        }
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        this.title = ChatColor.translateAlternateColorCodes('&', config.getString("title", title));
+        this.rows = config.getInt("rows", rows);
+        items.clear();
+        ConfigurationSection sec = config.getConfigurationSection("items");
+        if (sec != null) {
+            for (String key : sec.getKeys(false)) {
+                String base = "items." + key + ".";
+                try {
+                    Material material = Material.valueOf(config.getString(base + "material", "STONE"));
+                    String name = config.getString(base + "name", key);
+                    List<String> lore = config.getStringList(base + "lore");
+                    ResourceType resource = ResourceType.valueOf(config.getString(base + "cost.resource", "DIAMOND"));
+                    int cost = config.getInt(base + "cost.amount", 1);
+                    int slot = config.getInt(base + "slot", 0);
+                    String action = config.getString(base + "action");
+                    items.put(slot, new SpecialItem(material, name, lore, resource, cost, slot, action));
+                } catch (IllegalArgumentException ex) {
+                    plugin.getLogger().warning("Invalid special shop item: " + key);
+                }
+            }
+        }
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getRows() {
+        return rows;
+    }
+
+    public Map<Integer, SpecialItem> getItems() {
+        return items;
+    }
+
+    /**
+     * Represents an item sold in the special shop.
+     */
+    public record SpecialItem(Material material, String name, List<String> lore,
+                              ResourceType costResource, int costAmount, int slot, String action) {
+    }
+}
+

--- a/src/main/java/com/heneria/bedwars/setup/SetupType.java
+++ b/src/main/java/com/heneria/bedwars/setup/SetupType.java
@@ -9,5 +9,6 @@ public enum SetupType {
     TEAM_BED,
     GENERATOR,
     NPC_SHOP,
-    NPC_UPGRADE
+    NPC_UPGRADE,
+    SPECIAL_NPC
 }

--- a/src/main/resources/events.yml
+++ b/src/main/resources/events.yml
@@ -11,6 +11,14 @@ game-events:
     new-tier: 2
     broadcast-message: "&2Les générateurs d'Émeraudes ont été améliorés au Niveau II !"
 
+  - time: '15m'
+    type: 'SPAWN_SPECIAL_NPC'
+    broadcast-message: "&d&lUn Marchand Mystérieux est apparu au centre !"
+
+  - time: '18m'
+    type: 'DESPAWN_SPECIAL_NPC'
+    broadcast-message: "&dLe Marchand Mystérieux est parti !"
+
   - time: '30m'
     type: 'SUDDEN_DEATH'
     broadcast-message: "&c&lMORT SUBITE ! &fTous les lits restants ont été détruits !"

--- a/src/main/resources/special_shop.yml
+++ b/src/main/resources/special_shop.yml
@@ -1,0 +1,21 @@
+title: "&5Marchand Mystérieux"
+rows: 3
+items:
+  'iron-golem':
+    material: IRON_BLOCK
+    name: "&fGolem de Fer de Poche"
+    lore:
+      - "&7Posez ce bloc pour faire apparaître"
+      - "&7un Golem de Fer qui défendra votre île."
+    cost:
+      resource: DIAMOND
+      amount: 8
+    slot: 11
+    action: 'SPAWN_IRON_GOLEM'
+  'diamond-pickaxe':
+    material: DIAMOND_PICKAXE
+    name: "&bPioche en Diamant"
+    cost:
+      resource: EMERALD
+      amount: 4
+    slot: 15


### PR DESCRIPTION
## Summary
- add spawn/despawn events for a mid-game special merchant
- introduce special_shop.yml configuration and menu with unique items
- implement iron golem pocket item and related listeners

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a441a6e72c8329933e5a953340cbd6