### PR TITLE
fix(gameplay): Fix special shop, golem AI, dragon spawn, and hunger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [0.9.2] - En développement
 
+### Corrigé
+- Boutique spéciale : ajout des limites d'achat et remplacement de la Pioche en Diamant par la Super Boule de Feu.
+- Le Golem de Fer ne peut être posé que sur l'île de son propriétaire et cible maintenant les ennemis.
+- Correction de l'événement `SPAWN_DRAGONS` pour que les dragons apparaissent correctement.
+- Désactivation de la perte de faim pendant les parties.
+
 ### Ajouté
 - Ajout de l'achat d'outils et d'armures par paliers individuels dans la boutique d'objets.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
   - `scoreboard.yml` : Personnalisez le titre et les lignes du tableau de bord en jeu.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons).
-  - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie.
+  - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
 
 Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le plugin à n'importe quelle langue ou style.
@@ -171,7 +171,7 @@ game-events:
 
 ### Configuration du Marchand Mystérieux
 
-Le contenu de la boutique du PNJ spécial est défini dans le fichier `special_shop.yml` :
+Le contenu de la boutique du PNJ spécial est défini dans le fichier `special_shop.yml`. Chaque objet peut inclure un champ `purchase-limit` pour limiter le nombre d'achats par joueur :
 
 ```yaml
 title: "&5Marchand Mystérieux"
@@ -188,6 +188,15 @@ items:
       amount: 8
     slot: 11
     action: 'SPAWN_IRON_GOLEM'
+    purchase-limit: 1
+  super-fireball:
+    material: FIRE_CHARGE
+    name: "&cSuper Boule de Feu"
+    cost:
+      resource: EMERALD
+      amount: 4
+    slot: 15
+    purchase-limit: 3
 ```
 
 ### Configuration de la Base de Données

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -14,6 +14,7 @@ import com.heneria.bedwars.listeners.SpecialNpcListener;
 import com.heneria.bedwars.listeners.GolemListener;
 import com.heneria.bedwars.listeners.TrapListener;
 import com.heneria.bedwars.listeners.StatsListener;
+import com.heneria.bedwars.listeners.HungerListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -99,6 +100,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new GolemListener(), this);
         getServer().getPluginManager().registerEvents(new TrapListener(), this);
         getServer().getPluginManager().registerEvents(new StatsListener(), this);
+        getServer().getPluginManager().registerEvents(new HungerListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/gui/special/SpecialShopMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/special/SpecialShopMenu.java
@@ -6,6 +6,7 @@ import com.heneria.bedwars.managers.ResourceType;
 import com.heneria.bedwars.managers.SpecialShopManager;
 import com.heneria.bedwars.utils.ItemBuilder;
 import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -48,6 +49,9 @@ public class SpecialShopMenu extends Menu {
                 builder.addLore(line);
             }
             builder.addLore("&7Coût: &f" + item.costAmount() + " " + item.costResource().getDisplayName());
+            if (item.purchaseLimit() > 0) {
+                builder.addLore("&7Limite: &f" + item.purchaseLimit());
+            }
             ItemStack stack = builder.build();
             inventory.setItem(item.slot(), stack);
             slotItems.put(item.slot(), item);
@@ -72,6 +76,13 @@ public class SpecialShopMenu extends Menu {
         SpecialShopManager.SpecialItem item = slotItems.get(event.getRawSlot());
         if (item == null) {
             return;
+        }
+        Arena arena = HeneriaBedwars.getInstance().getArenaManager().getArena(player);
+        if (arena != null && item.purchaseLimit() > 0) {
+            if (!arena.canPurchase(player.getUniqueId(), item.id(), item.purchaseLimit())) {
+                player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 1f, 1f);
+                return;
+            }
         }
         ResourceType type = item.costResource();
         int price = item.costAmount();

--- a/src/main/java/com/heneria/bedwars/listeners/HungerListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/HungerListener.java
@@ -1,0 +1,27 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+
+/**
+ * Keeps players from losing hunger during active games.
+ */
+public class HungerListener implements Listener {
+
+    @EventHandler
+    public void onFoodChange(FoodLevelChangeEvent event) {
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+        Arena arena = HeneriaBedwars.getInstance().getArenaManager().getArena(player);
+        if (arena != null && arena.getState() == GameState.PLAYING) {
+            event.setCancelled(true);
+            player.setFoodLevel(20);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/EventManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/EventManager.java
@@ -8,9 +8,7 @@ import com.heneria.bedwars.events.GameEventType;
 import com.heneria.bedwars.events.TimedEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.Location;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.entity.EnderDragon;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -160,13 +158,10 @@ public class EventManager {
             } else if (event.getType() == GameEventType.SUDDEN_DEATH) {
                 arena.destroyAllBeds();
             } else if (event.getType() == GameEventType.SPAWN_DRAGONS) {
+                plugin.getLogger().info("EventManager: SPAWN_DRAGONS triggered for arena " + arena.getName());
                 int amount = Math.max(1, event.getAmount());
-                Location center = arena.getCenterLocation();
-                if (center != null) {
-                    for (int i = 0; i < amount; i++) {
-                        EnderDragon dragon = center.getWorld().spawn(center, EnderDragon.class);
-                        arena.getDragons().add(dragon);
-                    }
+                for (int i = 0; i < amount; i++) {
+                    arena.spawnDragon();
                 }
             } else if (event.getType() == GameEventType.SPAWN_SPECIAL_NPC) {
                 arena.spawnSpecialNpc();

--- a/src/main/java/com/heneria/bedwars/managers/SpecialShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/SpecialShopManager.java
@@ -47,7 +47,8 @@ public class SpecialShopManager {
                     int cost = config.getInt(base + "cost.amount", 1);
                     int slot = config.getInt(base + "slot", 0);
                     String action = config.getString(base + "action");
-                    items.put(slot, new SpecialItem(material, name, lore, resource, cost, slot, action));
+                    int limit = config.getInt(base + "purchase-limit", 0);
+                    items.put(slot, new SpecialItem(key, material, name, lore, resource, cost, slot, action, limit));
                 } catch (IllegalArgumentException ex) {
                     plugin.getLogger().warning("Invalid special shop item: " + key);
                 }
@@ -70,8 +71,8 @@ public class SpecialShopManager {
     /**
      * Represents an item sold in the special shop.
      */
-    public record SpecialItem(Material material, String name, List<String> lore,
-                              ResourceType costResource, int costAmount, int slot, String action) {
+    public record SpecialItem(String id, Material material, String name, List<String> lore,
+                              ResourceType costResource, int costAmount, int slot, String action, int purchaseLimit) {
     }
 }
 

--- a/src/main/resources/special_shop.yml
+++ b/src/main/resources/special_shop.yml
@@ -12,10 +12,12 @@ items:
       amount: 8
     slot: 11
     action: 'SPAWN_IRON_GOLEM'
-  'diamond-pickaxe':
-    material: DIAMOND_PICKAXE
-    name: "&bPioche en Diamant"
+    purchase-limit: 1
+  'super-fireball':
+    material: FIRE_CHARGE
+    name: "&cSuper Boule de Feu"
     cost:
       resource: EMERALD
       amount: 4
     slot: 15
+    purchase-limit: 3


### PR DESCRIPTION
## Summary
- limit special shop purchases and add super fireball option
- restrict and empower iron golems on player islands
- ensure dragons spawn and disable hunger during matches

## Testing
- ⚠️ `mvn -q -e package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a44cf6abd88329b787bd2d347719eb