### PR TITLE
feat(gameplay)!: Overhaul progression with permanent armor and temporary tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [1.0.0-BETA] - En développement
+
+### Ajouté
+- Refonte majeure du système de progression de l'équipement : les armures sont des améliorations permanentes, les outils/épées sont temporaires.
+
 ## [0.9.2] - En développement
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🧱 **Construction de Blocs** : Achetez, placez et cassez des blocs pour bâtir ponts et défenses.
 - 🛡️ **Kit de départ lié** : Vous réapparaissez avec une armure en cuir teintée aux couleurs de votre équipe et une épée en bois impossible à jeter.
 - 🌈 **Achats intelligents** : La laine achetée s'adapte automatiquement à la couleur de votre équipe et toute nouvelle épée remplace la précédente.
+- ⚒️ **Progression Hybride** : Achetez des paliers d'armure permanents pour la partie, mais perdez vos outils et épées améliorés à chaque mort.
 - 📊 **Tableau de Bord Dynamique** : Consultez en un coup d'œil l'état des équipes et le prochain événement.
 - 🛍️ **Marchand Mystérieux** : Un PNJ spécial apparaît au centre en milieu de partie pour vendre des objets uniques comme le Golem de Fer de Poche.
 - 🏆 **Conditions de Victoire** : La partie se termine automatiquement lorsque la dernière équipe en vie est déclarée vainqueur, et l'arène se réinitialise pour le prochain combat.
@@ -79,7 +80,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 
 ### Configuration de la Boutique d'Items
 
-La progression des outils et des armures se configure dans le fichier `shop.yml`. Chaque palier est un objet distinct possédant un bloc `upgrade_tier` indiquant son type (`PICKAXE`, `AXE`, `ARMOR`) et son niveau. Les objets partageant le même `slot` s'affichent progressivement au fur et à mesure des achats.
+La progression des outils et des armures se configure dans le fichier `shop.yml`. Chaque palier est un objet distinct possédant un bloc `upgrade_tier` indiquant son type (`PICKAXE`, `AXE`, `ARMOR`) et son niveau. Les objets partageant le même `slot` s'affichent progressivement au fur et à mesure des achats. Les armures achetées sont permanentes pour la durée de la partie alors que les outils et épées sont perdus à la mort.
 
 ```yaml
 tools_category:

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -545,6 +545,7 @@ public class Arena {
                 p.teleport(team.getSpawnLocation());
             }
             GameUtils.giveDefaultKit(p, team);
+            HeneriaBedwars.getInstance().getUpgradeManager().applyTeamUpgrades(p);
         }
         for (Generator gen : generators) {
             HeneriaBedwars.getInstance().getGeneratorManager().registerGenerator(gen);

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -19,6 +19,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.enchantments.Enchantment;
 
 import java.util.*;
 
@@ -134,6 +135,9 @@ public class ShopItemsMenu extends Menu {
             ItemStack give = new ItemStack(material, item.amount());
             ItemMeta meta = give.getItemMeta();
             if (meta != null) {
+                if (material.name().endsWith("_PICKAXE") || material.name().endsWith("_AXE")) {
+                    meta.addEnchant(Enchantment.DIG_SPEED, 1, true);
+                }
                 if (isSword) {
                     meta.getPersistentDataContainer().set(GameUtils.STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
                 }
@@ -185,7 +189,9 @@ public class ShopItemsMenu extends Menu {
                 progressionManager.setAxeTier(uuid, item.upgradeLevel());
             }
             case "ARMOR" -> {
-                clicker.getInventory().setBoots(give);
+                Arena arena = HeneriaBedwars.getInstance().getArenaManager().getArena(clicker);
+                Team team = arena != null ? arena.getTeam(clicker) : null;
+                GameUtils.equipArmorTier(clicker, team, item.upgradeLevel());
                 progressionManager.setArmorTier(uuid, item.upgradeLevel());
             }
             default -> clicker.getInventory().addItem(give);

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -20,6 +20,8 @@ import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.entity.EntityType;
 import org.bukkit.scheduler.BukkitRunnable;
 import com.heneria.bedwars.utils.GameUtils;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 
 public class GameListener implements Listener {
 
@@ -106,6 +108,17 @@ public class GameListener implements Listener {
         }
 
         if (playerTeam.hasBed()) {
+            // Remove temporary tools and swords
+            ItemStack[] contents = player.getInventory().getContents();
+            for (int i = 0; i < contents.length; i++) {
+                ItemStack item = contents[i];
+                if (item == null) continue;
+                String name = item.getType().name();
+                if ((name.endsWith("_SWORD") && item.getType() != Material.WOODEN_SWORD)
+                        || name.endsWith("_PICKAXE") || name.endsWith("_AXE")) {
+                    player.getInventory().setItem(i, null);
+                }
+            }
             plugin.getPlayerProgressionManager().resetProgress(player.getUniqueId());
             player.setGameMode(GameMode.SPECTATOR);
             player.teleport(playerTeam.getSpawnLocation());
@@ -120,6 +133,7 @@ public class GameListener implements Listener {
                         player.setGameMode(GameMode.SURVIVAL);
                         player.teleport(playerTeam.getSpawnLocation());
                         GameUtils.giveDefaultKit(player, playerTeam);
+                        plugin.getUpgradeManager().applyTeamUpgrades(player);
                     }
                 }
             }.runTaskTimer(plugin, 0L, 20L);

--- a/src/main/java/com/heneria/bedwars/managers/PlayerProgressionManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/PlayerProgressionManager.java
@@ -36,14 +36,14 @@ public class PlayerProgressionManager {
     }
 
     /**
-     * Resets progression tiers for a player.
+     * Resets temporary progression tiers (tools) for a player while preserving
+     * permanent upgrades like armor.
      *
      * @param uuid player's unique identifier
      */
     public void resetProgress(UUID uuid) {
         pickaxeTier.put(uuid, 0);
         axeTier.put(uuid, 0);
-        armorTier.put(uuid, 0);
     }
 
     public int getPickaxeTier(UUID uuid) {

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
@@ -9,6 +9,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
 
 import java.io.File;
 import java.util.*;
@@ -129,6 +131,42 @@ public class UpgradeManager {
      */
     public void applyTrapEffect(Player player, Trap trap) {
         player.addPotionEffect(new PotionEffect(trap.effectType(), trap.duration() * 20, trap.amplifier(), true, true, true));
+    }
+
+    /**
+     * Reapplies all team upgrades (sharpness, protection, haste) to the given player.
+     * Used on respawn to ensure equipment carries the proper enchantments.
+     *
+     * @param player the player to update
+     */
+    public void applyTeamUpgrades(Player player) {
+        Arena arena = plugin.getArenaManager().getArena(player);
+        if (arena == null) return;
+        Team team = arena.getTeam(player);
+        if (team == null) return;
+
+        int sharp = team.getUpgradeLevel("sharpness");
+        if (sharp > 0) {
+            for (ItemStack item : player.getInventory().getContents()) {
+                if (item != null && item.getType().name().endsWith("SWORD")) {
+                    applySharpness(item, sharp);
+                }
+            }
+        }
+
+        int prot = team.getUpgradeLevel("protection");
+        if (prot > 0) {
+            for (ItemStack item : player.getInventory().getArmorContents()) {
+                if (item != null) {
+                    applyProtection(item, prot);
+                }
+            }
+        }
+
+        int haste = team.getUpgradeLevel("haste");
+        if (haste > 0) {
+            applyHaste(player, haste - 1, 20 * 60 * 60);
+        }
     }
 
     public record Upgrade(String id, String name, Material item, Map<Integer, UpgradeTier> tiers) {

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -138,9 +138,9 @@ shop-categories:
     title: "Armures"
     rows: 3
     items:
-      'chainmail-boots':
-        material: CHAINMAIL_BOOTS
-        name: "&7Bottes en Mailles"
+      'chainmail-armor':
+        material: CHAINMAIL_CHESTPLATE
+        name: "&7Armure en Mailles"
         amount: 1
         cost:
           resource: IRON
@@ -149,9 +149,9 @@ shop-categories:
         upgrade_tier:
           type: 'ARMOR'
           level: 1
-      'iron-boots':
-        material: IRON_BOOTS
-        name: "&fBottes en Fer"
+      'iron-armor':
+        material: IRON_CHESTPLATE
+        name: "&fArmure en Fer"
         amount: 1
         cost:
           resource: GOLD
@@ -160,9 +160,9 @@ shop-categories:
         upgrade_tier:
           type: 'ARMOR'
           level: 2
-      'diamond-boots':
-        material: DIAMOND_BOOTS
-        name: "&bBottes en Diamant"
+      'diamond-armor':
+        material: DIAMOND_CHESTPLATE
+        name: "&bArmure en Diamant"
         amount: 1
         cost:
           resource: EMERALD


### PR DESCRIPTION
## Summary
- implement permanent armor tiers and temporary tools by tracking armor separately and re-equipping best tier on respawn
- apply team upgrades after each respawn and give pickaxes/axes Efficiency by default
- document progression overhaul in changelog and README

## Testing
- `mvn -q test` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4533d2e64832997b50b1989bab919