### PR TITLE
feat(gameplay)!: Overhaul progression system and fix API naming issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [1.0.0-BETA] - En développement
+
+### Modifié
+- Refonte majeure du système de progression de l'équipement et correction d'erreurs de compilation liées à l'API.
+
 ## [0.9.2] - En développement
 
 ### Corrigé

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -14,6 +14,7 @@ import com.heneria.bedwars.arena.elements.Team;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
@@ -176,11 +177,21 @@ public class ShopItemsMenu extends Menu {
         switch (type.toUpperCase()) {
             case "PICKAXE" -> {
                 removeTool(clicker, "_PICKAXE");
+                ItemMeta meta = give.getItemMeta();
+                if (meta != null) {
+                    meta.addEnchant(Enchantment.EFFICIENCY, 1, true);
+                    give.setItemMeta(meta);
+                }
                 clicker.getInventory().addItem(give);
                 progressionManager.setPickaxeTier(uuid, item.upgradeLevel());
             }
             case "AXE" -> {
                 removeTool(clicker, "_AXE");
+                ItemMeta meta = give.getItemMeta();
+                if (meta != null) {
+                    meta.addEnchant(Enchantment.EFFICIENCY, 1, true);
+                    give.setItemMeta(meta);
+                }
                 clicker.getInventory().addItem(give);
                 progressionManager.setAxeTier(uuid, item.upgradeLevel());
             }

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -120,6 +120,7 @@ public class GameListener implements Listener {
                         player.setGameMode(GameMode.SURVIVAL);
                         player.teleport(playerTeam.getSpawnLocation());
                         GameUtils.giveDefaultKit(player, playerTeam);
+                        plugin.getUpgradeManager().applyTeamUpgrades(player);
                     }
                 }
             }.runTaskTimer(plugin, 0L, 20L);

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
@@ -1,6 +1,8 @@
 package com.heneria.bedwars.managers;
 
 import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -129,6 +131,41 @@ public class UpgradeManager {
      */
     public void applyTrapEffect(Player player, Trap trap) {
         player.addPotionEffect(new PotionEffect(trap.effectType(), trap.duration() * 20, trap.amplifier(), true, true, true));
+    }
+
+    /**
+     * Reapplies all team upgrades to a player's equipment after respawn.
+     *
+     * @param player the player to update
+     */
+    public void applyTeamUpgrades(Player player) {
+        Arena arena = plugin.getArenaManager().getArena(player);
+        if (arena == null) return;
+        Team team = arena.getTeam(player);
+        if (team == null) return;
+
+        int sharpness = team.getUpgradeLevel("sharpness");
+        if (sharpness > 0) {
+            for (ItemStack item : player.getInventory().getContents()) {
+                if (item != null && item.getType().name().endsWith("SWORD")) {
+                    applySharpness(item, sharpness);
+                }
+            }
+        }
+
+        int protection = team.getUpgradeLevel("protection");
+        if (protection > 0) {
+            for (ItemStack armor : player.getInventory().getArmorContents()) {
+                if (armor != null) {
+                    applyProtection(armor, protection);
+                }
+            }
+        }
+
+        int haste = team.getUpgradeLevel("haste");
+        if (haste > 0) {
+            applyHaste(player, haste - 1, 20 * 60 * 60);
+        }
     }
 
     public record Upgrade(String id, String name, Material item, Map<Integer, UpgradeTier> tiers) {


### PR DESCRIPTION
## Summary
- Enchant purchased tools with the Spigot 1.21 `Enchantment.EFFICIENCY` constant
- Add `UpgradeManager.applyTeamUpgrades` and invoke after player respawn
- Document progression overhaul in the changelog

## Testing
- `mvn -q -e package` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4560236688329b1a4ac2d6e65501a