### PR TITLE
feat(gameplay)!: Final overhaul of progression with permanent armor and temporary tools/swords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.0.0-BETA] - En développement
 
 ### Modifié
-- Refonte majeure du système de progression de l'équipement et correction d'erreurs de compilation liées à l'API.
+- Refonte finale du système de progression de l'équipement : les armures sont des améliorations permanentes, les outils et épées sont des achats temporaires.
 
 ## [0.9.2] - En développement
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 💰 **Système Économique** : Collectez du Fer, de l'Or, des Diamants et des Émeraudes à des vitesses différentes pour acheter de l'équipement.
 - 🛒 **Boutiques Fonctionnelles** : Interagissez avec les PNJ pour acheter des objets dans la boutique d'items ou des améliorations permanentes pour votre équipe.
 - 🧱 **Construction de Blocs** : Achetez, placez et cassez des blocs pour bâtir ponts et défenses.
-- 🛡️ **Kit de départ lié** : Vous réapparaissez avec une armure en cuir teintée aux couleurs de votre équipe et une épée en bois impossible à jeter.
+ - 🛡️ **Kit de départ lié** : Vous réapparaissez avec une armure en cuir teintée aux couleurs de votre équipe ainsi qu'une épée, une pioche et une hache en bois impossibles à jeter.
+ - 🛡️ **Progression Hybride** : Les armures achetées sont conservées après la mort, tandis que les outils et épées doivent être rachetés.
 - 🌈 **Achats intelligents** : La laine achetée s'adapte automatiquement à la couleur de votre équipe et toute nouvelle épée remplace la précédente.
 - 📊 **Tableau de Bord Dynamique** : Consultez en un coup d'œil l'état des équipes et le prochain événement.
 - 🛍️ **Marchand Mystérieux** : Un PNJ spécial apparaît au centre en milieu de partie pour vendre des objets uniques comme le Golem de Fer de Poche.
@@ -79,7 +80,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 
 ### Configuration de la Boutique d'Items
 
-La progression des outils et des armures se configure dans le fichier `shop.yml`. Chaque palier est un objet distinct possédant un bloc `upgrade_tier` indiquant son type (`PICKAXE`, `AXE`, `ARMOR`) et son niveau. Les objets partageant le même `slot` s'affichent progressivement au fur et à mesure des achats.
+La boutique mélange améliorations permanentes et achats temporaires, tous définis dans le fichier `shop.yml`. Les armures (jambières et bottes) utilisent des paliers `upgrade_tier` de type `ARMOR` et sont conservées après la mort. Les pioches et haches sont vendues par paliers (`PICKAXE`, `AXE`) dont le niveau reste débloqué, mais l'outil doit être racheté après chaque mort. Les épées sont listées directement et sont toujours perdues à la mort.
 
 ```yaml
 tools_category:
@@ -104,7 +105,7 @@ tools_category:
         level: 2
 ```
 
-Seul le prochain palier disponible est proposé à l'achat.
+Seul le prochain palier disponible est proposé à l'achat. Après une mort, les joueurs réapparaissent avec leur meilleure armure débloquée mais uniquement les outils et armes en bois.
 
 ### Configuration des Pièges d'Équipe
 

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -196,7 +196,15 @@ public class ShopItemsMenu extends Menu {
                 progressionManager.setAxeTier(uuid, item.upgradeLevel());
             }
             case "ARMOR" -> {
-                clicker.getInventory().setBoots(give);
+                Material bootsType = give.getType();
+                clicker.getInventory().setBoots(GameUtils.createBoundArmor(bootsType));
+                Material leggingsType = switch (bootsType) {
+                    case CHAINMAIL_BOOTS -> Material.CHAINMAIL_LEGGINGS;
+                    case IRON_BOOTS -> Material.IRON_LEGGINGS;
+                    case DIAMOND_BOOTS -> Material.DIAMOND_LEGGINGS;
+                    default -> Material.LEATHER_LEGGINGS;
+                };
+                clicker.getInventory().setLeggings(GameUtils.createBoundArmor(leggingsType));
                 progressionManager.setArmorTier(uuid, item.upgradeLevel());
             }
             default -> clicker.getInventory().addItem(give);

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -106,7 +106,7 @@ public class GameListener implements Listener {
         }
 
         if (playerTeam.hasBed()) {
-            plugin.getPlayerProgressionManager().resetProgress(player.getUniqueId());
+            GameUtils.removeUpgradedToolsAndSwords(player);
             player.setGameMode(GameMode.SPECTATOR);
             player.teleport(playerTeam.getSpawnLocation());
             new BukkitRunnable() {

--- a/src/main/java/com/heneria/bedwars/utils/GameUtils.java
+++ b/src/main/java/com/heneria/bedwars/utils/GameUtils.java
@@ -2,6 +2,7 @@ package com.heneria.bedwars.utils;
 
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.managers.PlayerProgressionManager;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -44,7 +45,29 @@ public final class GameUtils {
                     createArmor(Material.LEATHER_HELMET, color)
             });
         }
+
+        PlayerProgressionManager progression = HeneriaBedwars.getInstance().getPlayerProgressionManager();
+        int armorTier = progression.getArmorTier(player.getUniqueId());
+        if (armorTier > 0) {
+            switch (armorTier) {
+                case 1 -> {
+                    player.getInventory().setBoots(createBoundArmor(Material.CHAINMAIL_BOOTS));
+                    player.getInventory().setLeggings(createBoundArmor(Material.CHAINMAIL_LEGGINGS));
+                }
+                case 2 -> {
+                    player.getInventory().setBoots(createBoundArmor(Material.IRON_BOOTS));
+                    player.getInventory().setLeggings(createBoundArmor(Material.IRON_LEGGINGS));
+                }
+                case 3 -> {
+                    player.getInventory().setBoots(createBoundArmor(Material.DIAMOND_BOOTS));
+                    player.getInventory().setLeggings(createBoundArmor(Material.DIAMOND_LEGGINGS));
+                }
+            }
+        }
+
         player.getInventory().addItem(createStarterSword());
+        player.getInventory().addItem(createStarterPickaxe());
+        player.getInventory().addItem(createStarterAxe());
         player.setLevel(0);
         player.setExp(0f);
     }
@@ -67,5 +90,49 @@ public final class GameUtils {
         meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
         item.setItemMeta(meta);
         return item;
+    }
+
+    private static ItemStack createStarterPickaxe() {
+        ItemStack item = new ItemStack(Material.WOODEN_PICKAXE);
+        ItemMeta meta = item.getItemMeta();
+        meta.setLore(Collections.singletonList(MessageManager.get("items.starter-lore")));
+        meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private static ItemStack createStarterAxe() {
+        ItemStack item = new ItemStack(Material.WOODEN_AXE);
+        ItemMeta meta = item.getItemMeta();
+        meta.setLore(Collections.singletonList(MessageManager.get("items.starter-lore")));
+        meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    public static ItemStack createBoundArmor(Material material) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.addEnchant(Enchantment.BINDING_CURSE, 1, true);
+            meta.setLore(Collections.singletonList(MessageManager.get("items.starter-lore")));
+            meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    public static void removeUpgradedToolsAndSwords(Player player) {
+        for (int i = 0; i < player.getInventory().getSize(); i++) {
+            ItemStack item = player.getInventory().getItem(i);
+            if (item == null) continue;
+            Material type = item.getType();
+            String name = type.name();
+            if ((name.endsWith("_SWORD") && type != Material.WOODEN_SWORD) ||
+                (name.endsWith("_PICKAXE") && type != Material.WOODEN_PICKAXE) ||
+                (name.endsWith("_AXE") && type != Material.WOODEN_AXE)) {
+                player.getInventory().setItem(i, null);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make armor upgrades persist through death while tools and swords reset to wood
- reapply team upgrades and spawn kit after deaths
- document new hybrid progression system and update changelog

## Testing
- `mvn -q -e -ntp test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*
- `mvn -q -e -ntp -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a45cbbc1a48329a33c698b2157baaf