### PR TITLE
fix(gameplay): Polish scoreboard, weather, golem damage, and bed interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - HeneriaBedwars
 
+## [1.0.0-RC] - En développement
+
+### Corrigé
+- Le scoreboard affiche désormais un nom d'événement lisible grâce au champ `display-name`.
+- La météo est forcée sur un temps clair et le cycle de pluie est désactivé dans les arènes.
+- Les dégâts du Golem de Fer sont maintenant configurables via `mobs.iron-golem.damage`.
+- Les joueurs ne peuvent plus interagir avec les lits pour dormir pendant une partie.
+
 ## [1.0.0-BETA] - En développement
 
 ### Modifié

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
   - `scoreboard.yml` : Personnalisez le titre et les lignes du tableau de bord en jeu.
-  - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons).
+  - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
+  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`).
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
 
@@ -136,10 +137,11 @@ game-events:
     type: 'UPGRADE_GENERATORS'
     targets: [DIAMOND]
     new-tier: 2
+    display-name: "&bDiamants II"
     broadcast-message: "&bLes générateurs de Diamants ont été améliorés au Niveau II !"
 ```
 
-Chaque entrée peut préciser un temps (`time`), le type d'événement (`type`), les cibles (`targets`), le nouveau niveau (`new-tier`) et le message diffusé aux joueurs.
+Chaque entrée peut préciser un temps (`time`), le type d'événement (`type`), les cibles (`targets`), le nouveau niveau (`new-tier`), un nom d'affichage (`display-name`) utilisé par le scoreboard, et le message diffusé aux joueurs.
 
 Les types disponibles incluent :
 
@@ -216,6 +218,19 @@ database:
     password: ""
     useSSL: false
 ```
+
+
+### Configuration des Mobs
+
+Le fichier `config.yml` permet aussi d'ajuster certains paramètres d'équilibrage :
+
+```yaml
+mobs:
+  iron-golem:
+    damage: 4.0
+```
+
+Cette valeur contrôle les dégâts infligés par les Golems de Fer invoqués par les joueurs.
 
 
 ---

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -21,6 +21,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.EnderDragon;
+import org.bukkit.World;
+import org.bukkit.GameRule;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -534,6 +536,12 @@ public class Arena {
         if (countdownTask != null) {
             countdownTask.cancel();
             countdownTask = null;
+        }
+        World world = Bukkit.getWorld(worldName);
+        if (world != null) {
+            world.setGameRule(GameRule.DO_WEATHER_CYCLE, false);
+            world.setStorm(false);
+            world.setThundering(false);
         }
         for (UUID id : players) {
             Player p = Bukkit.getPlayer(id);

--- a/src/main/java/com/heneria/bedwars/events/TimedEvent.java
+++ b/src/main/java/com/heneria/bedwars/events/TimedEvent.java
@@ -13,19 +13,21 @@ public class TimedEvent {
     private final GameEventType type;
     private final List<GeneratorType> targets;
     private final int newTier;
+    private final String displayName;
     private final String message;
     private final int amount;
     private final String location;
 
-    public TimedEvent(int time, GameEventType type, List<GeneratorType> targets, int newTier, String message) {
-        this(time, type, targets, newTier, message, 0, null);
+    public TimedEvent(int time, GameEventType type, List<GeneratorType> targets, int newTier, String message, String displayName) {
+        this(time, type, targets, newTier, message, displayName, 0, null);
     }
 
-    public TimedEvent(int time, GameEventType type, List<GeneratorType> targets, int newTier, String message, int amount, String location) {
+    public TimedEvent(int time, GameEventType type, List<GeneratorType> targets, int newTier, String message, String displayName, int amount, String location) {
         this.time = time;
         this.type = type;
         this.targets = targets;
         this.newTier = newTier;
+        this.displayName = displayName;
         this.message = message;
         this.amount = amount;
         this.location = location;
@@ -45,6 +47,10 @@ public class TimedEvent {
 
     public int getNewTier() {
         return newTier;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 
     public String getMessage() {

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -11,6 +11,7 @@ import com.heneria.bedwars.stats.PlayerStats;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.GameMode;
 import org.bukkit.block.Block;
+import org.bukkit.block.data.type.Bed;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -18,6 +19,8 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.entity.EntityType;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.block.Action;
 import org.bukkit.scheduler.BukkitRunnable;
 import com.heneria.bedwars.utils.GameUtils;
 
@@ -35,6 +38,23 @@ public class GameListener implements Listener {
             Arena arena = event.getArena();
             arena.registerBeds();
         }
+    }
+
+    @EventHandler
+    public void onBedInteract(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        Block block = event.getClickedBlock();
+        if (block == null || !(block.getBlockData() instanceof Bed)) {
+            return;
+        }
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        event.setCancelled(true);
     }
 
     @EventHandler

--- a/src/main/java/com/heneria/bedwars/listeners/GolemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GolemListener.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
 /**
  * Prevents team-owned golems from targeting their owners.
@@ -34,6 +35,20 @@ public class GolemListener implements Listener {
         String tag = "team_" + team.getColor().name();
         if (golem.getScoreboardTags().contains(tag)) {
             event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof IronGolem golem)) {
+            return;
+        }
+        for (String tag : golem.getScoreboardTags()) {
+            if (tag.startsWith("team_")) {
+                double damage = HeneriaBedwars.getInstance().getConfig().getDouble("mobs.iron-golem.damage", 4.0);
+                event.setDamage(damage);
+                break;
+            }
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/managers/EventManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/EventManager.java
@@ -50,9 +50,10 @@ public class EventManager {
                 }
                 int tier = map.get("new-tier") instanceof Number n ? n.intValue() : 1;
                 String message = map.get("broadcast-message") == null ? "" : String.valueOf(map.get("broadcast-message"));
+                String displayName = map.get("display-name") == null ? null : String.valueOf(map.get("display-name"));
                 int amount = map.get("amount") instanceof Number a ? a.intValue() : (type == GameEventType.SPAWN_DRAGONS ? 1 : 0);
                 String location = map.get("location") == null ? null : String.valueOf(map.get("location"));
-                templateEvents.add(new TimedEvent(time, type, targets, tier, message, amount, location));
+                templateEvents.add(new TimedEvent(time, type, targets, tier, message, displayName, amount, location));
             }
             templateEvents.sort(Comparator.comparingInt(TimedEvent::getTime));
         }
@@ -90,6 +91,9 @@ public class EventManager {
         TimedEvent ev = task.next;
         if (ev == null) {
             return "N/A";
+        }
+        if (ev.getDisplayName() != null && !ev.getDisplayName().isEmpty()) {
+            return ev.getDisplayName();
         }
         if (ev.getType() == GameEventType.UPGRADE_GENERATORS && !ev.getTargets().isEmpty()) {
             GeneratorType type = ev.getTargets().get(0);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,12 +2,16 @@ void-kill-height: 0
 trap-radius: 10
 
 database:
-  type: sqlite # sqlite or mysql
-  save-interval: 5 # minutes between automatic saves
-  mysql:
-    host: localhost
-    port: 3306
-    database: bedwars
-    username: root
-    password: ""
-    useSSL: false
+    type: sqlite # sqlite or mysql
+    save-interval: 5 # minutes between automatic saves
+    mysql:
+      host: localhost
+      port: 3306
+      database: bedwars
+      username: root
+      password: ""
+      useSSL: false
+
+mobs:
+  iron-golem:
+    damage: 4.0

--- a/src/main/resources/events.yml
+++ b/src/main/resources/events.yml
@@ -3,28 +3,34 @@ game-events:
     type: 'UPGRADE_GENERATORS'
     targets: [DIAMOND]
     new-tier: 2
+    display-name: "&bDiamants II"
     broadcast-message: "&bLes générateurs de Diamants ont été améliorés au Niveau II !"
 
   - time: '12m'
     type: 'UPGRADE_GENERATORS'
     targets: [EMERALD]
     new-tier: 2
+    display-name: "&2Émeraudes II"
     broadcast-message: "&2Les générateurs d'Émeraudes ont été améliorés au Niveau II !"
 
   - time: '15m'
     type: 'SPAWN_SPECIAL_NPC'
+    display-name: "&dMarchand Spécial"
     broadcast-message: "&d&lUn Marchand Mystérieux est apparu au centre !"
 
   - time: '18m'
     type: 'DESPAWN_SPECIAL_NPC'
+    display-name: "&dMarchand Parti"
     broadcast-message: "&dLe Marchand Mystérieux est parti !"
 
   - time: '30m'
     type: 'SUDDEN_DEATH'
+    display-name: "&cMort Subite"
     broadcast-message: "&c&lMORT SUBITE ! &fTous les lits restants ont été détruits !"
 
   - time: '31m'
     type: 'SPAWN_DRAGONS'
+    display-name: "&cDragons"
     # Paramètres optionnels
     # amount: 1 # Nombre de dragons
     # location: 'CENTER' # ou des coordonnées spécifiques


### PR DESCRIPTION
## Summary
- use `display-name` from `events.yml` so the scoreboard shows friendly event names
- lock arena weather to clear skies
- make iron golem damage configurable and block bed interactions during matches

## Testing
- `mvn -q package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4691d91f48329831420ea535e0ec8