### PR TITLE
feat: enhance map reset, add build boundaries, and improve void kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - HeneriaBedwars
 
+## [1.0.0-RC2] - En développement
+
+### Ajouté
+- Réinitialisation complète de la carte avec restauration des lits et nettoyage des items.
+- Limites de construction configurables par arène.
+- Mort instantanée sous le niveau du vide via un listener prioritaire.
+
 ## [1.0.0-RC] - En développement
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 5.  Utilisez les différentes options et l'outil de positionnement pour définir le lobby, les équipes (lits, spawns, PNJ) et les générateurs.
 6.  Quand tout est prêt, cliquez sur **"Activer l'Arène"** pour la rendre accessible aux joueurs.
 
+### Limites de Construction
+
+Définissez une zone de jeu sûre pour empêcher les constructions abusives. Dans chaque fichier d'arène, ajoutez une section `boundaries` :
+
+```yaml
+boundaries:
+  min-x: -50
+  max-x: 50
+  min-y: 0
+  max-y: 100
+  min-z: -50
+  max-z: 50
+```
+
+Toute tentative de placement de bloc en dehors de cette zone sera refusée.
+
 ### Configuration de la Boutique d'Items
 
 La boutique mélange améliorations permanentes et achats temporaires, tous définis dans le fichier `shop.yml`. Les armures (jambières et bottes) utilisent des paliers `upgrade_tier` de type `ARMOR` et sont conservées après la mort. Les pioches et haches sont vendues par paliers (`PICKAXE`, `AXE`) dont le niveau reste débloqué, mais l'outil doit être racheté après chaque mort. Les épées sont listées directement et sont toujours perdues à la mort.

--- a/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.enums.GameState;
 import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -25,6 +26,11 @@ public class BlockPlaceListener implements Listener {
             return;
         }
         Block block = event.getBlockPlaced();
+        if (!arena.isWithinBoundaries(block.getX(), block.getY(), block.getZ())) {
+            event.setCancelled(true);
+            MessageManager.sendMessage(player, "errors.out-of-bounds");
+            return;
+        }
         arena.getPlacedBlocks().add(block);
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -4,7 +4,6 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.elements.Team;
 import com.heneria.bedwars.arena.enums.GameState;
-import com.heneria.bedwars.events.GameStateChangeEvent;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.StatsManager;
 import com.heneria.bedwars.stats.PlayerStats;
@@ -29,16 +28,6 @@ public class GameListener implements Listener {
     private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
     private final ArenaManager arenaManager = plugin.getArenaManager();
     private final StatsManager statsManager = plugin.getStatsManager();
-
-    // Quand le jeu démarre, on doit enregistrer les lits
-    // CECI EST UN NOUVEL ÉVÉNEMENT A AJOUTER
-    @EventHandler
-    public void onGameStateChange(GameStateChangeEvent event) {
-        if (event.getNewState() == GameState.PLAYING) {
-            Arena arena = event.getArena();
-            arena.registerBeds();
-        }
-    }
 
     @EventHandler
     public void onBedInteract(PlayerInteractEvent event) {

--- a/src/main/java/com/heneria/bedwars/listeners/VoidKillListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/VoidKillListener.java
@@ -6,6 +6,7 @@ import com.heneria.bedwars.arena.enums.GameState;
 import com.heneria.bedwars.managers.ArenaManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 
@@ -21,14 +22,22 @@ public class VoidKillListener implements Listener {
         this.voidKillHeight = HeneriaBedwars.getInstance().getConfig().getInt("void-kill-height", 0);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onMove(PlayerMoveEvent event) {
+        if (event.getTo() == null) {
+            return;
+        }
+        if (event.getTo().getBlockX() == event.getFrom().getBlockX()
+                && event.getTo().getBlockY() == event.getFrom().getBlockY()
+                && event.getTo().getBlockZ() == event.getFrom().getBlockZ()) {
+            return;
+        }
         Player player = event.getPlayer();
         Arena arena = arenaManager.getArenaByPlayer(player.getUniqueId());
         if (arena == null || arena.getState() != GameState.PLAYING) {
             return;
         }
-        if (player.getLocation().getY() < voidKillHeight) {
+        if (event.getTo().getY() < voidKillHeight) {
             player.setHealth(0.0);
         }
     }

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -81,6 +81,15 @@ public class ArenaManager {
                     arena.setSpecialNpcLocation(loc);
                 }
             }
+            if (config.contains("boundaries")) {
+                arena.setBoundaries(
+                        config.getInt("boundaries.min-x"),
+                        config.getInt("boundaries.max-x"),
+                        config.getInt("boundaries.min-y"),
+                        config.getInt("boundaries.max-y"),
+                        config.getInt("boundaries.min-z"),
+                        config.getInt("boundaries.max-z"));
+            }
             if (config.contains("teams")) {
                 for (String key : Objects.requireNonNull(config.getConfigurationSection("teams")).getKeys(false)) {
                     TeamColor color = TeamColor.valueOf(key.toUpperCase());
@@ -197,6 +206,14 @@ public class ArenaManager {
             config.set("special-npc.z", loc.getZ());
             config.set("special-npc.yaw", loc.getYaw());
             config.set("special-npc.pitch", loc.getPitch());
+        }
+        if (arena.hasBoundaries()) {
+            config.set("boundaries.min-x", arena.getMinX());
+            config.set("boundaries.max-x", arena.getMaxX());
+            config.set("boundaries.min-y", arena.getMinY());
+            config.set("boundaries.max-y", arena.getMaxY());
+            config.set("boundaries.min-z", arena.getMinZ());
+            config.set("boundaries.max-z", arena.getMaxZ());
         }
         if (!arena.getTeams().isEmpty()) {
             for (Map.Entry<TeamColor, Team> entry : arena.getTeams().entrySet()) {

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -19,6 +19,7 @@ errors:
   lobby-not-set: "&cLe lobby n'est pas défini."
   team-incomplete: "&cToutes les équipes n'ont pas leur spawn et leur lit définis."
   no-teams-configured: "&cAucune équipe configurée."
+  out-of-bounds: "&cVous ne pouvez pas construire en dehors de la zone de jeu."
 
 commands:
   main-usage: "&eUsage: /{label} <admin|join|leave>"


### PR DESCRIPTION
## Summary
- restore original beds and purge dropped items when resetting arenas
- enforce per-arena build boundaries configurable via YAML
- prioritize void kill checks for instant death below configured height

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a46bf753b08329b4d010ddcb69ad5b