### PR TITLE
feat(game): Implement map reset improvements, build boundaries, and void kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - HeneriaBedwars
 
+## [1.0.0-RC2] - En développement
+
+### Ajouté
+- Réinitialisation complète des arènes avec restauration des lits et nettoyage des items.
+- Limites de construction configurables par arène via `boundaries.max-y`.
+- Mort instantanée dans le vide grâce à `void-kill-height`.
+
+### Corrigé
+- Mise à jour de l'API Spigot : remplacement de `EntityType.DROPPED_ITEM` par `EntityType.ITEM`.
+
 ## [1.0.0-RC] - En développement
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -202,6 +202,17 @@ items:
     purchase-limit: 3
 ```
 
+### Limites de Construction de l'Arène
+
+Chaque arène peut définir une hauteur maximale de construction pour éviter les abus. Dans le fichier `arenas/<nom>.yml`, ajoutez:
+
+```yaml
+boundaries:
+  max-y: 150
+```
+
+Tout bloc placé au-dessus de cette limite sera automatiquement annulé côté serveur.
+
 ### Configuration de la Base de Données
 
 Les statistiques des joueurs sont sauvegardées dans une base de données configurée via `config.yml` :

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -15,6 +15,7 @@ import com.heneria.bedwars.listeners.GolemListener;
 import com.heneria.bedwars.listeners.TrapListener;
 import com.heneria.bedwars.listeners.StatsListener;
 import com.heneria.bedwars.listeners.HungerListener;
+import com.heneria.bedwars.listeners.VoidKillListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -101,6 +102,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new TrapListener(), this);
         getServer().getPluginManager().registerEvents(new StatsListener(), this);
         getServer().getPluginManager().registerEvents(new HungerListener(), this);
+        getServer().getPluginManager().registerEvents(new VoidKillListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.enums.GameState;
 import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -25,6 +26,11 @@ public class BlockPlaceListener implements Listener {
             return;
         }
         Block block = event.getBlockPlaced();
+        if (arena.getMaxBuildY() > 0 && block.getY() > arena.getMaxBuildY()) {
+            event.setCancelled(true);
+            MessageManager.sendMessage(player, "errors.build-outside-boundaries");
+            return;
+        }
         arena.getPlacedBlocks().add(block);
     }
 }

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -57,6 +57,9 @@ public class ArenaManager {
             if (config.contains("maxPlayers")) {
                 arena.setMaxPlayers(config.getInt("maxPlayers"));
             }
+            if (config.contains("boundaries.max-y")) {
+                arena.setMaxBuildY(config.getInt("boundaries.max-y"));
+            }
             if (config.contains("lobby.world")) {
                 World world = Bukkit.getWorld(config.getString("lobby.world"));
                 if (world != null) {
@@ -180,6 +183,7 @@ public class ArenaManager {
         config.set("enabled", arena.isEnabled());
         config.set("minPlayers", arena.getMinPlayers());
         config.set("maxPlayers", arena.getMaxPlayers());
+        config.set("boundaries.max-y", arena.getMaxBuildY());
         if (arena.getLobbyLocation() != null) {
             Location loc = arena.getLobbyLocation();
             config.set("lobby.world", Objects.requireNonNull(loc.getWorld()).getName());

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -19,6 +19,7 @@ errors:
   lobby-not-set: "&cLe lobby n'est pas défini."
   team-incomplete: "&cToutes les équipes n'ont pas leur spawn et leur lit définis."
   no-teams-configured: "&cAucune équipe configurée."
+  build-outside-boundaries: "&cVous ne pouvez pas construire en dehors de la zone autorisée."
 
 commands:
   main-usage: "&eUsage: /{label} <admin|join|leave>"


### PR DESCRIPTION
## Summary
- restore beds and clear dropped items when resetting arenas
- enforce per-arena build height limits
- kill players instantly when falling into the void

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a46eafb81c8329aea34a097591ddb0