### PR TITLE
feat(ui): Implement state-aware lobby and game scoreboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Réinitialisation complète des arènes avec restauration des lits et nettoyage des items.
 - Limites de construction configurables par arène via `boundaries.max-y`.
 - Mort instantanée dans le vide grâce à `void-kill-height`.
+- Ajout d'un scoreboard distinct et configurable pour le lobby d'attente.
 
 ### Corrigé
 - Mise à jour de l'API Spigot : remplacement de `EntityType.DROPPED_ITEM` par `EntityType.ITEM`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `generators.yml` : Réglez la vitesse et la quantité de chaque générateur de ressources.
   - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
-  - `scoreboard.yml` : Personnalisez le titre et les lignes du tableau de bord en jeu.
+  - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby d'attente et de la partie via les sections `lobby` et `game`.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
   - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`).
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
@@ -200,6 +200,46 @@ items:
       amount: 4
     slot: 15
     purchase-limit: 3
+```
+
+### Configuration du Scoreboard
+
+Le fichier `scoreboard.yml` est divisé en deux sections : `lobby` pour le lobby d'attente et `game` pour la partie. Chaque section possède son propre `title` et sa liste de `lines`, avec des placeholders dédiés.
+
+- **Lobby :** `{date}`, `{map_name}`, `{current_players}`, `{max_players}`, `{status}`
+- **Jeu :** `{date}`, `{next_event_name}`, `{next_event_time}`, `{team_status}`
+
+Exemple complet :
+
+```yaml
+# Scoreboard pour le lobby d'attente
+lobby:
+  title: "&b&lHeneria BedWars"
+  lines:
+    - "&7{date}"
+    - "&1"
+    - "Carte: &a{map_name}"
+    - "&2"
+    - "Joueurs: &a{current_players}/{max_players}"
+    - "&3"
+    - "&e{status}"
+    - "&4"
+    - "&eheneria.com"
+
+# Scoreboard pour la partie en cours
+game:
+  title: "&b&lHeneria BedWars"
+  lines:
+    - "&7{date}"
+    - "&1"
+    - "Prochain événement:"
+    - "&a{next_event_name} &fen &a{next_event_time}"
+    - "&2"
+    - "{team_status}"
+    - "&3"
+    - "&eheneria.com"
+
+team-line-format: "{team_color_code}{team_icon} {team_bed_status} &f{team_players_alive} {you_marker}"
 ```
 
 ### Limites de Construction de l'Arène

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -63,6 +63,7 @@ public class Arena {
     private final Map<UUID, Map<String, Integer>> purchaseCounts = new HashMap<>();
     private BukkitTask countdownTask;
     private int countdownDuration = 10;
+    private int countdownTime;
     private int maxBuildY = 256;
 
     /**
@@ -180,6 +181,10 @@ public class Arena {
 
     public void setMaxBuildY(int maxBuildY) {
         this.maxBuildY = maxBuildY;
+    }
+
+    public int getCountdownTime() {
+        return countdownTime;
     }
 
     /**
@@ -500,27 +505,27 @@ public class Arena {
 
     private void startCountdown() {
         state = GameState.STARTING;
+        countdownTime = countdownDuration;
         final int total = countdownDuration;
         countdownTask = new BukkitRunnable() {
-            int time = total;
 
             @Override
             public void run() {
-                if (time <= 0) {
+                if (countdownTime <= 0) {
                     cancel();
                     startGame();
                     return;
                 }
-                broadcast("game.countdown", "time", String.valueOf(time));
+                broadcast("game.countdown", "time", String.valueOf(countdownTime));
                 for (UUID id : players) {
                     Player p = Bukkit.getPlayer(id);
                     if (p != null) {
-                        p.setLevel(time);
-                        p.setExp((float) time / total);
-                        MessageManager.sendTitle(p, "game.countdown-title", "game.countdown-subtitle", 0, 20, 0, "time", String.valueOf(time));
+                        p.setLevel(countdownTime);
+                        p.setExp((float) countdownTime / total);
+                        MessageManager.sendTitle(p, "game.countdown-title", "game.countdown-subtitle", 0, 20, 0, "time", String.valueOf(countdownTime));
                     }
                 }
-                time--;
+                countdownTime--;
             }
         }.runTaskTimer(HeneriaBedwars.getInstance(), 0L, 20L);
     }
@@ -531,6 +536,7 @@ public class Arena {
             countdownTask = null;
         }
         state = GameState.WAITING;
+        countdownTime = 0;
         for (UUID id : players) {
             Player p = Bukkit.getPlayer(id);
             if (p != null) {
@@ -546,6 +552,7 @@ public class Arena {
      */
     public void startGame() {
         state = GameState.PLAYING;
+        countdownTime = 0;
         Bukkit.getPluginManager().callEvent(new GameStateChangeEvent(this, GameState.PLAYING));
         if (countdownTask != null) {
             countdownTask.cancel();

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -94,6 +94,8 @@ scoreboard:
   bed-alive: "&a✔"
   bed-destroyed: "&c❌"
   you-marker: "&e(VOUS)"
+  lobby-waiting: "En attente de joueurs..."
+  lobby-starting: "Démarrage dans {time} seconde(s)..."
 
 stats:
   format:

--- a/src/main/resources/scoreboard.yml
+++ b/src/main/resources/scoreboard.yml
@@ -1,26 +1,29 @@
-title: "&b&lHeneria BedWars"
+# Scoreboard pour le lobby d'attente
+lobby:
+  title: "&b&lHeneria BedWars"
+  lines:
+    - "&7{date}"
+    - "&1"
+    - "Carte: &a{map_name}"
+    - "&2"
+    - "Joueurs: &a{current_players}/{max_players}"
+    - "&3"
+    - "&e{status}"
+    - "&4"
+    - "&eheneria.com"
 
-# Placeholders disponibles:
-# {date} -> Date actuelle
-# {next_event_name} -> Nom du prochain événement (ex: Diamond II)
-# {next_event_time} -> Temps avant le prochain événement
-# {team_status} -> Bloc de lignes pour chaque équipe
+# Scoreboard pour la partie en cours
+game:
+  title: "&b&lHeneria BedWars"
+  lines:
+    - "&7{date}"
+    - "&1"
+    - "Prochain événement:"
+    - "&a{next_event_name} &fen &a{next_event_time}"
+    - "&2"
+    - "{team_status}"
+    - "&3"
+    - "&eheneria.com"
 
-lines:
-  - "&7{date}"
-  - "&1"
-  - "Prochain événement:"
-  - "&a{next_event_name} &fdans &d{next_event_time}"
-  - "&2"
-  - "{team_status}"
-  - "&3"
-  - "&eheneria.com"
-
-# Format pour chaque ligne d'équipe dans {team_status}
-# Placeholders:
-# {team_color_code} -> Code couleur (ex: §c)
-# {team_icon} -> Icône de l'équipe (ex: R)
-# {team_bed_status} -> Statut du lit (✔ ou ❌)
-# {team_players_alive} -> Nombre de joueurs en vie
-# {you_marker} -> Affiche '(VOUS)' si c'est l'équipe du joueur
+# (La section team-line-format reste la même)
 team-line-format: "{team_color_code}{team_icon} {team_bed_status} &f{team_players_alive} {you_marker}"


### PR DESCRIPTION
## Summary
- add distinct lobby/game sections and placeholders to `scoreboard.yml`
- switch scoreboard layout based on arena state and support lobby placeholders
- track countdown time for dynamic lobby status messages

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4707471e48329adf622e7466cdcda