### PR TITLE
HBW-084: add generator holograms via DecentHolograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [1.0.0-RC3] - En développement
+
+### Ajouté
+- Ajout d'hologrammes informatifs au-dessus des générateurs de Diamants et d'Émeraudes grâce à l'intégration optionnelle avec DecentHolograms.
+
 ## [1.0.0-RC2] - En développement
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
  - 🛡️ **Progression Hybride** : Les armures achetées sont conservées après la mort, tandis que les outils et épées doivent être rachetés.
 - 🌈 **Achats intelligents** : La laine achetée s'adapte automatiquement à la couleur de votre équipe et toute nouvelle épée remplace la précédente.
 - 📊 **Tableau de Bord Dynamique** : Consultez en un coup d'œil l'état des équipes et le prochain événement.
+- 📡 **Hologrammes de Générateur** : Des textes flottants indiquent le prochain spawn de Diamants et d'Émeraudes (avec le plugin optionnel **DecentHolograms**).
 - 🛍️ **Marchand Mystérieux** : Un PNJ spécial apparaît au centre en milieu de partie pour vendre des objets uniques comme le Golem de Fer de Poche.
 - 🏆 **Conditions de Victoire** : La partie se termine automatiquement lorsque la dernière équipe en vie est déclarée vainqueur, et l'arène se réinitialise pour le prochain combat.
 
@@ -44,9 +45,10 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 ## 🚀 Installation
 
 1.  Téléchargez la dernière version du plugin depuis la page [Releases](https://github.com/tomashb/HeneriaBW/releases).
-2.  Placez le fichier `.jar` téléchargé dans le dossier `plugins` de votre serveur Spigot 1.21.
-3.  Redémarrez votre serveur.
-4.  Les fichiers de configuration par défaut seront générés dans le dossier `plugins/HeneriaBedwars/`.
+2.  *(Optionnel mais recommandé)* Téléchargez et installez également le plugin **DecentHolograms** pour afficher les hologrammes des générateurs.
+3.  Placez le(s) fichier(s) `.jar` dans le dossier `plugins` de votre serveur Spigot 1.21.
+4.  Redémarrez votre serveur.
+5.  Les fichiers de configuration par défaut seront générés dans le dossier `plugins/HeneriaBedwars/`.
 
 ---
 
@@ -281,8 +283,24 @@ mobs:
     damage: 4.0
 ```
 
-Cette valeur contrôle les dégâts infligés par les Golems de Fer invoqués par les joueurs.
+ Cette valeur contrôle les dégâts infligés par les Golems de Fer invoqués par les joueurs.
 
+### Configuration des Hologrammes de Générateur
+
+La section `generator-holograms` de `config.yml` permet de personnaliser le texte et la hauteur des hologrammes des générateurs. Le placeholder `{time}` est remplacé par le temps restant avant la prochaine apparition.
+
+```yaml
+generator-holograms:
+  enabled: true
+  offset-y: 2.5 # Hauteur de l'hologramme au-dessus du générateur
+  formats:
+    DIAMOND:
+      - "&b&lDiamants"
+      - "&fApparaît dans &a{time}s"
+    EMERALD:
+      - "&2&lÉmeraudes"
+      - "&fApparaît dans &a{time}s"
+```
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,16 +48,20 @@
         </resources>
     </build>
 
-    <repositories>
-        <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-            <id>placeholderapi</id>
-            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
-        </repository>
-    </repositories>
+      <repositories>
+          <repository>
+              <id>spigot-repo</id>
+              <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+          </repository>
+          <repository>
+              <id>placeholderapi</id>
+              <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+          </repository>
+          <repository>
+              <id>decentholograms</id>
+              <url>https://repo.decentholograms.eu/repository/maven-releases/</url>
+          </repository>
+      </repositories>
 
     <dependencies>
         <dependency>
@@ -76,11 +80,17 @@
             <artifactId>mysql-connector-j</artifactId>
             <version>8.3.0</version>
         </dependency>
-        <dependency>
-            <groupId>me.clip</groupId>
-            <artifactId>placeholderapi</artifactId>
-            <version>2.11.5</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-</project>
+          <dependency>
+              <groupId>me.clip</groupId>
+              <artifactId>placeholderapi</artifactId>
+              <version>2.11.5</version>
+              <scope>provided</scope>
+          </dependency>
+          <dependency>
+              <groupId>eu.decentsoftware.holograms</groupId>
+              <artifactId>DecentHolograms</artifactId>
+              <version>2.8.3</version>
+              <scope>provided</scope>
+          </dependency>
+      </dependencies>
+  </project>

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -19,6 +19,7 @@ import com.heneria.bedwars.listeners.VoidKillListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
+import com.heneria.bedwars.managers.HologramManager;
 import com.heneria.bedwars.managers.ShopManager;
 import com.heneria.bedwars.managers.SpecialShopManager;
 import com.heneria.bedwars.managers.UpgradeManager;
@@ -37,6 +38,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private ArenaManager arenaManager;
     private SetupManager setupManager;
     private GeneratorManager generatorManager;
+    private HologramManager hologramManager;
     private ShopManager shopManager;
     private SpecialShopManager specialShopManager;
     private UpgradeManager upgradeManager;
@@ -59,6 +61,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.arenaManager = new ArenaManager(this);
         this.setupManager = new SetupManager();
         this.arenaManager.loadArenas();
+        this.hologramManager = new HologramManager(this);
         this.generatorManager = new GeneratorManager(this);
         this.shopManager = new ShopManager(this);
         this.specialShopManager = new SpecialShopManager(this);
@@ -119,6 +122,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public GeneratorManager getGeneratorManager() {
         return generatorManager;
+    }
+
+    public HologramManager getHologramManager() {
+        return hologramManager;
     }
 
     public ShopManager getShopManager() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.elements.Generator;
 import com.heneria.bedwars.arena.elements.Team;
 import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.arena.enums.GeneratorType;
 import com.heneria.bedwars.arena.enums.TeamColor;
 import com.heneria.bedwars.events.GameStateChangeEvent;
 import com.heneria.bedwars.utils.GameUtils;
@@ -577,6 +578,9 @@ public class Arena {
         }
         for (Generator gen : generators) {
             HeneriaBedwars.getInstance().getGeneratorManager().registerGenerator(gen);
+            if (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD) {
+                HeneriaBedwars.getInstance().getHologramManager().createGeneratorHologram(gen);
+            }
         }
         HeneriaBedwars.getInstance().getEventManager().startTimeline(this);
         for (Team team : this.getTeams().values()) {
@@ -706,6 +710,7 @@ public class Arena {
 
     public void reset() {
         HeneriaBedwars.getInstance().getEventManager().stopTimeline(this);
+        HeneriaBedwars.getInstance().getHologramManager().removeArenaHolograms(this);
         for (UUID id : new ArrayList<>(players)) {
             Player p = Bukkit.getPlayer(id);
             if (p != null) {

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -65,12 +65,18 @@ public class GeneratorManager {
 
     private void tick() {
         for (Map.Entry<Generator, Integer> entry : counters.entrySet()) {
+            Generator gen = entry.getKey();
             int remaining = entry.getValue() - 1;
             if (remaining <= 0) {
-                spawn(entry.getKey());
-                remaining = getDelayCycles(entry.getKey());
+                spawn(gen);
+                remaining = getDelayCycles(gen);
             }
             entry.setValue(remaining);
+            int updateInterval = 20 / TICK_RATE;
+            if (remaining % updateInterval == 0) {
+                int seconds = (int) Math.ceil(remaining / (double) updateInterval);
+                plugin.getHologramManager().updateGeneratorHologram(gen, seconds);
+            }
         }
     }
 
@@ -111,6 +117,15 @@ public class GeneratorManager {
 
     public void unregisterGenerator(Generator gen) {
         counters.remove(gen);
+    }
+
+    public int getRemainingSeconds(Generator gen) {
+        Integer remaining = counters.get(gen);
+        if (remaining == null) {
+            return 0;
+        }
+        int updateInterval = 20 / TICK_RATE;
+        return (int) Math.ceil(remaining / (double) updateInterval);
     }
 
     /**

--- a/src/main/java/com/heneria/bedwars/managers/HologramManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/HologramManager.java
@@ -1,0 +1,107 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import eu.decentsoftware.holograms.api.DHAPI;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import org.bukkit.Location;
+import org.bukkit.plugin.Plugin;
+
+import java.util.*;
+
+/**
+ * Manages creation and update of generator holograms through DecentHolograms.
+ */
+public class HologramManager {
+
+    private final HeneriaBedwars plugin;
+    private final boolean hooked;
+    private final Map<Generator, Hologram> holograms = new HashMap<>();
+    private final Map<GeneratorType, List<String>> formats = new EnumMap<>(GeneratorType.class);
+    private final double offsetY;
+
+    public HologramManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        Plugin dh = plugin.getServer().getPluginManager().getPlugin("DecentHolograms");
+        this.hooked = dh != null;
+        var section = plugin.getConfig().getConfigurationSection("generator-holograms");
+        if (section != null && section.isConfigurationSection("formats")) {
+            for (String key : section.getConfigurationSection("formats").getKeys(false)) {
+                try {
+                    GeneratorType type = GeneratorType.valueOf(key);
+                    formats.put(type, section.getStringList("formats." + key));
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+        }
+        this.offsetY = section != null ? section.getDouble("offset-y", 2.5) : 2.5;
+    }
+
+    private boolean enabled() {
+        var section = plugin.getConfig().getConfigurationSection("generator-holograms");
+        return hooked && section != null && section.getBoolean("enabled", false);
+    }
+
+    /**
+     * Creates an hologram for the given generator.
+     *
+     * @param generator generator to display
+     */
+    public void createGeneratorHologram(Generator generator) {
+        if (!enabled() || generator.getLocation() == null) {
+            return;
+        }
+        List<String> lines = formats.get(generator.getType());
+        if (lines == null || lines.isEmpty()) {
+            return;
+        }
+        Location loc = generator.getLocation().clone().add(0, offsetY, 0);
+        Hologram holo = DHAPI.createHologram("gen_" + UUID.randomUUID(), loc, lines);
+        holograms.put(generator, holo);
+        updateGeneratorHologram(generator, plugin.getGeneratorManager().getRemainingSeconds(generator));
+    }
+
+    /**
+     * Updates the countdown line of a generator hologram.
+     *
+     * @param generator generator whose hologram to update
+     * @param seconds   seconds remaining
+     */
+    public void updateGeneratorHologram(Generator generator, int seconds) {
+        if (!enabled()) {
+            return;
+        }
+        Hologram holo = holograms.get(generator);
+        if (holo == null) {
+            return;
+        }
+        List<String> lines = formats.get(generator.getType());
+        if (lines == null || lines.size() < 2) {
+            return;
+        }
+        String line = lines.get(1).replace("{time}", String.valueOf(seconds));
+        DHAPI.setHologramLine(holo, 1, line);
+    }
+
+    /**
+     * Removes all holograms associated with the given arena.
+     *
+     * @param arena arena whose holograms to remove
+     */
+    public void removeArenaHolograms(Arena arena) {
+        if (!enabled()) {
+            return;
+        }
+        Iterator<Map.Entry<Generator, Hologram>> it = holograms.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Generator, Hologram> entry = it.next();
+            if (arena.getGenerators().contains(entry.getKey())) {
+                DHAPI.removeHologram(entry.getValue());
+                it.remove();
+            }
+        }
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,3 +15,14 @@ database:
 mobs:
   iron-golem:
     damage: 4.0
+
+generator-holograms:
+  enabled: true
+  offset-y: 2.5 # Hauteur de l'hologramme au-dessus du générateur
+  formats:
+    DIAMOND:
+      - "&b&lDiamants"
+      - "&fApparaît dans &a{time}s"
+    EMERALD:
+      - "&2&lÉmeraudes"
+      - "&fApparaît dans &a{time}s"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: ${project.version}
 main: com.heneria.bedwars.HeneriaBedwars
 api-version: '1.21'
 author: tomashb
+softdepend: [DecentHolograms]
 
 commands:
   bedwars:


### PR DESCRIPTION
## Summary
- integrate optional DecentHolograms dependency and config for generator holograms
- add `HologramManager` with lifecycle hooks to show countdowns above diamond and emerald generators
- document and expose new configuration and soft dependency

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a47279fb7c8329ba13f3e4bd1df494