### PR TITLE
Add generator holograms and fix DecentHolograms repo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - HeneriaBedwars
 
+## [1.0.0-RC3] - En développement
+
+### Ajouté
+- Affichage d'hologrammes dynamiques au-dessus des générateurs de Diamants et d'Émeraudes.
+
+### Corrigé
+- Correction de l'URL du dépôt Maven de DecentHolograms empêchant le build.
+
 ## [1.0.0-RC2] - En développement
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
   - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby d'attente et de la partie via les sections `lobby` et `game`.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
-  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`).
+  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`) ou l'affichage des hologrammes des générateurs via `generator-holograms`.
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
 
@@ -47,6 +47,10 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 2.  Placez le fichier `.jar` téléchargé dans le dossier `plugins` de votre serveur Spigot 1.21.
 3.  Redémarrez votre serveur.
 4.  Les fichiers de configuration par défaut seront générés dans le dossier `plugins/HeneriaBedwars/`.
+
+### Dépendances Optionnelles
+
+- **DecentHolograms** : affiche des hologrammes au-dessus des générateurs de Diamants et d'Émeraudes. Le plugin fonctionne également sans cette dépendance.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>decentholograms</id>
+            <url>https://repo.decentholograms.com/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -80,6 +84,12 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.decentsoftware</groupId>
+            <artifactId>DecentHolograms</artifactId>
+            <version>2.8.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -19,6 +19,7 @@ import com.heneria.bedwars.listeners.VoidKillListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
+import com.heneria.bedwars.managers.HologramManager;
 import com.heneria.bedwars.managers.ShopManager;
 import com.heneria.bedwars.managers.SpecialShopManager;
 import com.heneria.bedwars.managers.UpgradeManager;
@@ -37,6 +38,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private ArenaManager arenaManager;
     private SetupManager setupManager;
     private GeneratorManager generatorManager;
+    private HologramManager hologramManager;
     private ShopManager shopManager;
     private SpecialShopManager specialShopManager;
     private UpgradeManager upgradeManager;
@@ -59,6 +61,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.arenaManager = new ArenaManager(this);
         this.setupManager = new SetupManager();
         this.arenaManager.loadArenas();
+        this.hologramManager = new HologramManager(this);
         this.generatorManager = new GeneratorManager(this);
         this.shopManager = new ShopManager(this);
         this.specialShopManager = new SpecialShopManager(this);
@@ -119,6 +122,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public GeneratorManager getGeneratorManager() {
         return generatorManager;
+    }
+
+    public HologramManager getHologramManager() {
+        return hologramManager;
     }
 
     public ShopManager getShopManager() {

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -71,6 +71,8 @@ public class GeneratorManager {
                 remaining = getDelayCycles(entry.getKey());
             }
             entry.setValue(remaining);
+            int seconds = (int) Math.ceil(remaining * TICK_RATE / 20.0);
+            plugin.getHologramManager().updateGeneratorHologram(entry.getKey(), seconds);
         }
     }
 
@@ -107,10 +109,13 @@ public class GeneratorManager {
 
     public void registerGenerator(Generator gen) {
         counters.put(gen, getDelayCycles(gen));
+        plugin.getHologramManager().createGeneratorHologram(gen);
+        plugin.getHologramManager().updateGeneratorHologram(gen, (int) Math.ceil(getDelayCycles(gen) * TICK_RATE / 20.0));
     }
 
     public void unregisterGenerator(Generator gen) {
         counters.remove(gen);
+        plugin.getHologramManager().removeGeneratorHologram(gen);
     }
 
     /**

--- a/src/main/java/com/heneria/bedwars/managers/HologramManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/HologramManager.java
@@ -1,0 +1,87 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import eu.decentsoftware.holograms.api.DHAPI;
+import eu.decentsoftware.holograms.api.hologram.Hologram;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.plugin.Plugin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles creation and updating of holograms above generators.
+ * This manager only works if DecentHolograms is present on the server.
+ */
+public class HologramManager {
+
+    private final HeneriaBedwars plugin;
+    private final boolean enabled;
+    private final Map<Generator, Hologram> holograms = new HashMap<>();
+    private final double height;
+    private final String diamondText;
+    private final String emeraldText;
+
+    public HologramManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        Plugin dh = Bukkit.getPluginManager().getPlugin("DecentHolograms");
+        this.enabled = dh != null;
+        this.height = plugin.getConfig().getDouble("generator-holograms.height", 2.5);
+        this.diamondText = plugin.getConfig().getString("generator-holograms.diamond", "&bDiamants dans &f%time%s");
+        this.emeraldText = plugin.getConfig().getString("generator-holograms.emerald", "&aÉmeraudes dans &f%time%s");
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void createGeneratorHologram(Generator gen) {
+        if (!enabled || gen.getLocation() == null) {
+            return;
+        }
+        if (gen.getType() != GeneratorType.DIAMOND && gen.getType() != GeneratorType.EMERALD) {
+            return;
+        }
+        Location loc = gen.getLocation().clone().add(0, height, 0);
+        String id = "gen-" + gen.hashCode();
+        Hologram hologram = DHAPI.createHologram(id, loc);
+        DHAPI.addHologramLine(hologram, formatText(gen, 0));
+        holograms.put(gen, hologram);
+    }
+
+    public void updateGeneratorHologram(Generator gen, int seconds) {
+        if (!enabled) {
+            return;
+        }
+        Hologram hologram = holograms.get(gen);
+        if (hologram != null) {
+            DHAPI.setHologramLine(hologram, 0, formatText(gen, seconds));
+        }
+    }
+
+    public void removeGeneratorHologram(Generator gen) {
+        if (!enabled) {
+            return;
+        }
+        Hologram hologram = holograms.remove(gen);
+        if (hologram != null) {
+            hologram.delete();
+        }
+    }
+
+    public void removeAll() {
+        if (!enabled) {
+            return;
+        }
+        holograms.values().forEach(Hologram::delete);
+        holograms.clear();
+    }
+
+    private String formatText(Generator gen, int seconds) {
+        String template = gen.getType() == GeneratorType.DIAMOND ? diamondText : emeraldText;
+        return template.replace("%time%", String.valueOf(seconds));
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,3 +15,8 @@ database:
 mobs:
   iron-golem:
     damage: 4.0
+
+generator-holograms:
+  height: 2.5
+  diamond: "&bDiamants dans &f%time%s"
+  emerald: "&aÉmeraudes dans &f%time%s"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,9 @@ main: com.heneria.bedwars.HeneriaBedwars
 api-version: '1.21'
 author: tomashb
 
+softdepend:
+  - DecentHolograms
+
 commands:
   bedwars:
     description: Commande principale de HeneriaBedwars.


### PR DESCRIPTION
## Summary
- correct DecentHolograms Maven repository and add dependency
- display holograms above diamond and emerald generators with dynamic countdowns
- document new generator holograms feature and optional DecentHolograms dependency

## Testing
- `mvn -B package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a475132c9c8329aaa3854790040a2c