### PR TITLE
Fix arena world loading to prevent startup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Corrigé
 - Correction d'un bug de blocage du décompte de démarrage de partie.
+- Correction d'un bug critique qui empêchait le démarrage des parties (monde non défini).
 
 ## [1.0.0-RC2] - En développement
 

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -420,7 +420,7 @@ public class Arena {
     }
 
     public Location getCenterLocation() {
-        org.bukkit.World world = Bukkit.getWorld(worldName);
+        org.bukkit.World world = Bukkit.getWorld(this.worldName);
         if (world == null) {
             return null;
         }
@@ -570,7 +570,7 @@ public class Arena {
             System.out.println("[DEBUG-STARTGAME] Compte à rebours annulé.");
         }
 
-        World world = Bukkit.getWorld(worldName);
+        World world = Bukkit.getWorld(this.worldName);
         if (world != null) {
             world.setGameRule(GameRule.DO_WEATHER_CYCLE, false);
             world.setStorm(false);
@@ -765,7 +765,7 @@ public class Arena {
         bedBlocks.clear();
         originalBedStates.clear();
 
-        World world = Bukkit.getWorld(worldName);
+        World world = Bukkit.getWorld(this.worldName);
         if (world != null) {
             for (Entity entity : new ArrayList<>(world.getEntities())) {
                 if (entity.getType() == EntityType.ITEM) {

--- a/src/main/java/com/heneria/bedwars/gui/admin/creation/ArenaSettingsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/creation/ArenaSettingsMenu.java
@@ -74,7 +74,7 @@ public class ArenaSettingsMenu extends Menu {
         } else if (slot == 15) {
             Player player = (Player) event.getWhoClicked();
             player.closeInventory();
-            HeneriaBedwars.getInstance().getArenaManager().createAndSaveArena(arenaName, playersPerTeam, teamCount);
+            HeneriaBedwars.getInstance().getArenaManager().createAndSaveArena(arenaName, playersPerTeam, teamCount, player.getWorld().getName());
             MessageManager.sendMessage(player, "admin.arena-created", "arena", arenaName);
         }
     }

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -51,6 +51,9 @@ public class ArenaManager {
             if (config.contains("enabled")) {
                 arena.setEnabled(config.getBoolean("enabled"));
             }
+            if (config.contains("world")) {
+                arena.setWorldName(config.getString("world"));
+            }
             if (config.contains("minPlayers")) {
                 arena.setMinPlayers(config.getInt("minPlayers"));
             }
@@ -184,6 +187,9 @@ public class ArenaManager {
         config.set("minPlayers", arena.getMinPlayers());
         config.set("maxPlayers", arena.getMaxPlayers());
         config.set("boundaries.max-y", arena.getMaxBuildY());
+        if (arena.getWorldName() != null) {
+            config.set("world", arena.getWorldName());
+        }
         if (arena.getLobbyLocation() != null) {
             Location loc = arena.getLobbyLocation();
             config.set("lobby.world", Objects.requireNonNull(loc.getWorld()).getName());
@@ -321,15 +327,34 @@ public class ArenaManager {
      *
      * @param name the arena name
      */
-    public void createArena(String name) {
-        arenas.put(name.toLowerCase(), new Arena(name));
+    public void createArena(String name, String worldName) {
+        Arena arena = new Arena(name);
+        arena.setWorldName(worldName);
+        arenas.put(name.toLowerCase(), arena);
     }
 
-    public void createAndSaveArena(String name, int playersPerTeam, int teamCount) {
+    public void createArena(String name) {
+        createArena(name, null);
+    }
+
+    /**
+     * Creates a new arena with the given parameters and saves it to disk.
+     *
+     * @param name           the arena name
+     * @param playersPerTeam number of players per team
+     * @param teamCount      number of teams
+     * @param worldName      name of the world where the arena resides
+     */
+    public void createAndSaveArena(String name, int playersPerTeam, int teamCount, String worldName) {
         Arena arena = new Arena(name);
+        arena.setWorldName(worldName);
         arena.setMinPlayers(teamCount);
         arena.setMaxPlayers(playersPerTeam * teamCount);
         arenas.put(name.toLowerCase(), arena);
         saveArena(arena);
+    }
+
+    public void createAndSaveArena(String name, int playersPerTeam, int teamCount) {
+        createAndSaveArena(name, playersPerTeam, teamCount, null);
     }
 }


### PR DESCRIPTION
## Summary
- persist arena world names in config on save/load and during creation
- use stored world name when starting or resetting games
- document fix in changelog

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a479efe5148329a4aac4c638349f8a