### PR TITLE
HBW-088: Polish unbreakables, forge upgrade, and scoreboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Corrigé
 - Correction d'un bug de blocage du décompte de démarrage de partie.
 - Correction d'un bug critique qui empêchait le démarrage des parties (monde non défini).
+- Tous les équipements fournis ou achetés sont désormais incassables.
+- La Forge d'équipe accélère le Fer et l'Or avec des paliers rééquilibrés et génère des Émeraudes au niveau final.
+- Les nouvelles armes achetées héritent correctement des enchantements d'équipe débloqués.
+- Correction d'une faute de frappe dans le scoreboard par défaut.
 
 ## [1.0.0-RC2] - En développement
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🕹️ **Cycle de Jeu Complet** : Rejoignez une arène, attendez dans le lobby avec un décompte, et lancez-vous dans la bataille.
 - 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, et détruisez celui de vos ennemis pour les éliminer définitivement.
 - 💰 **Système Économique** : Collectez du Fer, de l'Or, des Diamants et des Émeraudes à des vitesses différentes pour acheter de l'équipement.
+- 🔥 **Forge évolutive** : Améliorez la Forge de votre équipe pour accélérer le Fer et l'Or, le dernier niveau produisant même des Émeraudes sur votre île.
 - 🛒 **Boutiques Fonctionnelles** : Interagissez avec les PNJ pour acheter des objets dans la boutique d'items ou des améliorations permanentes pour votre équipe.
 - 🧱 **Construction de Blocs** : Achetez, placez et cassez des blocs pour bâtir ponts et défenses.
  - 🛡️ **Kit de départ lié** : Vous réapparaissez avec une armure en cuir teintée aux couleurs de votre équipe ainsi qu'une épée, une pioche et une hache en bois impossibles à jeter.

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -142,8 +142,12 @@ public class ShopItemsMenu extends Menu {
                     meta.getPersistentDataContainer()
                             .set(HeneriaBedwars.getItemTypeKey(), PersistentDataType.STRING, item.action());
                 }
+                if (give.getType().getMaxDurability() > 0) {
+                    meta.setUnbreakable(true);
+                }
                 give.setItemMeta(meta);
             }
+            HeneriaBedwars.getInstance().getUpgradeManager().applyTeamUpgrades(clicker, give);
             handleUpgrade(clicker, item, give);
             clicker.playSound(clicker.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
             setupItems();
@@ -180,6 +184,7 @@ public class ShopItemsMenu extends Menu {
                 ItemMeta meta = give.getItemMeta();
                 if (meta != null) {
                     meta.addEnchant(Enchantment.EFFICIENCY, 1, true);
+                    meta.setUnbreakable(true);
                     give.setItemMeta(meta);
                 }
                 clicker.getInventory().addItem(give);
@@ -190,6 +195,7 @@ public class ShopItemsMenu extends Menu {
                 ItemMeta meta = give.getItemMeta();
                 if (meta != null) {
                     meta.addEnchant(Enchantment.EFFICIENCY, 1, true);
+                    meta.setUnbreakable(true);
                     give.setItemMeta(meta);
                 }
                 clicker.getInventory().addItem(give);
@@ -205,6 +211,10 @@ public class ShopItemsMenu extends Menu {
                     default -> Material.LEATHER_LEGGINGS;
                 };
                 clicker.getInventory().setLeggings(GameUtils.createBoundArmor(leggingsType));
+                HeneriaBedwars.getInstance().getUpgradeManager()
+                        .applyTeamUpgrades(clicker, clicker.getInventory().getBoots());
+                HeneriaBedwars.getInstance().getUpgradeManager()
+                        .applyTeamUpgrades(clicker, clicker.getInventory().getLeggings());
                 progressionManager.setArmorTier(uuid, item.upgradeLevel());
             }
             default -> clicker.getInventory().addItem(give);

--- a/src/main/java/com/heneria/bedwars/gui/special/SpecialShopMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/special/SpecialShopMenu.java
@@ -90,10 +90,16 @@ public class SpecialShopMenu extends Menu {
             ResourceManager.takeResources(player, type, price);
             ItemStack give = new ItemStack(item.material(), 1);
             ItemMeta meta = give.getItemMeta();
-            if (meta != null && item.action() != null) {
-                meta.getPersistentDataContainer().set(HeneriaBedwars.getItemTypeKey(), PersistentDataType.STRING, item.action());
+            if (meta != null) {
+                if (item.action() != null) {
+                    meta.getPersistentDataContainer().set(HeneriaBedwars.getItemTypeKey(), PersistentDataType.STRING, item.action());
+                }
+                if (give.getType().getMaxDurability() > 0) {
+                    meta.setUnbreakable(true);
+                }
                 give.setItemMeta(meta);
             }
+            HeneriaBedwars.getInstance().getUpgradeManager().applyTeamUpgrades(player, give);
             player.getInventory().addItem(give);
             player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
         } else {

--- a/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
@@ -177,7 +177,7 @@ public class TeamUpgradesMenu extends Menu {
                     upgradeManager.applyHaste(p, level - 1, 20 * 60 * 60);
                 }
             }
-            case "forge" -> plugin.getGeneratorManager().upgradeTeamGenerators(arena, team, level + 1);
+            case "forge" -> plugin.getGeneratorManager().upgradeTeamGenerators(arena, team, level);
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
@@ -168,6 +168,33 @@ public class UpgradeManager {
         }
     }
 
+    /**
+     * Applies relevant team upgrades to a freshly obtained item.
+     *
+     * @param player the owner of the item
+     * @param item   the item to update
+     */
+    public void applyTeamUpgrades(Player player, ItemStack item) {
+        if (item == null) return;
+        Arena arena = plugin.getArenaManager().getArena(player);
+        if (arena == null) return;
+        Team team = arena.getTeam(player);
+        if (team == null) return;
+        String name = item.getType().name();
+        if (name.endsWith("SWORD")) {
+            int sharpness = team.getUpgradeLevel("sharpness");
+            if (sharpness > 0) {
+                applySharpness(item, sharpness);
+            }
+        } else if (name.endsWith("HELMET") || name.endsWith("CHESTPLATE")
+                || name.endsWith("LEGGINGS") || name.endsWith("BOOTS")) {
+            int protection = team.getUpgradeLevel("protection");
+            if (protection > 0) {
+                applyProtection(item, protection);
+            }
+        }
+    }
+
     public record Upgrade(String id, String name, Material item, Map<Integer, UpgradeTier> tiers) {
     }
 

--- a/src/main/java/com/heneria/bedwars/utils/GameUtils.java
+++ b/src/main/java/com/heneria/bedwars/utils/GameUtils.java
@@ -79,6 +79,7 @@ public final class GameUtils {
         meta.addEnchant(Enchantment.BINDING_CURSE, 1, true);
         meta.setLore(Collections.singletonList(MessageManager.get("items.starter-lore")));
         meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+        meta.setUnbreakable(true);
         item.setItemMeta(meta);
         return item;
         }
@@ -88,6 +89,7 @@ public final class GameUtils {
         ItemMeta meta = item.getItemMeta();
         meta.setLore(Collections.singletonList(MessageManager.get("items.starter-lore")));
         meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+        meta.setUnbreakable(true);
         item.setItemMeta(meta);
         return item;
     }
@@ -97,6 +99,7 @@ public final class GameUtils {
         ItemMeta meta = item.getItemMeta();
         meta.setLore(Collections.singletonList(MessageManager.get("items.starter-lore")));
         meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+        meta.setUnbreakable(true);
         item.setItemMeta(meta);
         return item;
     }
@@ -106,6 +109,7 @@ public final class GameUtils {
         ItemMeta meta = item.getItemMeta();
         meta.setLore(Collections.singletonList(MessageManager.get("items.starter-lore")));
         meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+        meta.setUnbreakable(true);
         item.setItemMeta(meta);
         return item;
     }
@@ -117,6 +121,7 @@ public final class GameUtils {
             meta.addEnchant(Enchantment.BINDING_CURSE, 1, true);
             meta.setLore(Collections.singletonList(MessageManager.get("items.starter-lore")));
             meta.getPersistentDataContainer().set(STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
+            meta.setUnbreakable(true);
             item.setItemMeta(meta);
         }
         return item;

--- a/src/main/resources/scoreboard.yml
+++ b/src/main/resources/scoreboard.yml
@@ -19,7 +19,7 @@ game:
     - "&7{date}"
     - "&1"
     - "Prochain événement:"
-    - "&a{next_event_name} &fen &a{next_event_time}"
+    - "&a{next_event_name} &fdans &a{next_event_time}"
     - "&2"
     - "{team_status}"
     - "&3"

--- a/src/main/resources/upgrades.yml
+++ b/src/main/resources/upgrades.yml
@@ -28,16 +28,24 @@ haste:
     2:
       cost: 4
       description: "&7Les joueurs gagnent Hâte II."
+# L'amélioration Forge accélère les générateurs de Fer et d'Or de l'île.
+# Le dernier niveau génère également des Émeraudes directement sur la base.
 forge:
   name: "&aForge améliorée"
   item: FURNACE
   tiers:
     1:
-      cost: 4
-      description: "&7Augmente la vitesse des générateurs de l'équipe."
+      cost: 2
+      description: "&7+25% de vitesse pour le Fer et l'Or."
     2:
+      cost: 4
+      description: "&7+50% de vitesse pour le Fer et l'Or."
+    3:
+      cost: 6
+      description: "&7Vitesse maximale pour le Fer et l'Or."
+    4:
       cost: 8
-      description: "&7Générateurs encore plus rapides."
+      description: "&7Active un générateur d'Émeraudes lent."
 
 # Catégorie pour les pièges
 traps:


### PR DESCRIPTION
## Summary
- Make all starting and shop equipment unbreakable and persist team enchantments on new purchases
- Rework Forge upgrade to boost iron & gold, add late-game emerald generator, and fix scoreboard typo
- Document Forge changes and update changelog

## Testing
- ⚠️ `mvn -q -DskipTests package` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a4852a3f3083299c2f7f1046139b69