### PR TITLE
feat(admin, gameplay): Add final polish features and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - HeneriaBedwars
 
+## [1.0.0-RC4] - En développement
+
+### Ajouté
+- Message de chat lors de la destruction d'un lit.
+- Commande `/bw admin delete` avec confirmation pour supprimer une arène.
+- Jour permanent dans les arènes (cycle jour/nuit désactivé).
+
+### Corrigé
+- Réinitialisation des améliorations d'équipe à la fin de chaque partie.
+
 ## [1.0.0-RC3] - En développement
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
   - Ouvre le menu principal de gestion des arènes.
   - **Permission :** `heneriabw.admin`
 
+- `/bw admin delete <nom_de_l_arene>`
+  - Supprime une arène (confirmation requise via `/bw admin confirmdelete <nom_de_l_arene>`).
+  - **Permission :** `heneriabw.admin.delete`
+
 ### Commandes Joueurs
 
 - `/bw join <nom_de_l_arene>`

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -573,8 +573,10 @@ public class Arena {
         World world = Bukkit.getWorld(this.worldName);
         if (world != null) {
             world.setGameRule(GameRule.DO_WEATHER_CYCLE, false);
+            world.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, false);
             world.setStorm(false);
             world.setThundering(false);
+            world.setTime(6000L);
         }
         System.out.println("[DEBUG-STARTGAME] Préparation du monde terminée.");
 
@@ -746,6 +748,7 @@ public class Arena {
         for (Team team : teams.values()) {
             team.getMembers().clear();
             team.setHasBed(true);
+            team.resetUpgrades();
         }
         state = GameState.WAITING;
         liveNpcs.forEach(Entity::remove);

--- a/src/main/java/com/heneria/bedwars/arena/elements/Team.java
+++ b/src/main/java/com/heneria/bedwars/arena/elements/Team.java
@@ -210,6 +210,14 @@ public class Team {
     }
 
     /**
+     * Resets all upgrades and traps for this team.
+     */
+     public void resetUpgrades() {
+         upgradeLevels.clear();
+         traps.clear();
+     }
+
+    /**
      * Gets all traps and their active state for this team.
      *
      * @return map of traps

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -1,16 +1,20 @@
 package com.heneria.bedwars.commands.subcommands;
 
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.gui.admin.AdminMainMenu;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.entity.Player;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
- * Handles the "/bedwars admin" sub-command.
+ * Handles the "/bedwars admin" sub-command and its administrative operations.
  */
 public class AdminCommand implements SubCommand {
+
+    private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+    private final Map<UUID, PendingDelete> pendingDeletes = new HashMap<>();
 
     @Override
     public String getName() {
@@ -19,6 +23,41 @@ public class AdminCommand implements SubCommand {
 
     @Override
     public void execute(Player player, String[] args) {
+        if (args.length > 0) {
+            String sub = args[0].toLowerCase();
+            if (sub.equals("delete") && args.length >= 2) {
+                if (!player.hasPermission("heneriabw.admin.delete")) {
+                    MessageManager.sendMessage(player, "errors.no-permission");
+                    return;
+                }
+                String arenaName = args[1];
+                Arena arena = plugin.getArenaManager().getArena(arenaName);
+                if (arena == null) {
+                    MessageManager.sendMessage(player, "errors.arena-not-found");
+                    return;
+                }
+                pendingDeletes.put(player.getUniqueId(), new PendingDelete(arenaName, System.currentTimeMillis() + 30000));
+                MessageManager.sendMessage(player, "admin.delete-pending", "arena", arenaName);
+                return;
+            } else if (sub.equals("confirmdelete") && args.length >= 2) {
+                String arenaName = args[1];
+                PendingDelete pending = pendingDeletes.get(player.getUniqueId());
+                if (pending == null || !pending.arenaName.equalsIgnoreCase(arenaName) || System.currentTimeMillis() > pending.expireAt) {
+                    MessageManager.sendMessage(player, "admin.delete-expired", "arena", arenaName);
+                    pendingDeletes.remove(player.getUniqueId());
+                    return;
+                }
+                boolean success = plugin.getArenaManager().deleteArena(arenaName);
+                pendingDeletes.remove(player.getUniqueId());
+                if (success) {
+                    MessageManager.sendMessage(player, "admin.delete-confirmed", "arena", arenaName);
+                } else {
+                    MessageManager.sendMessage(player, "errors.arena-not-found");
+                }
+                return;
+            }
+        }
+
         if (!player.hasPermission("heneriabw.admin")) {
             MessageManager.sendMessage(player, "errors.no-permission");
             return;
@@ -28,6 +67,29 @@ public class AdminCommand implements SubCommand {
 
     @Override
     public List<String> tabComplete(Player player, String[] args) {
+        if (args.length == 1) {
+            return Arrays.asList("delete", "confirmdelete");
+        }
+        if (args.length == 2 && (args[0].equalsIgnoreCase("delete") || args[0].equalsIgnoreCase("confirmdelete"))) {
+            List<String> names = new ArrayList<>();
+            for (Arena arena : plugin.getArenaManager().getAllArenas()) {
+                if (arena.getName().toLowerCase().startsWith(args[1].toLowerCase())) {
+                    names.add(arena.getName());
+                }
+            }
+            return names;
+        }
         return Collections.emptyList();
     }
+
+    private static class PendingDelete {
+        final String arenaName;
+        final long expireAt;
+
+        PendingDelete(String arenaName, long expireAt) {
+            this.arenaName = arenaName;
+            this.expireAt = expireAt;
+        }
+    }
 }
+

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -77,6 +77,7 @@ public class GameListener implements Listener {
                     event.setDropItems(false);
                     bedTeam.setHasBed(false);
                     arena.broadcastTitle("game.bed-destroyed-title", "game.bed-destroyed-subtitle", 10, 70, 20, "team", bedTeam.getColor().getDisplayName(), "player", player.getName());
+                    arena.broadcast("game.bed-destroyed-chat", "team", bedTeam.getColor().getDisplayName(), "player", player.getName());
                     PlayerStats stats = statsManager.getStats(player);
                     if (stats != null) {
                         stats.incrementBedsBroken();

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -8,6 +8,7 @@ import com.heneria.bedwars.arena.enums.TeamColor;
 import com.heneria.bedwars.arena.enums.GeneratorType;
 
 import org.bukkit.Bukkit;
+import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -53,6 +54,10 @@ public class ArenaManager {
             }
             if (config.contains("world")) {
                 arena.setWorldName(config.getString("world"));
+                World arenaWorld = Bukkit.getWorld(arena.getWorldName());
+                if (arenaWorld != null) {
+                    arenaWorld.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, false);
+                }
             }
             if (config.contains("minPlayers")) {
                 arena.setMinPlayers(config.getInt("minPlayers"));
@@ -288,6 +293,26 @@ public class ArenaManager {
      */
     public Collection<Arena> getAllArenas() {
         return arenas.values();
+    }
+
+    /**
+     * Deletes an arena from memory and disk.
+     *
+     * @param name the arena name
+     * @return {@code true} if the arena existed and was removed
+     */
+    public boolean deleteArena(String name) {
+        Arena removed = arenas.remove(name.toLowerCase());
+        if (removed == null) {
+            return false;
+        }
+        File dir = new File(plugin.getDataFolder(), "arenas");
+        File file = new File(dir, name.toLowerCase() + ".yml");
+        if (file.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            file.delete();
+        }
+        return true;
     }
 
     /**

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -36,6 +36,7 @@ game:
   countdown-cancelled: "&cDécompte annulé : pas assez de joueurs."
   bed-destroyed-title: "&c&lDESTRUCTION DE LIT !"
   bed-destroyed-subtitle: "Lit de l'équipe {team} détruit par {player}"
+  bed-destroyed-chat: "&cLe lit de l'équipe {team} a été détruit par {player}!"
   respawn-title: "&cVOUS ÊTES MORT !"
   respawn-subtitle: "Réapparition dans &e{seconds}s"
   elimination-title: "&c&lÉLIMINATION !"
@@ -81,6 +82,9 @@ admin:
   generator-removed: "&cGénérateur supprimé."
   arena-activated: "&aArène activée."
   arena-deactivated: "&cArène désactivée."
+  delete-pending: "&eTapez /bw admin confirmdelete {arena} dans 30s pour confirmer la suppression."
+  delete-confirmed: "&aL'arène {arena} a été supprimée."
+  delete-expired: "&cConfirmation expirée pour l'arène {arena}."
 
 menus:
   admin-main-title: "&8HeneriaBedwars - Administration"


### PR DESCRIPTION
## Summary
- reset team upgrades after each game to prevent carryover
- broadcast chat notice when a bed is destroyed
- force arenas to run in perpetual daylight
- add admin delete command with confirmation
- document new features and fixes

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a48892753c83299d9614f106ef3c96