### PR TITLE
fix(build): Switch to JitPack for DecentHolograms dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ## [1.0.0-RC3] - En développement
 
+### Ajouté
+- Affichage d'hologrammes au-dessus des générateurs de Diamants et d'Émeraudes.
+
 ### Corrigé
 - Correction d'un bug de blocage du décompte de démarrage de partie.
 - Correction d'un bug critique qui empêchait le démarrage des parties (monde non défini).
@@ -19,6 +22,7 @@
 - La Forge d'équipe accélère le Fer et l'Or avec des paliers rééquilibrés et génère des Émeraudes au niveau final.
 - Les nouvelles armes achetées héritent correctement des enchantements d'équipe débloqués.
 - Correction d'une faute de frappe dans le scoreboard par défaut.
+- Dépendance DecentHolograms récupérée via JitPack pour résoudre les erreurs de build.
 
 ## [1.0.0-RC2] - En développement
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🌈 **Achats intelligents** : La laine achetée s'adapte automatiquement à la couleur de votre équipe et toute nouvelle épée remplace la précédente.
 - 📊 **Tableau de Bord Dynamique** : Consultez en un coup d'œil l'état des équipes et le prochain événement.
 - 🛍️ **Marchand Mystérieux** : Un PNJ spécial apparaît au centre en milieu de partie pour vendre des objets uniques comme le Golem de Fer de Poche.
+- 🪄 **Hologrammes dynamiques** : Si [DecentHolograms](https://modrinth.com/plugin/decentholograms) est installé, les générateurs de Diamants et d'Émeraudes affichent un compte à rebours personnalisable via `generator-holograms` dans `config.yml`.
 - 🏆 **Conditions de Victoire** : La partie se termine automatiquement lorsque la dernière équipe en vie est déclarée vainqueur, et l'arène se réinitialise pour le prochain combat.
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -80,6 +84,12 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.DecentSoftware-EU</groupId>
+            <artifactId>DecentHolograms</artifactId>
+            <version>2.8.6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -27,6 +27,7 @@ import com.heneria.bedwars.managers.DatabaseManager;
 import com.heneria.bedwars.managers.StatsManager;
 import com.heneria.bedwars.managers.EventManager;
 import com.heneria.bedwars.managers.PlayerProgressionManager;
+import com.heneria.bedwars.managers.HologramManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -37,6 +38,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private ArenaManager arenaManager;
     private SetupManager setupManager;
     private GeneratorManager generatorManager;
+    private HologramManager hologramManager;
     private ShopManager shopManager;
     private SpecialShopManager specialShopManager;
     private UpgradeManager upgradeManager;
@@ -59,6 +61,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.arenaManager = new ArenaManager(this);
         this.setupManager = new SetupManager();
         this.arenaManager.loadArenas();
+        this.hologramManager = new HologramManager(this);
         this.generatorManager = new GeneratorManager(this);
         this.shopManager = new ShopManager(this);
         this.specialShopManager = new SpecialShopManager(this);
@@ -83,6 +86,9 @@ public final class HeneriaBedwars extends JavaPlugin {
     public void onDisable() {
         if (statsManager != null) {
             statsManager.saveAll();
+        }
+        if (hologramManager != null) {
+            hologramManager.clear();
         }
         getLogger().info("HeneriaBedwars a été désactivé.");
     }
@@ -119,6 +125,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public GeneratorManager getGeneratorManager() {
         return generatorManager;
+    }
+
+    public HologramManager getHologramManager() {
+        return hologramManager;
     }
 
     public ShopManager getShopManager() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -595,6 +595,7 @@ public class Arena {
 
         for (Generator gen : generators) {
             HeneriaBedwars.getInstance().getGeneratorManager().registerGenerator(gen);
+            HeneriaBedwars.getInstance().getHologramManager().createGeneratorHologram(gen);
         }
         System.out.println("[DEBUG-STARTGAME] Démarrage des générateurs terminé.");
 

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -65,12 +65,17 @@ public class GeneratorManager {
 
     private void tick() {
         for (Map.Entry<Generator, Integer> entry : counters.entrySet()) {
+            Generator gen = entry.getKey();
             int remaining = entry.getValue() - 1;
             if (remaining <= 0) {
-                spawn(entry.getKey());
-                remaining = getDelayCycles(entry.getKey());
+                spawn(gen);
+                remaining = getDelayCycles(gen);
             }
             entry.setValue(remaining);
+            if (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD) {
+                double seconds = remaining * TICK_RATE / 20.0;
+                plugin.getHologramManager().updateGenerator(gen, seconds);
+            }
         }
     }
 
@@ -111,6 +116,7 @@ public class GeneratorManager {
 
     public void unregisterGenerator(Generator gen) {
         counters.remove(gen);
+        plugin.getHologramManager().removeGeneratorHologram(gen);
     }
 
     /**

--- a/src/main/java/com/heneria/bedwars/managers/HologramManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/HologramManager.java
@@ -1,0 +1,101 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import eu.decentsoftware.holograms.api.DHAPI;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.ChatColor;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Handles creation and upkeep of DecentHolograms holograms for resource generators.
+ */
+public class HologramManager {
+
+    private final HeneriaBedwars plugin;
+    private final boolean enabled;
+    private final double height;
+    private final Map<GeneratorType, String> templates = new EnumMap<>(GeneratorType.class);
+    private final Map<Generator, Hologram> holograms = new HashMap<>();
+
+    public HologramManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        Plugin dh = Bukkit.getPluginManager().getPlugin("DecentHolograms");
+        ConfigurationSection section = plugin.getConfig().getConfigurationSection("generator-holograms");
+        this.enabled = dh != null && section != null;
+        if (section != null) {
+            this.height = section.getDouble("height", 2.5);
+            templates.put(GeneratorType.DIAMOND, ChatColor.translateAlternateColorCodes('&', section.getString("diamond", "&bDiamants dans &f{time}s")));
+            templates.put(GeneratorType.EMERALD, ChatColor.translateAlternateColorCodes('&', section.getString("emerald", "&aÉmeraudes dans &f{time}s")));
+        } else {
+            this.height = 0.0;
+        }
+    }
+
+    /**
+     * Creates a hologram above the given generator.
+     */
+    public void createGeneratorHologram(Generator gen) {
+        if (!enabled || gen.getLocation() == null) {
+            return;
+        }
+        String template = templates.get(gen.getType());
+        if (template == null) {
+            return;
+        }
+        Location loc = gen.getLocation().clone().add(0, height, 0);
+        Hologram holo = DHAPI.createHologram(UUID.randomUUID().toString(), loc, Collections.singletonList(template.replace("{time}", "-")));
+        holograms.put(gen, holo);
+    }
+
+    /**
+     * Updates the hologram line with the remaining time.
+     *
+     * @param gen the generator
+     * @param seconds time remaining before spawn
+     */
+    public void updateGenerator(Generator gen, double seconds) {
+        if (!enabled) {
+            return;
+        }
+        Hologram holo = holograms.get(gen);
+        if (holo == null) {
+            return;
+        }
+        String template = templates.get(gen.getType());
+        if (template == null) {
+            return;
+        }
+        String line = template.replace("{time}", String.format("%.1f", seconds));
+        DHAPI.setHologramLine(holo, 0, line);
+    }
+
+    /**
+     * Removes the hologram of the given generator.
+     */
+    public void removeGeneratorHologram(Generator gen) {
+        Hologram holo = holograms.remove(gen);
+        if (holo != null) {
+            holo.delete();
+        }
+    }
+
+    /**
+     * Deletes all active holograms.
+     */
+    public void clear() {
+        holograms.values().forEach(Hologram::delete);
+        holograms.clear();
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,3 +15,8 @@ database:
 mobs:
   iron-golem:
     damage: 4.0
+
+generator-holograms:
+  height: 2.5
+  diamond: "&bDiamants dans &f{time}s"
+  emerald: "&aÉmeraudes dans &f{time}s"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: ${project.version}
 main: com.heneria.bedwars.HeneriaBedwars
 api-version: '1.21'
 author: tomashb
+softdepend: [DecentHolograms]
 
 commands:
   bedwars:


### PR DESCRIPTION
## Summary
- fetch DecentHolograms via JitPack to fix missing repository errors
- add dynamic holograms above diamond and emerald generators

## Testing
- `mvn -B package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a48a5473b483298964a1659036e8d5