### PR TITLE
feat: add generator holograms and fix build dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 - Message de chat lors de la destruction d'un lit.
 - Commande `/bw admin delete` avec confirmation pour supprimer une arène.
 - Jour permanent dans les arènes (cycle jour/nuit désactivé).
+- Affichage d'hologrammes au-dessus des générateurs de Diamants et Émeraudes (DecentHolograms).
 
 ### Corrigé
 - Réinitialisation des améliorations d'équipe à la fin de chaque partie.
+- Correction du build en ajoutant le dépôt Maven de `tr7zw`.
 
 ## [1.0.0-RC3] - En développement
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
   - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby d'attente et de la partie via les sections `lobby` et `game`.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
-  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`).
+  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`) et personnalisez les hologrammes des générateurs via `generator-holograms`.
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
 
@@ -37,6 +37,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
  - 🛡️ **Progression Hybride** : Les armures achetées sont conservées après la mort, tandis que les outils et épées doivent être rachetés.
 - 🌈 **Achats intelligents** : La laine achetée s'adapte automatiquement à la couleur de votre équipe et toute nouvelle épée remplace la précédente.
 - 📊 **Tableau de Bord Dynamique** : Consultez en un coup d'œil l'état des équipes et le prochain événement.
+- 👁️ **Hologrammes de Générateur** : Affiche un compte à rebours au-dessus des générateurs de Diamants et Émeraudes grâce à [DecentHolograms](https://github.com/DecentSoftware-eu/DecentHolograms).
 - 🛍️ **Marchand Mystérieux** : Un PNJ spécial apparaît au centre en milieu de partie pour vendre des objets uniques comme le Golem de Fer de Poche.
 - 🏆 **Conditions de Victoire** : La partie se termine automatiquement lorsque la dernière équipe en vie est déclarée vainqueur, et l'arène se réinitialise pour le prochain combat.
 
@@ -288,6 +289,21 @@ mobs:
 
 Cette valeur contrôle les dégâts infligés par les Golems de Fer invoqués par les joueurs.
 
+### Hologrammes de Générateur
+
+Si le plugin [DecentHolograms](https://github.com/DecentSoftware-eu/DecentHolograms) est installé, HeneriaBedwars peut afficher un compte à rebours au-dessus des générateurs de Diamants et d'Émeraudes. Le texte et la hauteur sont configurables :
+
+```yaml
+generator-holograms:
+  diamond:
+    text: "&bDiamant dans &f{time}"
+    height: 2.5
+  emerald:
+    text: "&aÉmeraude dans &f{time}"
+    height: 2.5
+```
+
+Le placeholder `{time}` est remplacé par le nombre de secondes restantes avant la prochaine apparition de ressource.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,14 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+            <id>tr7zw</id>
+            <url>https://repo.tr7zw.dev/repository/maven-releases/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -80,6 +88,12 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.DecentSoftware-eu</groupId>
+            <artifactId>DecentHolograms</artifactId>
+            <version>2.9.6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -27,6 +27,7 @@ import com.heneria.bedwars.managers.DatabaseManager;
 import com.heneria.bedwars.managers.StatsManager;
 import com.heneria.bedwars.managers.EventManager;
 import com.heneria.bedwars.managers.PlayerProgressionManager;
+import com.heneria.bedwars.managers.HologramManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -45,6 +46,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private DatabaseManager databaseManager;
     private StatsManager statsManager;
     private PlayerProgressionManager playerProgressionManager;
+    private HologramManager hologramManager;
     private static NamespacedKey itemTypeKey;
 
     @Override
@@ -65,6 +67,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.upgradeManager = new UpgradeManager(this);
         this.eventManager = new EventManager(this);
         this.scoreboardManager = new ScoreboardManager(this);
+        this.hologramManager = new HologramManager(this);
         this.databaseManager = new DatabaseManager(this);
         this.statsManager = new StatsManager(this, this.databaseManager);
         this.playerProgressionManager = new PlayerProgressionManager();
@@ -83,6 +86,9 @@ public final class HeneriaBedwars extends JavaPlugin {
     public void onDisable() {
         if (statsManager != null) {
             statsManager.saveAll();
+        }
+        if (hologramManager != null) {
+            hologramManager.removeAll();
         }
         getLogger().info("HeneriaBedwars a été désactivé.");
     }
@@ -155,5 +161,9 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public PlayerProgressionManager getPlayerProgressionManager() {
         return playerProgressionManager;
+    }
+
+    public HologramManager getHologramManager() {
+        return hologramManager;
     }
 }

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -71,6 +71,8 @@ public class GeneratorManager {
                 remaining = getDelayCycles(entry.getKey());
             }
             entry.setValue(remaining);
+            int seconds = (int) Math.ceil(remaining * TICK_RATE / 20.0);
+            plugin.getHologramManager().update(entry.getKey(), seconds);
         }
     }
 
@@ -106,11 +108,15 @@ public class GeneratorManager {
     }
 
     public void registerGenerator(Generator gen) {
-        counters.put(gen, getDelayCycles(gen));
+        int cycles = getDelayCycles(gen);
+        counters.put(gen, cycles);
+        int seconds = (int) Math.ceil(cycles * TICK_RATE / 20.0);
+        plugin.getHologramManager().create(gen, seconds);
     }
 
     public void unregisterGenerator(Generator gen) {
         counters.remove(gen);
+        plugin.getHologramManager().remove(gen);
     }
 
     /**

--- a/src/main/java/com/heneria/bedwars/managers/HologramManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/HologramManager.java
@@ -1,0 +1,83 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import eu.decentsoftware.holograms.api.DHAPI;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Manages holograms displayed above generators using DecentHolograms.
+ */
+public class HologramManager {
+
+    private final HeneriaBedwars plugin;
+    private final boolean enabled;
+    private final Map<Generator, Hologram> holograms = new HashMap<>();
+    private String diamondText;
+    private String emeraldText;
+    private double diamondHeight;
+    private double emeraldHeight;
+
+    public HologramManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        this.enabled = Bukkit.getPluginManager().isPluginEnabled("DecentHolograms");
+        loadConfig();
+    }
+
+    private void loadConfig() {
+        this.diamondText = plugin.getConfig().getString("generator-holograms.diamond.text", "&bDiamant dans &f{time}");
+        this.emeraldText = plugin.getConfig().getString("generator-holograms.emerald.text", "&aÉmeraude dans &f{time}");
+        this.diamondHeight = plugin.getConfig().getDouble("generator-holograms.diamond.height", 2.5);
+        this.emeraldHeight = plugin.getConfig().getDouble("generator-holograms.emerald.height", 2.5);
+    }
+
+    public void create(Generator gen, int seconds) {
+        if (!enabled || gen.getLocation() == null) return;
+        if (gen.getType() != GeneratorType.DIAMOND && gen.getType() != GeneratorType.EMERALD) return;
+        Location loc = gen.getLocation().clone().add(0, getHeight(gen), 0);
+        String id = "hbw-" + UUID.randomUUID();
+        Hologram hologram = DHAPI.createHologram(id, loc);
+        DHAPI.addHologramLine(hologram, format(gen, seconds));
+        holograms.put(gen, hologram);
+    }
+
+    public void update(Generator gen, int seconds) {
+        if (!enabled) return;
+        Hologram hologram = holograms.get(gen);
+        if (hologram == null) return;
+        DHAPI.setHologramLine(hologram, 0, format(gen, seconds));
+    }
+
+    public void remove(Generator gen) {
+        if (!enabled) return;
+        Hologram hologram = holograms.remove(gen);
+        if (hologram != null) {
+            hologram.delete();
+        }
+    }
+
+    public void removeAll() {
+        if (!enabled) return;
+        for (Hologram hologram : holograms.values()) {
+            hologram.delete();
+        }
+        holograms.clear();
+    }
+
+    private String format(Generator gen, int seconds) {
+        String base = gen.getType() == GeneratorType.DIAMOND ? diamondText : emeraldText;
+        return ChatColor.translateAlternateColorCodes('&', base.replace("{time}", String.valueOf(seconds)));
+    }
+
+    private double getHeight(Generator gen) {
+        return gen.getType() == GeneratorType.DIAMOND ? diamondHeight : emeraldHeight;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,3 +15,11 @@ database:
 mobs:
   iron-golem:
     damage: 4.0
+
+generator-holograms:
+  diamond:
+    text: "&bDiamant dans &f{time}"
+    height: 2.5
+  emerald:
+    text: "&aÉmeraude dans &f{time}"
+    height: 2.5

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,11 +3,12 @@ version: ${project.version}
 main: com.heneria.bedwars.HeneriaBedwars
 api-version: '1.21'
 author: tomashb
+softdepend: [DecentHolograms]
 
 commands:
-  bedwars:
-    description: Commande principale de HeneriaBedwars.
-    aliases: [bw, hbw]
+    bedwars:
+        description: Commande principale de HeneriaBedwars.
+        aliases: [bw, hbw]
 
 permissions:
   heneriabw.admin:


### PR DESCRIPTION
## Summary
- add DecentHolograms hologram support for diamond and emerald generators
- fix Maven build by adding JitPack and tr7zw repositories
- document hologram configuration and dependency

## Testing
- `mvn -B package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a48dd50b588329be3733bc77b0fbd4