### PR TITLE
feat: team selector, lobby protection and build limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - HeneriaBedwars
 
+## [1.0.0] - 2024-04-XX
+
+### Ajouté
+- Sélecteur d'équipe interactif permettant aux joueurs de choisir leur camp avant le début de la partie.
+- Protections complètes du lobby d'attente (PvP désactivé, mode aventure).
+- Limites de construction configurables incluant une distance maximale au centre de l'arène.
+- Toutes les fonctionnalités prévues pour la version initiale sont désormais implémentées.
+
 ## [1.0.0-RC4] - En développement
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 ### Pour les Joueurs
 
 - 🕹️ **Cycle de Jeu Complet** : Rejoignez une arène, attendez dans le lobby avec un décompte, et lancez-vous dans la bataille.
+- 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.
 - 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, et détruisez celui de vos ennemis pour les éliminer définitivement.
 - 💰 **Système Économique** : Collectez du Fer, de l'Or, des Diamants et des Émeraudes à des vitesses différentes pour acheter de l'équipement.
 - 🔥 **Forge évolutive** : Améliorez la Forge de votre équipe pour accélérer le Fer et l'Or, le dernier niveau produisant même des Émeraudes sur votre île.
@@ -249,14 +250,15 @@ team-line-format: "{team_color_code}{team_icon} {team_bed_status} &f{team_player
 
 ### Limites de Construction de l'Arène
 
-Chaque arène peut définir une hauteur maximale de construction pour éviter les abus. Dans le fichier `arenas/<nom>.yml`, ajoutez:
+Chaque arène peut définir des limites pour empêcher les constructions abusives. Dans le fichier `arenas/<nom>.yml`, ajoutez :
 
 ```yaml
 boundaries:
   max-y: 150
+  max-distance-from-center: 100
 ```
 
-Tout bloc placé au-dessus de cette limite sera automatiquement annulé côté serveur.
+Les blocs placés au‑dessus ou au‑delà de ces limites seront automatiquement annulés côté serveur.
 
 ### Configuration de la Base de Données
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,15 +38,18 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 * [✔] Logique d'achat d'objets et gestion des ressources.
 * [✔] Boutique d'améliorations d'équipe.
 
-## 🎯 **Étape 4 : Polissage & Fonctionnalités Avancées (Version Cible : 1.0.0) - [WIP]**
+## 🎯 **Étape 4 : Polissage & Fonctionnalités Avancées (Version Cible : 1.0.0) - [✔] TERMINÉE**
 *Objectif : Ajouter les fonctionnalités spéciales, optimiser le code et préparer la version stable.*
 
 * [✔] La Construction : Ajout de la pose/destruction de blocs par les joueurs.
 * [✔] Ajout des kits de départ complets (armure liée, épée).
- * [✔] Les Objets Spéciaux (TNT, Boules de feu...).
+* [✔] Les Objets Spéciaux (TNT, Boules de feu...).
 * [✔] Tour Instantanée (Pop-up Tower).
 * [✔] Le Tableau de Bord (Scoreboard).
 * [✔] Les Pièges d'Équipe.
   * [✔] Un Fichier de Langue Complet (messages.yml).
   * [✔] Sauvegarde des Statistiques des Joueurs.
-  * [ ] Compatibilité avec PlaceholderAPI.
+  * [✔] Compatibilité avec PlaceholderAPI.
+* [✔] Limites de construction configurables par arène.
+* [✔] Protections complètes du lobby d'attente.
+* [✔] Sélecteur d'équipe interactif pour les joueurs.

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -16,6 +16,8 @@ import com.heneria.bedwars.listeners.TrapListener;
 import com.heneria.bedwars.listeners.StatsListener;
 import com.heneria.bedwars.listeners.HungerListener;
 import com.heneria.bedwars.listeners.VoidKillListener;
+import com.heneria.bedwars.listeners.LobbyProtectionListener;
+import com.heneria.bedwars.listeners.TeamSelectorListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -103,6 +105,8 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new StatsListener(), this);
         getServer().getPluginManager().registerEvents(new HungerListener(), this);
         getServer().getPluginManager().registerEvents(new VoidKillListener(), this);
+        getServer().getPluginManager().registerEvents(new LobbyProtectionListener(), this);
+        getServer().getPluginManager().registerEvents(new TeamSelectorListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -14,6 +14,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.GameMode;
+import com.heneria.bedwars.listeners.TeamSelectorListener;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Bed;
@@ -65,6 +67,7 @@ public class Arena {
     private int countdownDuration = 10;
     private int countdownTime;
     private int maxBuildY = 256;
+    private int maxBuildDistance = 0;
 
     /**
      * Creates a new arena with the given name.
@@ -183,6 +186,14 @@ public class Arena {
         this.maxBuildY = maxBuildY;
     }
 
+    public int getMaxBuildDistance() {
+        return maxBuildDistance;
+    }
+
+    public void setMaxBuildDistance(int maxBuildDistance) {
+        this.maxBuildDistance = maxBuildDistance;
+    }
+
     public int getCountdownTime() {
         return countdownTime;
     }
@@ -229,6 +240,8 @@ public class Arena {
         player.teleport(lobbyLocation);
         player.setLevel(0);
         player.setExp(0f);
+        player.setGameMode(GameMode.ADVENTURE);
+        player.getInventory().setItem(0, TeamSelectorListener.createSelectorItem());
         Team team = getLeastPopulatedTeam();
         if (team != null) {
             team.addMember(player.getUniqueId());
@@ -589,6 +602,7 @@ public class Arena {
             if (team != null && team.getSpawnLocation() != null) {
                 p.teleport(team.getSpawnLocation());
             }
+            p.setGameMode(GameMode.SURVIVAL);
             GameUtils.giveDefaultKit(p, team);
         }
         System.out.println("[DEBUG-STARTGAME] Téléportation des joueurs terminée.");

--- a/src/main/java/com/heneria/bedwars/gui/TeamSelectorMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/TeamSelectorMenu.java
@@ -1,0 +1,97 @@
+package com.heneria.bedwars.gui;
+
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.arena.enums.TeamColor;
+import com.heneria.bedwars.utils.MessageManager;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Menu allowing players to choose their team before the game starts.
+ */
+public class TeamSelectorMenu extends Menu {
+
+    private final Arena arena;
+    private final Map<Integer, TeamColor> slotTeam = new HashMap<>();
+
+    public TeamSelectorMenu(Arena arena) {
+        this.arena = arena;
+    }
+
+    @Override
+    public String getTitle() {
+        return MessageManager.get("menus.team-selector-title");
+    }
+
+    @Override
+    public int getSize() {
+        int teams = arena.getTeams().size();
+        int rows = (int) Math.ceil(teams / 9.0);
+        return Math.max(9, rows * 9);
+    }
+
+    @Override
+    public void setupItems() {
+        slotTeam.clear();
+        int maxPerTeam = arena.getMaxPlayers() / arena.getTeams().size();
+        int slot = 0;
+        for (Map.Entry<TeamColor, Team> entry : arena.getTeams().entrySet()) {
+            TeamColor color = entry.getKey();
+            Team team = entry.getValue();
+            ItemBuilder builder = new ItemBuilder(color.getWoolMaterial())
+                    .setName(color.getChatColor() + team.getColor().getDisplayName())
+                    .addLore(team.getMembers().size() + "/" + maxPerTeam + " Joueurs");
+            for (UUID id : team.getMembers()) {
+                Player p = Bukkit.getPlayer(id);
+                if (p != null) {
+                    builder.addLore(" &7- " + p.getName());
+                }
+            }
+            ItemStack item = builder.build();
+            inventory.setItem(slot, item);
+            slotTeam.put(slot, color);
+            slot++;
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        if (handleBack(event)) {
+            return;
+        }
+        int slot = event.getRawSlot();
+        TeamColor color = slotTeam.get(slot);
+        if (color == null) {
+            return;
+        }
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+        Team target = arena.getTeams().get(color);
+        int maxPerTeam = arena.getMaxPlayers() / arena.getTeams().size();
+        if (target.getMembers().size() >= maxPerTeam) {
+            MessageManager.sendMessage(player, "errors.team-full");
+            return;
+        }
+        Team current = arena.getTeam(player);
+        if (current != null) {
+            current.removeMember(player.getUniqueId());
+        }
+        target.addMember(player.getUniqueId());
+        MessageManager.sendMessage(player, "game.team-joined", "team", target.getColor().getDisplayName());
+        // Refresh menus for all players in lobby
+        for (UUID id : arena.getPlayers()) {
+            Player p = Bukkit.getPlayer(id);
+            if (p != null && p.getOpenInventory().getTopInventory().getHolder() instanceof TeamSelectorMenu) {
+                new TeamSelectorMenu(arena).open(p);
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/BlockPlaceListener.java
@@ -6,6 +6,7 @@ import com.heneria.bedwars.arena.enums.GameState;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.block.Block;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -30,6 +31,19 @@ public class BlockPlaceListener implements Listener {
             event.setCancelled(true);
             MessageManager.sendMessage(player, "errors.build-outside-boundaries");
             return;
+        }
+        if (arena.getMaxBuildDistance() > 0) {
+            Location center = arena.getCenterLocation();
+            if (center != null) {
+                double dx = block.getX() - center.getX();
+                double dz = block.getZ() - center.getZ();
+                double dist = Math.sqrt(dx * dx + dz * dz);
+                if (dist > arena.getMaxBuildDistance()) {
+                    event.setCancelled(true);
+                    MessageManager.sendMessage(player, "errors.build-outside-boundaries");
+                    return;
+                }
+            }
         }
         arena.getPlacedBlocks().add(block);
     }

--- a/src/main/java/com/heneria/bedwars/listeners/LobbyProtectionListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/LobbyProtectionListener.java
@@ -1,0 +1,49 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.projectiles.ProjectileSource;
+import org.bukkit.entity.Projectile;
+
+/**
+ * Protects the lobby from PvP before the game starts.
+ */
+public class LobbyProtectionListener implements Listener {
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+
+    @EventHandler(ignoreCancelled = true)
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        Entity victim = event.getEntity();
+        if (!(victim instanceof Player player)) {
+            return;
+        }
+        Player damagerPlayer = null;
+        Entity damager = event.getDamager();
+        if (damager instanceof Player p) {
+            damagerPlayer = p;
+        } else if (damager instanceof Projectile projectile) {
+            ProjectileSource source = projectile.getShooter();
+            if (source instanceof Player p) {
+                damagerPlayer = p;
+            }
+        }
+        if (damagerPlayer == null) {
+            return;
+        }
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null) {
+            return;
+        }
+        if (arena.getState() == GameState.WAITING || arena.getState() == GameState.STARTING) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
@@ -1,0 +1,57 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.gui.TeamSelectorMenu;
+import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.utils.MessageManager;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Listener to handle the team selector item interactions.
+ */
+public class TeamSelectorListener implements Listener {
+
+    private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+    private final ArenaManager arenaManager = plugin.getArenaManager();
+    public static final NamespacedKey TEAM_SELECTOR_KEY = new NamespacedKey(HeneriaBedwars.getInstance(), "team-selector");
+
+    public static ItemStack createSelectorItem() {
+        ItemStack item = new ItemStack(Material.NETHER_STAR);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(MessageManager.get("items.team-selector-name"));
+            meta.getPersistentDataContainer().set(TEAM_SELECTOR_KEY, PersistentDataType.BYTE, (byte) 1);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        ItemStack item = event.getItem();
+        if (item == null) {
+            return;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.getPersistentDataContainer().has(TEAM_SELECTOR_KEY, PersistentDataType.BYTE)) {
+            return;
+        }
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || (arena.getState() != GameState.WAITING && arena.getState() != GameState.STARTING)) {
+            return;
+        }
+        event.setCancelled(true);
+        new TeamSelectorMenu(arena).open(player);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -68,6 +68,9 @@ public class ArenaManager {
             if (config.contains("boundaries.max-y")) {
                 arena.setMaxBuildY(config.getInt("boundaries.max-y"));
             }
+            if (config.contains("boundaries.max-distance-from-center")) {
+                arena.setMaxBuildDistance(config.getInt("boundaries.max-distance-from-center"));
+            }
             if (config.contains("lobby.world")) {
                 World world = Bukkit.getWorld(config.getString("lobby.world"));
                 if (world != null) {
@@ -192,6 +195,7 @@ public class ArenaManager {
         config.set("minPlayers", arena.getMinPlayers());
         config.set("maxPlayers", arena.getMaxPlayers());
         config.set("boundaries.max-y", arena.getMaxBuildY());
+        config.set("boundaries.max-distance-from-center", arena.getMaxBuildDistance());
         if (arena.getWorldName() != null) {
             config.set("world", arena.getWorldName());
         }


### PR DESCRIPTION
## Summary
- add per-arena build boundaries
- protect waiting lobbies and give players adventure mode
- add team selector item and GUI
- finish project documentation for v1.0.0

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a490ee01b08329b573edec7c992e4c