### PR TITLE
feat(game): Add generator holograms via DecentHolograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ## [1.0.0-RC3] - En développement
 
+### Ajouté
+- Hologrammes dynamiques au-dessus des générateurs de Diamants et d'Émeraudes (support optionnel de DecentHolograms).
+
 ### Corrigé
 - Correction d'un bug de blocage du décompte de démarrage de partie.
 - Correction d'un bug critique qui empêchait le démarrage des parties (monde non défini).

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
 - 🧙‍♂️ **Assistant de Création Intuitif** : Un système de création d'arène simple via le chat vous guide pour définir les paramètres de base.
 - 📍 **Configuration Précise** : Utilisez un outil de positionnement en jeu pour définir avec précision l'emplacement du lobby, des lits, des points de spawn, des générateurs et des PNJ pour chaque équipe.
 - ⚙️ **Haute Personnalisation** : Prenez le contrôle total du gameplay en modifiant les fichiers de configuration dédiés :
-  - `generators.yml` : Réglez la vitesse et la quantité de chaque générateur de ressources.
-  - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
-  - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
-  - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby d'attente et de la partie via les sections `lobby` et `game`.
-  - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
-  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`).
-  - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
-  - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
+    - `generators.yml` : Réglez la vitesse et la quantité de chaque générateur de ressources.
+    - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
+    - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
+    - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby d'attente et de la partie via les sections `lobby` et `game`.
+    - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
+    - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`) et le texte des hologrammes des générateurs via `generator-holograms`.
+    - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
+    - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
 
 Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le plugin à n'importe quelle langue ou style.
 
@@ -38,6 +38,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
  - 🛡️ **Progression Hybride** : Les armures achetées sont conservées après la mort, tandis que les outils et épées doivent être rachetés.
 - 🌈 **Achats intelligents** : La laine achetée s'adapte automatiquement à la couleur de votre équipe et toute nouvelle épée remplace la précédente.
 - 📊 **Tableau de Bord Dynamique** : Consultez en un coup d'œil l'état des équipes et le prochain événement.
+- 🪩 **Hologrammes de Générateur** : Des hologrammes indiquent le temps avant le prochain drop de Diamants ou d'Émeraudes (plugin optionnel DecentHolograms).
 - 🛍️ **Marchand Mystérieux** : Un PNJ spécial apparaît au centre en milieu de partie pour vendre des objets uniques comme le Golem de Fer de Poche.
 - 🏆 **Conditions de Victoire** : La partie se termine automatiquement lorsque la dernière équipe en vie est déclarée vainqueur, et l'arène se réinitialise pour le prochain combat.
 
@@ -47,8 +48,9 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 
 1.  Téléchargez la dernière version du plugin depuis la page [Releases](https://github.com/tomashb/HeneriaBW/releases).
 2.  Placez le fichier `.jar` téléchargé dans le dossier `plugins` de votre serveur Spigot 1.21.
-3.  Redémarrez votre serveur.
-4.  Les fichiers de configuration par défaut seront générés dans le dossier `plugins/HeneriaBedwars/`.
+3.  *(Optionnel mais recommandé)* Téléchargez et installez [DecentHolograms](https://www.spigotmc.org/resources/decent-holograms.96927/) pour activer les hologrammes des générateurs.
+4.  Redémarrez votre serveur.
+5.  Les fichiers de configuration par défaut seront générés dans le dossier `plugins/HeneriaBedwars/`.
 
 ---
 
@@ -289,6 +291,16 @@ mobs:
 ```
 
 Cette valeur contrôle les dégâts infligés par les Golems de Fer invoqués par les joueurs.
+
+### Hologrammes de Générateur
+
+La section `generator-holograms` du `config.yml` permet de personnaliser le texte affiché au-dessus des générateurs de Diamants et d'Émeraudes. Le placeholder `{time}` sera remplacé par le compte à rebours en secondes.
+
+```yaml
+generator-holograms:
+  diamond: "&bDiamant dans &f{time}s"
+  emerald: "&aÉmeraude dans &f{time}s"
+```
 
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -80,6 +84,12 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.DecentSoftware-EU</groupId>
+            <artifactId>DecentHolograms</artifactId>
+            <version>2.8.6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -29,6 +29,7 @@ import com.heneria.bedwars.managers.DatabaseManager;
 import com.heneria.bedwars.managers.StatsManager;
 import com.heneria.bedwars.managers.EventManager;
 import com.heneria.bedwars.managers.PlayerProgressionManager;
+import com.heneria.bedwars.managers.HologramManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -39,6 +40,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private ArenaManager arenaManager;
     private SetupManager setupManager;
     private GeneratorManager generatorManager;
+    private HologramManager hologramManager;
     private ShopManager shopManager;
     private SpecialShopManager specialShopManager;
     private UpgradeManager upgradeManager;
@@ -62,6 +64,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.setupManager = new SetupManager();
         this.arenaManager.loadArenas();
         this.generatorManager = new GeneratorManager(this);
+        this.hologramManager = new HologramManager(this);
         this.shopManager = new ShopManager(this);
         this.specialShopManager = new SpecialShopManager(this);
         this.upgradeManager = new UpgradeManager(this);
@@ -123,6 +126,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public GeneratorManager getGeneratorManager() {
         return generatorManager;
+    }
+
+    public HologramManager getHologramManager() {
+        return hologramManager;
     }
 
     public ShopManager getShopManager() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -609,6 +609,7 @@ public class Arena {
 
         for (Generator gen : generators) {
             HeneriaBedwars.getInstance().getGeneratorManager().registerGenerator(gen);
+            HeneriaBedwars.getInstance().getHologramManager().createGeneratorHologram(gen);
         }
         System.out.println("[DEBUG-STARTGAME] Démarrage des générateurs terminé.");
 
@@ -744,6 +745,7 @@ public class Arena {
     }
 
     public void reset() {
+        HeneriaBedwars.getInstance().getHologramManager().removeGeneratorHolograms(this);
         HeneriaBedwars.getInstance().getEventManager().stopTimeline(this);
         for (UUID id : new ArrayList<>(players)) {
             Player p = Bukkit.getPlayer(id);

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -71,6 +71,8 @@ public class GeneratorManager {
                 remaining = getDelayCycles(entry.getKey());
             }
             entry.setValue(remaining);
+            int seconds = (int) Math.ceil(remaining * TICK_RATE / 20.0);
+            plugin.getHologramManager().updateGeneratorCountdown(entry.getKey(), seconds);
         }
     }
 
@@ -111,6 +113,14 @@ public class GeneratorManager {
 
     public void unregisterGenerator(Generator gen) {
         counters.remove(gen);
+    }
+
+    public int getRemainingSeconds(Generator gen) {
+        Integer cycles = counters.get(gen);
+        if (cycles == null) {
+            return -1;
+        }
+        return (int) Math.ceil(cycles * TICK_RATE / 20.0);
     }
 
     /**

--- a/src/main/java/com/heneria/bedwars/managers/HologramManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/HologramManager.java
@@ -1,0 +1,61 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Generator;
+import com.heneria.bedwars.arena.enums.GeneratorType;
+import eu.decentsoftware.holograms.api.DHAPI;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles creation and updating of generator holograms using DecentHolograms.
+ */
+public class HologramManager {
+
+    private final HeneriaBedwars plugin;
+    private final boolean enabled;
+    private final Map<Generator, Hologram> holograms = new HashMap<>();
+
+    public HologramManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        this.enabled = Bukkit.getPluginManager().getPlugin("DecentHolograms") != null;
+        if (!enabled) {
+            plugin.getLogger().info("DecentHolograms not found. Generator holograms disabled.");
+        }
+    }
+
+    public void createGeneratorHologram(Generator gen) {
+        if (!enabled || gen.getLocation() == null) return;
+        if (gen.getType() != GeneratorType.DIAMOND && gen.getType() != GeneratorType.EMERALD) return;
+
+        Location loc = gen.getLocation().clone().add(0, 2.5, 0);
+        String template = plugin.getConfig().getString("generator-holograms." + gen.getType().name().toLowerCase(), "{time}");
+        Hologram hologram = DHAPI.createHologram("hbw_gen_" + gen.hashCode(), loc);
+        DHAPI.addHologramLine(hologram, ChatColor.translateAlternateColorCodes('&', template.replace("{time}", String.valueOf(plugin.getGeneratorManager().getRemainingSeconds(gen)))));
+        holograms.put(gen, hologram);
+    }
+
+    public void updateGeneratorCountdown(Generator gen, int seconds) {
+        if (!enabled) return;
+        Hologram hologram = holograms.get(gen);
+        if (hologram == null) return;
+        String template = plugin.getConfig().getString("generator-holograms." + gen.getType().name().toLowerCase(), "{time}");
+        DHAPI.setHologramLine(hologram, 0, ChatColor.translateAlternateColorCodes('&', template.replace("{time}", String.valueOf(seconds))));
+    }
+
+    public void removeGeneratorHolograms(Arena arena) {
+        if (!enabled) return;
+        for (Generator gen : arena.getGenerators()) {
+            Hologram hologram = holograms.remove(gen);
+            if (hologram != null) {
+                hologram.delete();
+            }
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,3 +15,7 @@ database:
 mobs:
   iron-golem:
     damage: 4.0
+
+generator-holograms:
+  diamond: "&bDiamant dans &f{time}s"
+  emerald: "&aÉmeraude dans &f{time}s"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,8 @@ main: com.heneria.bedwars.HeneriaBedwars
 api-version: '1.21'
 author: tomashb
 
+softdepend: [DecentHolograms]
+
 commands:
   bedwars:
     description: Commande principale de HeneriaBedwars.


### PR DESCRIPTION
## Summary
- add JitPack and DecentHolograms dependency
- implement generator holograms with safe HologramManager and live countdown updates
- document optional DecentHolograms usage and configuration

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4943eb9b48329b57acd858e4c046c