### PR TITLE
feat(gameplay): Add advanced items and fix PotionEffectType API usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog - HeneriaBedwars
 
+## [1.1.0] - 2024-??-??
+
+### Ajouté
+- Système de primes sur les séries d'éliminations avec récompense pour le joueur qui la brise.
+- Boussole Traqueuse permettant de localiser l'ennemi le plus proche.
+- Verre Trempé résistant aux explosions.
+- Éponge Magique supprimant l'eau dans une zone.
+- Plateforme de Secours pour éviter les chutes dans le vide.
+- Lait du Guérisseur retirant les effets négatifs pour soi et ses alliés proches.
+
+### Corrigé
+- Remplacement de l'appel à `isBad()` par une liste d'effets négatifs pour la gestion des potions.
+
 ## [1.0.0] - 2024-04-30
 
 ### Ajouté

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -18,6 +18,12 @@ import com.heneria.bedwars.listeners.HungerListener;
 import com.heneria.bedwars.listeners.VoidKillListener;
 import com.heneria.bedwars.listeners.LobbyProtectionListener;
 import com.heneria.bedwars.listeners.TeamSelectorListener;
+import com.heneria.bedwars.listeners.BountyListener;
+import com.heneria.bedwars.listeners.TrackerCompassListener;
+import com.heneria.bedwars.listeners.TemperedGlassListener;
+import com.heneria.bedwars.listeners.MagicSpongeListener;
+import com.heneria.bedwars.listeners.SafetyPlatformListener;
+import com.heneria.bedwars.listeners.HealerMilkListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -107,6 +113,12 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new VoidKillListener(), this);
         getServer().getPluginManager().registerEvents(new LobbyProtectionListener(), this);
         getServer().getPluginManager().registerEvents(new TeamSelectorListener(), this);
+        getServer().getPluginManager().registerEvents(new BountyListener(), this);
+        getServer().getPluginManager().registerEvents(new TrackerCompassListener(), this);
+        getServer().getPluginManager().registerEvents(new TemperedGlassListener(), this);
+        getServer().getPluginManager().registerEvents(new MagicSpongeListener(), this);
+        getServer().getPluginManager().registerEvents(new SafetyPlatformListener(), this);
+        getServer().getPluginManager().registerEvents(new HealerMilkListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/listeners/BountyListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/BountyListener.java
@@ -1,0 +1,66 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Simple bounty system placing rewards on players with killstreaks.
+ */
+public class BountyListener implements Listener {
+
+    private static final int BOUNTY_THRESHOLD = 3;
+    private static final int REWARD_AMOUNT = 2; // emeralds
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+    private final Map<UUID, Integer> streaks = new HashMap<>();
+    private final Set<UUID> bountied = new HashSet<>();
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        Player victim = event.getEntity();
+        Player killer = victim.getKiller();
+        Arena arena = arenaManager.getArena(victim);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+
+        streaks.remove(victim.getUniqueId());
+        if (killer != null) {
+            UUID killerId = killer.getUniqueId();
+            int streak = streaks.getOrDefault(killerId, 0) + 1;
+            streaks.put(killerId, streak);
+            if (streak >= BOUNTY_THRESHOLD && !bountied.contains(killerId)) {
+                bountied.add(killerId);
+                Bukkit.broadcastMessage(ChatColor.GOLD + killer.getName() + " a une prime sur sa tête!");
+            }
+        }
+        if (bountied.remove(victim.getUniqueId()) && killer != null) {
+            killer.getInventory().addItem(new ItemStack(Material.EMERALD, REWARD_AMOUNT));
+            Bukkit.broadcastMessage(ChatColor.GREEN + killer.getName() + " a récupéré la prime de " + victim.getName());
+        }
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        UUID id = event.getPlayer().getUniqueId();
+        streaks.remove(id);
+        bountied.remove(id);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/HealerMilkListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/HealerMilkListener.java
@@ -1,0 +1,77 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.Set;
+
+/**
+ * Healer milk removes negative potion effects from the player and nearby teammates.
+ */
+public class HealerMilkListener implements Listener {
+
+    private static final Set<PotionEffectType> DEBUFFS = Set.of(
+            PotionEffectType.SLOWNESS,
+            PotionEffectType.MINING_FATIGUE,
+            PotionEffectType.NAUSEA,
+            PotionEffectType.BLINDNESS,
+            PotionEffectType.HUNGER,
+            PotionEffectType.WEAKNESS,
+            PotionEffectType.POISON,
+            PotionEffectType.WITHER
+    );
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+
+    @EventHandler
+    public void onConsume(PlayerItemConsumeEvent event) {
+        ItemStack item = event.getItem();
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        String special = meta.getPersistentDataContainer()
+                .get(HeneriaBedwars.getItemTypeKey(), PersistentDataType.STRING);
+        if (!"HEALER_MILK".equals(special)) {
+            return;
+        }
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        cleanse(player);
+        Team team = arena.getTeam(player);
+        if (team != null) {
+            for (java.util.UUID id : team.getMembers()) {
+                if (id.equals(player.getUniqueId())) {
+                    continue;
+                }
+                Player mate = player.getWorld().getPlayer(id);
+                if (mate != null && mate.getLocation().distanceSquared(player.getLocation()) <= 25) {
+                    cleanse(mate);
+                }
+            }
+        }
+    }
+
+    private void cleanse(Player player) {
+        for (PotionEffect effect : player.getActivePotionEffects()) {
+            if (DEBUFFS.contains(effect.getType())) {
+                player.removePotionEffect(effect.getType());
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/MagicSpongeListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/MagicSpongeListener.java
@@ -1,0 +1,50 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Handles the magic sponge item that removes water in an area.
+ */
+public class MagicSpongeListener implements Listener {
+
+    private static final int RADIUS = 3;
+
+    @EventHandler
+    public void onPlace(BlockPlaceEvent event) {
+        ItemStack item = event.getItemInHand();
+        if (item == null) {
+            return;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        String special = meta.getPersistentDataContainer()
+                .get(HeneriaBedwars.getItemTypeKey(), PersistentDataType.STRING);
+        if (!"MAGIC_SPONGE".equals(special)) {
+            return;
+        }
+        event.setCancelled(true);
+        item.setAmount(item.getAmount() - 1);
+        Location center = event.getBlock().getLocation();
+        for (int x = -RADIUS; x <= RADIUS; x++) {
+            for (int y = -RADIUS; y <= RADIUS; y++) {
+                for (int z = -RADIUS; z <= RADIUS; z++) {
+                    Block b = center.clone().add(x, y, z).getBlock();
+                    if (b.getType() == Material.WATER) {
+                        b.setType(Material.AIR);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/SafetyPlatformListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SafetyPlatformListener.java
@@ -1,0 +1,72 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.Vector;
+
+/**
+ * Places a small wool platform beneath the player to save them from falling.
+ */
+public class SafetyPlatformListener implements Listener {
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+
+    @EventHandler
+    public void onUse(PlayerInteractEvent event) {
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        ItemStack item = event.getItem();
+        if (item == null) {
+            return;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        String special = meta.getPersistentDataContainer()
+                .get(HeneriaBedwars.getItemTypeKey(), PersistentDataType.STRING);
+        if (!"SAFETY_PLATFORM".equals(special)) {
+            return;
+        }
+        Player player = event.getPlayer();
+        if (player.isOnGround()) {
+            return;
+        }
+        if (player.getVelocity().getY() >= 0) {
+            return;
+        }
+        event.setCancelled(true);
+        item.setAmount(item.getAmount() - 1);
+        Arena arena = arenaManager.getArena(player);
+        Team team = arena != null ? arena.getTeam(player) : null;
+        Material wool = team != null ? team.getColor().getWoolMaterial() : Material.WHITE_WOOL;
+        Location center = player.getLocation().clone().add(0, -1, 0);
+        for (int x = -1; x <= 1; x++) {
+            for (int z = -1; z <= 1; z++) {
+                Block b = center.clone().add(x, 0, z).getBlock();
+                if (b.getType() == Material.AIR) {
+                    b.setType(wool);
+                    if (arena != null) {
+                        arena.getPlacedBlocks().add(b);
+                    }
+                }
+            }
+        }
+        player.setVelocity(new Vector(0, 0.5, 0));
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/TemperedGlassListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/TemperedGlassListener.java
@@ -1,0 +1,17 @@
+package com.heneria.bedwars.listeners;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityExplodeEvent;
+
+/**
+ * Prevents tempered glass blocks from being destroyed by explosions.
+ */
+public class TemperedGlassListener implements Listener {
+
+    @EventHandler
+    public void onExplode(EntityExplodeEvent event) {
+        event.blockList().removeIf(block -> block.getType() == Material.GLASS);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/TrackerCompassListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/TrackerCompassListener.java
@@ -1,0 +1,100 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Updates a compass to point to the nearest enemy when used.
+ */
+public class TrackerCompassListener implements Listener {
+
+    private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+    private final ArenaManager arenaManager = plugin.getArenaManager();
+    private final Map<UUID, BukkitTask> tasks = new HashMap<>();
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        ItemStack item = event.getItem();
+        if (item == null) {
+            return;
+        }
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        String special = meta.getPersistentDataContainer()
+                .get(HeneriaBedwars.getItemTypeKey(), PersistentDataType.STRING);
+        if (!"TRACKER_COMPASS".equals(special)) {
+            return;
+        }
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        BukkitTask previous = tasks.remove(player.getUniqueId());
+        if (previous != null) {
+            previous.cancel();
+        }
+        BukkitTask task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                Arena arena = arenaManager.getArena(player);
+                if (arena == null || arena.getState() != GameState.PLAYING) {
+                    cancel();
+                    return;
+                }
+                Team team = arena.getTeam(player);
+                Player target = null;
+                double best = Double.MAX_VALUE;
+                for (UUID id : arena.getPlayers()) {
+                    Player p = Bukkit.getPlayer(id);
+                    if (p == null || p == player) {
+                        continue;
+                    }
+                    Team t = arena.getTeam(p);
+                    if (team != null && t != null && team.equals(t)) {
+                        continue;
+                    }
+                    double dist = p.getLocation().distanceSquared(player.getLocation());
+                    if (dist < best) {
+                        best = dist;
+                        target = p;
+                    }
+                }
+                if (target != null) {
+                    player.setCompassTarget(target.getLocation());
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+        tasks.put(player.getUniqueId(), task);
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        BukkitTask task = tasks.remove(event.getPlayer().getUniqueId());
+        if (task != null) {
+            task.cancel();
+        }
+    }
+}

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -89,6 +89,14 @@ shop-categories:
           resource: IRON
           amount: 24
         slot: 12
+      'tempered_glass':
+        material: GLASS
+        name: "&fVerre Trempé"
+        amount: 4
+        cost:
+          resource: IRON
+          amount: 12
+        slot: 13
   'utilities_category':
     title: "Utilitaires"
     rows: 5
@@ -134,6 +142,42 @@ shop-categories:
           amount: 24
         slot: 14
         action: 'POPUP_TOWER'
+      'enemy_tracker':
+        material: COMPASS
+        name: "&eBoussole Traqueuse"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 1
+        slot: 15
+        action: 'TRACKER_COMPASS'
+      'magic_sponge':
+        material: SPONGE
+        name: "&eÉponge Magique"
+        amount: 1
+        cost:
+          resource: IRON
+          amount: 20
+        slot: 16
+        action: 'MAGIC_SPONGE'
+      'safety_platform':
+        material: SLIME_BALL
+        name: "&aPlateforme de Secours"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 4
+        slot: 24
+        action: 'SAFETY_PLATFORM'
+      'healer_milk':
+        material: MILK_BUCKET
+        name: "&fLait du Guérisseur"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 4
+        slot: 25
+        action: 'HEALER_MILK'
   'armors_category':
     title: "Armures"
     rows: 3


### PR DESCRIPTION
## Summary
- implement bounty system for killstreaks
- add enemy-tracking compass, tempered glass, magic sponge, safety platform, and healer milk
- fix potion effect handling without `isBad` and update shop and changelog

## Testing
- `mvn -q test` *(failed: Network is unreachable)*
- `mvn -q -o test` *(failed: Cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a1c749688329a252648b0b38c017