### PR TITLE
fix(lobby): Fix and redesign team selector and add leave item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@
 - Message de chat lors de la destruction d'un lit.
 - Commande `/bw admin delete` avec confirmation pour supprimer une arène.
 - Jour permanent dans les arènes (cycle jour/nuit désactivé).
+- Item de lobby pour quitter rapidement une arène.
 
 ### Corrigé
 - Réinitialisation des améliorations d'équipe à la fin de chaque partie.
+- Sélecteur d'équipe : clic dans l'air, nom coloré et menu avec bordure repensé.
 
 ## [1.0.0-RC3] - En développement
 

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -20,6 +20,7 @@ import com.heneria.bedwars.listeners.LobbyProtectionListener;
 import com.heneria.bedwars.listeners.TeamSelectorListener;
 import com.heneria.bedwars.listeners.HealerMilkListener;
 import com.heneria.bedwars.listeners.TemperedGlassListener;
+import com.heneria.bedwars.listeners.LeaveItemListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -112,6 +113,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new VoidKillListener(), this);
         getServer().getPluginManager().registerEvents(new LobbyProtectionListener(), this);
         getServer().getPluginManager().registerEvents(new TeamSelectorListener(), this);
+        getServer().getPluginManager().registerEvents(new LeaveItemListener(), this);
         getServer().getPluginManager().registerEvents(new HealerMilkListener(), this);
         getServer().getPluginManager().registerEvents(new TemperedGlassListener(), this);
     }

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -16,6 +16,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.GameMode;
 import com.heneria.bedwars.listeners.TeamSelectorListener;
+import com.heneria.bedwars.listeners.LeaveItemListener;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Bed;
@@ -242,6 +243,7 @@ public class Arena {
         player.setExp(0f);
         player.setGameMode(GameMode.ADVENTURE);
         player.getInventory().setItem(0, TeamSelectorListener.createSelectorItem());
+        player.getInventory().setItem(7, LeaveItemListener.createLeaveItem());
         Team team = getLeastPopulatedTeam();
         if (team != null) {
             team.addMember(player.getUniqueId());

--- a/src/main/java/com/heneria/bedwars/gui/TeamSelectorMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/TeamSelectorMenu.java
@@ -44,9 +44,14 @@ public class TeamSelectorMenu extends Menu {
     public void setupItems() {
         slotTeam.clear();
         int maxPerTeam = arena.getMaxPlayers() / arena.getTeams().size();
-        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
-        for (int i = 0; i < getSize(); i++) {
-            inventory.setItem(i, filler);
+        ItemStack border = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        int rows = getSize() / 9;
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < 9; c++) {
+                if (r == 0 || r == rows - 1 || c == 0 || c == 8) {
+                    inventory.setItem(r * 9 + c, border);
+                }
+            }
         }
         int index = 0;
         for (Map.Entry<TeamColor, Team> entry : arena.getTeams().entrySet()) {
@@ -55,18 +60,19 @@ public class TeamSelectorMenu extends Menu {
             int row = index / 7;
             int col = index % 7;
             int slot = 10 + row * 9 + col;
+            int size = team.getMembers().size();
+            boolean full = size >= maxPerTeam;
             ItemBuilder builder = new ItemBuilder(color.getWoolMaterial())
-                    .setName(color.getChatColor() + team.getColor().getDisplayName()
-                            + (team.getMembers().size() >= maxPerTeam ? " &c(PLEIN)" : ""))
-                    .addLore(team.getMembers().size() + "/" + maxPerTeam + " Joueurs");
+                    .setName(color.getChatColor() + team.getColor().getDisplayName());
+            builder.addLore((full ? "&c" : "&a") + (full ? "Équipe pleine" : "Clique pour rejoindre"));
+            builder.addLore("&7" + size + "/" + maxPerTeam + " Joueurs");
             for (UUID id : team.getMembers()) {
                 Player p = Bukkit.getPlayer(id);
                 if (p != null) {
                     builder.addLore(" &7- " + p.getName());
                 }
             }
-            ItemStack item = builder.build();
-            inventory.setItem(slot, item);
+            inventory.setItem(slot, builder.build());
             slotTeam.put(slot, color);
             index++;
         }

--- a/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
@@ -2,8 +2,6 @@ package com.heneria.bedwars.listeners;
 
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
-import com.heneria.bedwars.arena.enums.GameState;
-import com.heneria.bedwars.gui.TeamSelectorMenu;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.utils.GameUtils;
 import com.heneria.bedwars.utils.ItemBuilder;
@@ -20,21 +18,25 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 
 /**
- * Listener to handle the team selector item interactions.
+ * Listener for the lobby leave item allowing players to exit an arena.
  */
-public class TeamSelectorListener implements Listener {
+public class LeaveItemListener implements Listener {
 
-    private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
-    private final ArenaManager arenaManager = plugin.getArenaManager();
-    public static final NamespacedKey TEAM_SELECTOR_KEY = new NamespacedKey(HeneriaBedwars.getInstance(), "team-selector");
+    public static final NamespacedKey LEAVE_ITEM_KEY = new NamespacedKey(HeneriaBedwars.getInstance(), "leave-item");
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
 
-    public static ItemStack createSelectorItem() {
-        ItemStack item = new ItemBuilder(Material.WHITE_BANNER)
-                .setName(MessageManager.get("items.team-selector-name"))
+    /**
+     * Creates the special bed item used to leave the arena lobby.
+     *
+     * @return the configured ItemStack
+     */
+    public static ItemStack createLeaveItem() {
+        ItemStack item = new ItemBuilder(Material.RED_BED)
+                .setName(MessageManager.get("items.leave-item-name"))
                 .build();
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.getPersistentDataContainer().set(TEAM_SELECTOR_KEY, PersistentDataType.BYTE, (byte) 1);
+            meta.getPersistentDataContainer().set(LEAVE_ITEM_KEY, PersistentDataType.BYTE, (byte) 1);
             meta.getPersistentDataContainer().set(GameUtils.STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
             item.setItemMeta(meta);
         }
@@ -52,15 +54,15 @@ public class TeamSelectorListener implements Listener {
             return;
         }
         ItemMeta meta = item.getItemMeta();
-        if (meta == null || !meta.getPersistentDataContainer().has(TEAM_SELECTOR_KEY, PersistentDataType.BYTE)) {
+        if (meta == null || !meta.getPersistentDataContainer().has(LEAVE_ITEM_KEY, PersistentDataType.BYTE)) {
             return;
         }
         Player player = event.getPlayer();
         Arena arena = arenaManager.getArena(player);
-        if (arena == null || (arena.getState() != GameState.WAITING && arena.getState() != GameState.STARTING)) {
+        if (arena == null) {
             return;
         }
         event.setCancelled(true);
-        new TeamSelectorMenu(arena).open(player);
+        arena.removePlayer(player);
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -93,6 +93,8 @@ menus:
 
 items:
   starter-lore: "&7Objet de départ"
+  team-selector-name: "&eSélecteur d'équipe"
+  leave-item-name: "&cQuitter la partie"
 
 scoreboard:
   bed-alive: "&a✔"


### PR DESCRIPTION
## Summary
- add unmovable leave bed item in lobby
- redesign team selector item and menu with color-coded details
- update translations and changelog

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a645bca88329abffbd0b60c7c29e