### PR TITLE
fix(polish): Final gameplay and GUI polishing for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,18 @@
 - Limites de construction configurables incluant une distance maximale au centre de l'arène.
 - Toutes les fonctionnalités prévues pour la version initiale sont désormais implémentées.
 
+### Modifié
+- Le Verre Trempé a été déplacé dans la catégorie « Blocs » de la boutique.
+- Les générateurs d'or produisent plus lentement pour améliorer l'équilibrage.
+
 ### Corrigé
 - Le sélecteur d'équipe fonctionne aussi lors d'un clic dans les airs et son menu affiche des bordures en verre ainsi que les équipes pleines.
 - La vitesse des générateurs est réinitialisée entre les parties et les émeraudes de forge apparaissent désormais sur les générateurs des îles.
 - Les joueurs ne perdent plus de faim dans une arène.
+- L'item « Quitter l'arène » est désormais placé dans le neuvième slot du lobby.
+- Les clics dans le vide déclenchent correctement les items de lobby.
+- Le titre du sélecteur d'équipe est correctement traduit via le fichier de messages.
+- Les ressources apparaissent maintenant au centre exact de leur bloc générateur.
 
 ## [1.0.0-RC4] - En développement
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,3 +59,5 @@ Ce document détaille les étapes de développement prévues pour le plugin Hene
 
 ## 🎉 **Version 1.0.0 Stable**
 Toutes les étapes de la roadmap initiale sont maintenant complétées. Le plugin est prêt pour une utilisation en production.
+ 
+✅ 100% de la roadmap est désormais accomplie.

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -243,7 +243,7 @@ public class Arena {
         player.setExp(0f);
         player.setGameMode(GameMode.ADVENTURE);
         player.getInventory().setItem(0, TeamSelectorListener.createSelectorItem());
-        player.getInventory().setItem(7, LeaveItemListener.createLeaveItem());
+        player.getInventory().setItem(8, LeaveItemListener.createLeaveItem());
         Team team = getLeastPopulatedTeam();
         if (team != null) {
             team.addMember(player.getUniqueId());

--- a/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
@@ -46,7 +46,7 @@ public class LeaveItemListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
         Action action = event.getAction();
-        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+        if (!action.isRightClick()) {
             return;
         }
         ItemStack item = event.getItem();

--- a/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
@@ -44,7 +44,7 @@ public class TeamSelectorListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
         Action action = event.getAction();
-        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+        if (!action.isRightClick()) {
             return;
         }
         ItemStack item = event.getItem();

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -8,8 +8,10 @@ import com.heneria.bedwars.arena.enums.GeneratorType;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
 
 import java.io.File;
 import java.util.*;
@@ -86,7 +88,9 @@ public class GeneratorManager {
             case EMERALD -> material = Material.EMERALD;
             default -> material = Material.IRON_INGOT;
         }
-        gen.getLocation().getWorld().dropItemNaturally(gen.getLocation(), new ItemStack(material, gs.amount()));
+        Location dropLoc = gen.getLocation().clone().add(0.5, 0.5, 0.5);
+        Item item = dropLoc.getWorld().dropItem(dropLoc, new ItemStack(material, gs.amount()));
+        item.setVelocity(new Vector(0, 0, 0));
     }
 
     private GeneratorSettings getSettings(Generator gen) {

--- a/src/main/resources/generators.yml
+++ b/src/main/resources/generators.yml
@@ -10,10 +10,10 @@ IRON:
     amount: 2
 GOLD:
   tier-1:
-    delay: 6.0
+    delay: 8.0
     amount: 1
   tier-2:
-    delay: 4.0
+    delay: 6.0
     amount: 1
 DIAMOND:
   tier-1:

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -89,6 +89,15 @@ shop-categories:
           resource: IRON
           amount: 24
         slot: 12
+      'tempered_glass':
+        material: GLASS
+        name: "&fVerre Trempé"
+        amount: 4
+        cost:
+          resource: IRON
+          amount: 12
+        slot: 13
+        action: 'TEMPERED_GLASS'
   'utilities_category':
     title: "Utilitaires"
     rows: 5
@@ -143,15 +152,6 @@ shop-categories:
           amount: 2
         slot: 15
         action: 'ENEMY_TRACKER'
-      'tempered_glass':
-        material: GLASS
-        name: "&fVerre Trempé"
-        amount: 4
-        cost:
-          resource: IRON
-          amount: 12
-        slot: 16
-        action: 'TEMPERED_GLASS'
       'magic_sponge':
         material: SPONGE
         name: "&eÉponge Magique"
@@ -159,7 +159,7 @@ shop-categories:
         cost:
           resource: GOLD
           amount: 3
-        slot: 17
+        slot: 16
         action: 'MAGIC_SPONGE'
       'safety_platform':
         material: SLIME_BLOCK
@@ -168,7 +168,7 @@ shop-categories:
         cost:
           resource: IRON
           amount: 20
-        slot: 18
+        slot: 17
         action: 'SAFETY_PLATFORM'
       'healer_milk':
         material: MILK_BUCKET
@@ -177,7 +177,7 @@ shop-categories:
         cost:
           resource: GOLD
           amount: 6
-        slot: 19
+        slot: 18
         action: 'HEALER_MILK'
   'armors_category':
     title: "Armures"


### PR DESCRIPTION
## Summary
- move tempered glass shop item to blocks and slow gold generators
- fix lobby item slots and right-click handling
- center generator drops and finalize changelog/roadmap for 1.0.0

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ad4a6a748329bd6488bc41bbc7eb