### PR TITLE
feat(shop): add potions, bows, and utility items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - HeneriaBedwars
 
+## [1.2.0] - 2024-05-27
+
+### Ajouté
+- Support des effets de potion et des enchantements dans `shop.yml`.
+- Nouvelles catégories de boutique : Potions, Combat à Distance et Utilitaires.
+- Ajout de potions de vitesse, de saut et d'invisibilité.
+- Ajout des flèches, d'un arc et d'un arc Puissant.
+- Ajout de la Pomme d'Or et du Seau d'eau.
+
 ## [1.1.0] - 2024-05-01
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ tools_category:
 
 Seul le prochain palier disponible est proposé à l'achat. Après une mort, les joueurs réapparaissent avec leur meilleure armure débloquée mais uniquement les outils et armes en bois.
 
+La configuration prend aussi en charge des objets plus avancés. La boutique par défaut inclut désormais les catégories « Potions », « Combat à Distance » et « Utilitaires » pour des effets temporaires, des arcs enchantés et des objets pratiques comme la Pomme d'Or.
+
+Les items peuvent définir des effets de potion et des enchantements personnalisés via les sections `potion-effects` et `enchantments` du `shop.yml` :
+
+```yaml
+speed-potion:
+  material: POTION
+  cost: { resource: EMERALD, amount: 1 }
+  potion-effects:
+    - { type: SPEED, duration: 45, amplifier: 0 }
+power-bow:
+  material: BOW
+  cost: { resource: GOLD, amount: 24 }
+  enchantments:
+    - { type: POWER, level: 1 }
+```
+
+La durée des effets est exprimée en secondes.
+
 ### Configuration des Pièges d'Équipe
 
 Les pièges sont définis dans le fichier `upgrades.yml` sous la section `traps`. Chaque piège possède un nom, un item de menu, un coût en diamants et un effet de potion appliqué à l'intrus.

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -19,6 +19,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.persistence.PersistentDataType;
 
 import java.util.*;
@@ -88,6 +90,7 @@ public class ShopItemsMenu extends Menu {
                     .addLore("&7Quantité: &f" + display.amount())
                     .addLore("&7Coût: &f" + display.costAmount() + " " + display.costResource().getDisplayName());
             ItemStack stack = builder.build();
+            applyCustomMeta(stack, display);
             stack.setAmount(display.amount());
             inventory.setItem(slot, stack);
             slotItems.put(slot, display);
@@ -147,6 +150,7 @@ public class ShopItemsMenu extends Menu {
                 }
                 give.setItemMeta(meta);
             }
+            applyCustomMeta(give, item);
             HeneriaBedwars.getInstance().getUpgradeManager().applyTeamUpgrades(clicker, give);
             handleUpgrade(clicker, item, give);
             clicker.playSound(clicker.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
@@ -159,6 +163,24 @@ public class ShopItemsMenu extends Menu {
             MessageManager.sendMessage(clicker, "errors.not-enough-resource", "resource", type.getDisplayName().toLowerCase());
             clicker.playSound(clicker.getLocation(), Sound.ENTITY_VILLAGER_NO, 1f, 1f);
         }
+    }
+
+    private void applyCustomMeta(ItemStack item, ShopManager.ShopItem data) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        if (meta instanceof PotionMeta potionMeta) {
+            for (ShopManager.PotionEffectData effect : data.potionEffects()) {
+                potionMeta.addCustomEffect(new PotionEffect(effect.type(), effect.duration() * 20, effect.amplifier()), true);
+            }
+            item.setItemMeta(potionMeta);
+            meta = item.getItemMeta();
+        }
+        for (Map.Entry<Enchantment, Integer> enchant : data.enchantments().entrySet()) {
+            meta.addEnchant(enchant.getKey(), enchant.getValue(), true);
+        }
+        item.setItemMeta(meta);
     }
 
     private int getTier(String type) {

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -38,8 +38,26 @@ main-menu:
         - "&7Pour creuser vite"
       slot: 14
       category: 'tools_category'
+    'potions':
+      material: BREWING_STAND
+      name: "&dPotions"
+      lore:
+        - "&7Effets temporaires puissants"
+      slot: 15
+      category: 'potions_category'
+    'ranged':
+      material: BOW
+      name: "&6Combat à Distance"
+      lore:
+        - "&7Arcs et flèches"
+      slot: 16
+      category: 'ranged_category'
 
 # Définition d'une catégorie d'objets
+# Chaque item peut définir des effets de potion via `potion-effects`
+#   - { type: SPEED, duration: 45, amplifier: 0 }  # durée en secondes
+# et des enchantements via `enchantments`
+#   - { type: POWER, level: 1 }
 shop-categories:
   'quick_buy_category':
     title: "Achats Rapides"
@@ -213,6 +231,22 @@ shop-categories:
           amount: 6
         slot: 20
         action: 'HEALER_MILK'
+      'golden_apple':
+        material: GOLDEN_APPLE
+        name: "&6Pomme d'Or"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 3
+        slot: 21
+      'water_bucket':
+        material: WATER_BUCKET
+        name: "&9Seau d'eau"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 3
+        slot: 22
 
   'armors_category':
     title: "Armures"
@@ -330,4 +364,70 @@ shop-categories:
           resource: IRON
           amount: 20
         slot: 12
+
+  'potions_category':
+    title: "Potions"
+    rows: 3
+    items:
+      'speed_potion':
+        material: POTION
+        name: "&bPotion de Vitesse (45s)"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 1
+        slot: 10
+        potion-effects:
+          - { type: SPEED, duration: 45, amplifier: 0 }
+      'jump_potion':
+        material: POTION
+        name: "&bPotion de Saut (45s)"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 1
+        slot: 11
+        potion-effects:
+          - { type: JUMP, duration: 45, amplifier: 1 }
+      'invisibility_potion':
+        material: POTION
+        name: "&bPotion d'Invisibilité (30s)"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 2
+        slot: 12
+        potion-effects:
+          - { type: INVISIBILITY, duration: 30, amplifier: 0 }
+
+  'ranged_category':
+    title: "Combat à Distance"
+    rows: 3
+    items:
+      'arrows':
+        material: ARROW
+        name: "&fFlèches"
+        amount: 8
+        cost:
+          resource: GOLD
+          amount: 2
+        slot: 10
+      'bow':
+        material: BOW
+        name: "&fArc"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 12
+        slot: 11
+      'power_bow':
+        material: BOW
+        name: "&6Arc Puissant"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 24
+        slot: 12
+        enchantments:
+          - { type: POWER, level: 1 }
 


### PR DESCRIPTION
## Summary
- extend shop loader to read `potion-effects` and `enchantments`
- create shop items with potion meta and enchantments
- add potions, ranged gear, and utility items to default shop config and docs

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1987b548329b6cd15cc03991d49