### PR TITLE
feat(shop): Add advanced items and fix compilation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog - HeneriaBedwars
 
+## [1.2.0] - 2024-05-03
+
+### Ajouté
+- Nouvelles catégories de boutique : Potions et Combat à Distance.
+- Potions de Vitesse, Saut et Invisibilité avec leurs effets configurables.
+- Flèches, Arc et Arc Puissant (Puissance I).
+- Pomme d'Or et Seau d'eau dans les Utilitaires.
+
+### Corrigé
+- Lecture robuste des listes `potion-effects` et `enchantments` dans `ShopManager`.
+- Remplacement de `PotionEffectType.valueOf` par `PotionEffectType.getByName`.
+
 ## [1.1.0] - 2024-05-01
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ tools_category:
         level: 2
 ```
 
+Les objets peuvent aussi définir des enchantements (`enchantments`) ou des effets de potion (`potion-effects`) via des listes de mappages :
+
+```yaml
+power_bow:
+  material: BOW
+  enchantments:
+    - type: POWER
+      level: 1
+speed_potion:
+  material: POTION
+  potion-effects:
+    - type: SPEED
+      duration: 45
+      amplifier: 1
+```
+
 Seul le prochain palier disponible est proposé à l'achat. Après une mort, les joueurs réapparaissent avec leur meilleure armure débloquée mais uniquement les outils et armes en bois.
 
 ### Configuration des Pièges d'Équipe

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -20,6 +20,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
 
 import java.util.*;
 
@@ -135,12 +136,21 @@ public class ShopItemsMenu extends Menu {
             ItemStack give = new ItemStack(material, item.amount());
             ItemMeta meta = give.getItemMeta();
             if (meta != null) {
+                meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', item.name()));
                 if (isSword) {
                     meta.getPersistentDataContainer().set(GameUtils.STARTER_KEY, PersistentDataType.BYTE, (byte) 1);
                 }
                 if (item.action() != null) {
                     meta.getPersistentDataContainer()
                             .set(HeneriaBedwars.getItemTypeKey(), PersistentDataType.STRING, item.action());
+                }
+                for (Map.Entry<Enchantment, Integer> entry : item.enchantments().entrySet()) {
+                    meta.addEnchant(entry.getKey(), entry.getValue(), true);
+                }
+                if (meta instanceof org.bukkit.inventory.meta.PotionMeta potionMeta) {
+                    for (PotionEffect effect : item.potionEffects()) {
+                        potionMeta.addCustomEffect(effect, true);
+                    }
                 }
                 if (give.getType().getMaxDurability() > 0) {
                     meta.setUnbreakable(true);

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -38,6 +38,20 @@ main-menu:
         - "&7Pour creuser vite"
       slot: 14
       category: 'tools_category'
+    'potions':
+      material: BREWING_STAND
+      name: "&dPotions"
+      lore:
+        - "&7Effets temporaires"
+      slot: 15
+      category: 'potions_category'
+    'ranged':
+      material: BOW
+      name: "&6Combat à Distance"
+      lore:
+        - "&7Arcs et flèches"
+      slot: 16
+      category: 'ranged_category'
 
 # Définition d'une catégorie d'objets
 shop-categories:
@@ -213,6 +227,22 @@ shop-categories:
           amount: 6
         slot: 20
         action: 'HEALER_MILK'
+      'golden_apple':
+        material: GOLDEN_APPLE
+        name: "&6Pomme d'Or"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 3
+        slot: 21
+      'water_bucket':
+        material: WATER_BUCKET
+        name: "&9Seau d'eau"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 3
+        slot: 22
 
   'armors_category':
     title: "Armures"
@@ -330,4 +360,77 @@ shop-categories:
           resource: IRON
           amount: 20
         slot: 12
+
+  'potions_category':
+    title: "Potions"
+    rows: 3
+    items:
+      'speed_potion':
+        material: POTION
+        name: "&bPotion de Vitesse"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 1
+        slot: 10
+        potion-effects:
+          - type: SPEED
+            duration: 45
+            amplifier: 1
+      'jump_potion':
+        material: POTION
+        name: "&aPotion de Saut"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 1
+        slot: 11
+        potion-effects:
+          - type: JUMP
+            duration: 45
+            amplifier: 2
+      'invisibility_potion':
+        material: POTION
+        name: "&7Potion d'Invisibilité"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 2
+        slot: 12
+        potion-effects:
+          - type: INVISIBILITY
+            duration: 30
+            amplifier: 0
+
+  'ranged_category':
+    title: "Combat à Distance"
+    rows: 3
+    items:
+      'arrows':
+        material: ARROW
+        name: "&fFlèches"
+        amount: 8
+        cost:
+          resource: IRON
+          amount: 8
+        slot: 10
+      'bow':
+        material: BOW
+        name: "&fArc"
+        amount: 1
+        cost:
+          resource: GOLD
+          amount: 12
+        slot: 11
+      'power_bow':
+        material: BOW
+        name: "&6Arc Puissant"
+        amount: 1
+        cost:
+          resource: EMERALD
+          amount: 6
+        slot: 12
+        enchantments:
+          - type: POWER
+            level: 1
 


### PR DESCRIPTION
## Summary
- extend shop configuration to support potion effects and enchantments
- add potions, ranged combat gear, golden apple and water bucket to default shop
- apply item enchantments and potion data when purchasing

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c4295e708329bea94830b0eeeecc