### PR TITLE
feat(integrations): Add Citizens API support for custom-skinned NPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [2.1.0] - 2024-05-06
+
+### Ajouté
+- Intégration optionnelle de l'API Citizens pour des PNJ de jonction et de boutique avec skins personnalisés.
+
 ## [2.0.0] - 2024-05-05
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # HeneriaBedwars
 
 **HeneriaBedwars** est un plugin BedWars moderne, performant et entièrement configurable pour les serveurs Spigot 1.21. Conçu pour être à la fois puissant pour les administrateurs et amusant pour les joueurs, il offre un cycle de jeu complet et une gestion intuitive.
+Il peut s'intégrer avec le plugin optionnel **Citizens** pour proposer des PNJ aux skins personnalisés.
 
 ---
 
@@ -51,8 +52,9 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 
 1.  Téléchargez la dernière version du plugin depuis la page [Releases](https://github.com/tomashb/HeneriaBW/releases).
 2.  Placez le fichier `.jar` téléchargé dans le dossier `plugins` de votre serveur Spigot 1.21.
-3.  Redémarrez votre serveur.
-4.  Les fichiers de configuration par défaut seront générés dans le dossier `plugins/HeneriaBedwars/`.
+3.  (Optionnel) Installez le plugin [Citizens](https://github.com/CitizensDev/Citizens2) pour activer les PNJ à skins personnalisés.
+4.  Redémarrez votre serveur.
+5.  Les fichiers de configuration par défaut seront générés dans le dossier `plugins/HeneriaBedwars/`.
 
 ---
 
@@ -70,9 +72,12 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - `/bw admin setmainlobby`
   - Définit la position du lobby principal BedWars.
   - **Permission :** `heneriabw.admin.setmainlobby`
-- `/bw admin setjoinnpc <mode>`
-  - Fait apparaître un PNJ de sélection d'arène pour le mode donné (ex: `solos`, `duos`).
+- `/bw admin setjoinnpc <mode> <nom_du_skin>`
+  - Fait apparaître un PNJ de sélection d'arène pour le mode donné (ex: `solos`, `duos`) avec le skin choisi.
   - **Permission :** `heneriabw.admin.setjoinnpc`
+- `/bw admin setshopnpc <équipe> <type_boutique> <nom_du_skin>`
+  - Place un PNJ de boutique (items ou améliorations) pour l'équipe donnée avec le skin choisi.
+  - **Permission :** `heneriabw.admin.setshopnpc`
 
 ### Commandes Joueurs
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.tomashb</groupId>
     <artifactId>HeneriaBedwars</artifactId>
-    <version>1.3.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>HeneriaBedwars</name>
@@ -57,6 +57,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -80,6 +84,13 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.citizensnpcs</groupId>
+            <artifactId>citizens-main</artifactId>
+            <version>2.0.33-SNAPSHOT</version>
+            <type>jar</type>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -64,14 +64,34 @@ public class AdminCommand implements SubCommand {
                 plugin.setMainLobby(player.getLocation());
                 player.sendMessage(ChatColor.GREEN + "Lobby principal défini.");
                 return;
-            } else if (sub.equals("setjoinnpc") && args.length >= 2) {
+            } else if (sub.equals("setjoinnpc") && args.length >= 3) {
                 if (!player.hasPermission("heneriabw.admin.setjoinnpc")) {
                     MessageManager.sendMessage(player, "errors.no-permission");
                     return;
                 }
+                if (!plugin.getNpcManager().isCitizensEnabled()) {
+                    player.sendMessage(ChatColor.RED + "Citizens n'est pas disponible.");
+                    return;
+                }
                 String mode = args[1].toLowerCase();
-                plugin.getNpcManager().addNpc(player.getLocation(), mode);
+                String skin = args[2];
+                plugin.getNpcManager().addJoinNpc(player.getLocation(), mode, skin);
                 player.sendMessage(ChatColor.GREEN + "PNJ de jonction " + mode + " placé.");
+                return;
+            } else if (sub.equals("setshopnpc") && args.length >= 4) {
+                if (!player.hasPermission("heneriabw.admin.setshopnpc")) {
+                    MessageManager.sendMessage(player, "errors.no-permission");
+                    return;
+                }
+                if (!plugin.getNpcManager().isCitizensEnabled()) {
+                    player.sendMessage(ChatColor.RED + "Citizens n'est pas disponible.");
+                    return;
+                }
+                String team = args[1];
+                String type = args[2];
+                String skin = args[3];
+                plugin.getNpcManager().addShopNpc(player.getLocation(), team, type, skin);
+                player.sendMessage(ChatColor.GREEN + "PNJ de boutique " + type + " pour l'équipe " + team + " placé.");
                 return;
             }
         }
@@ -86,7 +106,7 @@ public class AdminCommand implements SubCommand {
     @Override
     public List<String> tabComplete(Player player, String[] args) {
         if (args.length == 1) {
-            return Arrays.asList("delete", "confirmdelete", "setmainlobby", "setjoinnpc");
+            return Arrays.asList("delete", "confirmdelete", "setmainlobby", "setjoinnpc", "setshopnpc");
         }
         if (args.length == 2 && (args[0].equalsIgnoreCase("delete") || args[0].equalsIgnoreCase("confirmdelete"))) {
             List<String> names = new ArrayList<>();
@@ -99,6 +119,9 @@ public class AdminCommand implements SubCommand {
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("setjoinnpc")) {
             return Arrays.asList("solos", "duos", "trios", "quads");
+        }
+        if (args.length == 3 && args[0].equalsIgnoreCase("setshopnpc")) {
+            return Arrays.asList("item", "upgrade");
         }
         return Collections.emptyList();
     }

--- a/src/main/java/com/heneria/bedwars/listeners/JoinNpcListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/JoinNpcListener.java
@@ -3,7 +3,6 @@ package com.heneria.bedwars.listeners;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.gui.ArenaSelectorMenu;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -15,15 +14,12 @@ public class JoinNpcListener implements Listener {
 
     @EventHandler
     public void onInteract(PlayerInteractEntityEvent event) {
-        if (!(event.getRightClicked() instanceof Villager villager)) {
-            return;
-        }
-        String mode = HeneriaBedwars.getInstance().getNpcManager().getMode(villager);
+        Player player = event.getPlayer();
+        String mode = HeneriaBedwars.getInstance().getNpcManager().getJoinMode(event.getRightClicked());
         if (mode == null) {
             return;
         }
         event.setCancelled(true);
-        Player player = event.getPlayer();
         new ArenaSelectorMenu(mode).open(player);
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/ShopListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/ShopListener.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.gui.shop.ShopCategoryMenu;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
+import com.heneria.bedwars.managers.NpcManager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -15,6 +16,13 @@ public class ShopListener implements Listener {
 
     @EventHandler
     public void onInteract(PlayerInteractEntityEvent event) {
+        Player player = event.getPlayer();
+        NpcManager.ShopInfo info = HeneriaBedwars.getInstance().getNpcManager().getShopInfo(event.getRightClicked());
+        if (info != null && "item".equalsIgnoreCase(info.type())) {
+            event.setCancelled(true);
+            new ShopCategoryMenu(HeneriaBedwars.getInstance().getShopManager()).open(player);
+            return;
+        }
         if (!(event.getRightClicked() instanceof Villager villager)) {
             return;
         }
@@ -22,7 +30,6 @@ public class ShopListener implements Listener {
             return;
         }
         event.setCancelled(true);
-        Player player = event.getPlayer();
         new ShopCategoryMenu(HeneriaBedwars.getInstance().getShopManager()).open(player);
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/UpgradeListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/UpgradeListener.java
@@ -7,6 +7,7 @@ import com.heneria.bedwars.gui.upgrades.TeamUpgradesMenu;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
+import com.heneria.bedwars.managers.NpcManager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -18,15 +19,20 @@ public class UpgradeListener implements Listener {
 
     @EventHandler
     public void onInteract(PlayerInteractEntityEvent event) {
-        if (!(event.getRightClicked() instanceof Villager villager)) {
-            return;
-        }
-        if (!villager.getScoreboardTags().contains("upgrade_npc")) {
-            return;
-        }
-        event.setCancelled(true);
         Player player = event.getPlayer();
         HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+        NpcManager.ShopInfo info = plugin.getNpcManager().getShopInfo(event.getRightClicked());
+        if (info != null && "upgrade".equalsIgnoreCase(info.type())) {
+            event.setCancelled(true);
+        } else {
+            if (!(event.getRightClicked() instanceof Villager villager)) {
+                return;
+            }
+            if (!villager.getScoreboardTags().contains("upgrade_npc")) {
+                return;
+            }
+            event.setCancelled(true);
+        }
         Arena arena = plugin.getArenaManager().getArenaByPlayer(player.getUniqueId());
         if (arena == null) {
             return;

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -1,33 +1,40 @@
 package com.heneria.bedwars.managers;
 
 import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.utils.MessageManager;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.trait.traits.SkinTrait;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Villager;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Manages persistent join NPCs for the main lobby.
+ * Manages persistent NPCs (join and shop) using the Citizens API.
  */
 public class NpcManager {
 
     private final HeneriaBedwars plugin;
     private final File file;
     private final YamlConfiguration config;
-    private final List<NpcInfo> npcs = new ArrayList<>();
+    private final boolean citizens;
+
+    private final Map<Integer, String> joinNpcs = new HashMap<>();
+    private final Map<Integer, ShopInfo> shopNpcs = new HashMap<>();
 
     public NpcManager(HeneriaBedwars plugin) {
         this.plugin = plugin;
+        this.citizens = Bukkit.getPluginManager().getPlugin("Citizens") != null;
         this.file = new File(plugin.getDataFolder(), "npcs.yml");
         if (!file.exists()) {
             try {
@@ -41,68 +48,66 @@ public class NpcManager {
         loadNpcs();
     }
 
-    private double getDouble(Map<?, ?> map, String key) {
-        Object obj = map.get(key);
-        if (obj instanceof Number n) {
-            return n.doubleValue();
-        }
-        return 0;
+    public boolean isCitizensEnabled() {
+        return citizens;
     }
 
-    public void loadNpcs() {
-        npcs.clear();
+    private void loadNpcs() {
+        joinNpcs.clear();
+        shopNpcs.clear();
         List<Map<?, ?>> list = config.getMapList("npcs");
         for (Map<?, ?> map : list) {
-            String world = (String) map.get("world");
-            if (world == null) continue;
-            Location loc = new Location(
-                    Bukkit.getWorld(world),
-                    getDouble(map, "x"),
-                    getDouble(map, "y"),
-                    getDouble(map, "z"),
-                    (float) getDouble(map, "yaw"),
-                    (float) getDouble(map, "pitch"));
-            String mode = (String) map.get("mode");
-            spawnNpc(loc, mode);
-            npcs.add(new NpcInfo(loc, mode));
+            Object idObj = map.get("id");
+            if (!(idObj instanceof Number)) continue;
+            int id = ((Number) idObj).intValue();
+            String type = (String) map.get("type");
+            if ("join".equalsIgnoreCase(type)) {
+                String mode = (String) map.get("mode");
+                joinNpcs.put(id, mode);
+            } else if ("shop".equalsIgnoreCase(type)) {
+                String team = (String) map.get("team");
+                String shopType = (String) map.get("shopType");
+                shopNpcs.put(id, new ShopInfo(team, shopType));
+            }
+        }
+
+        if (citizens) {
+            for (int id : joinNpcs.keySet()) {
+                NPC npc = CitizensAPI.getNPCRegistry().getById(id);
+                if (npc != null) {
+                    npc.setProtected(true);
+                    if (!npc.isSpawned()) {
+                        npc.spawn(npc.getStoredLocation());
+                    }
+                }
+            }
+            for (int id : shopNpcs.keySet()) {
+                NPC npc = CitizensAPI.getNPCRegistry().getById(id);
+                if (npc != null) {
+                    npc.setProtected(true);
+                    if (!npc.isSpawned()) {
+                        npc.spawn(npc.getStoredLocation());
+                    }
+                }
+            }
         }
     }
 
-    public void spawnNpc(Location location, String mode) {
-        if (location == null || mode == null) return;
-        Villager npc = (Villager) location.getWorld().spawnEntity(location, EntityType.VILLAGER);
-        npc.setAI(false);
-        npc.setInvulnerable(true);
-        npc.setSilent(true);
-        npc.setCollidable(false);
-        npc.addScoreboardTag("joinnpc_" + mode.toLowerCase());
-        npc.setCustomName(ChatColor.translateAlternateColorCodes('&', "&a" + capitalize(mode)));
-        npc.setCustomNameVisible(true);
-    }
-
-    private String capitalize(String input) {
-        if (input == null || input.isEmpty()) return "";
-        return input.substring(0, 1).toUpperCase() + input.substring(1).toLowerCase();
-    }
-
-    public void addNpc(Location location, String mode) {
-        npcs.add(new NpcInfo(location, mode));
-        spawnNpc(location, mode);
-        saveNpcs();
-    }
-
-    public void saveNpcs() {
+    private void saveNpcs() {
         List<Map<String, Object>> list = new ArrayList<>();
-        for (NpcInfo info : npcs) {
-            Location loc = info.location;
-            Map<String, Object> map = new LinkedHashMap<>();
-            map.put("world", loc.getWorld().getName());
-            map.put("x", loc.getX());
-            map.put("y", loc.getY());
-            map.put("z", loc.getZ());
-            map.put("yaw", loc.getYaw());
-            map.put("pitch", loc.getPitch());
-            map.put("mode", info.mode);
+        for (Map.Entry<Integer, String> entry : joinNpcs.entrySet()) {
+            Map<String, Object> map = new HashMap<>();
+            map.put("id", entry.getKey());
+            map.put("type", "join");
+            map.put("mode", entry.getValue());
+            list.add(map);
+        }
+        for (Map.Entry<Integer, ShopInfo> entry : shopNpcs.entrySet()) {
+            Map<String, Object> map = new HashMap<>();
+            map.put("id", entry.getKey());
+            map.put("type", "shop");
+            map.put("team", entry.getValue().team());
+            map.put("shopType", entry.getValue().type());
             list.add(map);
         }
         config.set("npcs", list);
@@ -113,13 +118,36 @@ public class NpcManager {
         }
     }
 
-    /**
-     * Gets the mode associated with the given entity if it is a join NPC.
-     *
-     * @param entity the entity clicked
-     * @return mode string or {@code null}
-     */
-    public String getMode(Entity entity) {
+    public void addJoinNpc(Location location, String mode, String skin) {
+        if (!citizens) return;
+        String name = ChatColor.translateAlternateColorCodes('&', "&a" + capitalize(mode));
+        NPC npc = CitizensAPI.getNPCRegistry().createNPC(EntityType.PLAYER, name);
+        npc.spawn(location);
+        npc.setProtected(true);
+        npc.getOrAddTrait(SkinTrait.class).setSkinName(skin);
+        joinNpcs.put(npc.getId(), mode.toLowerCase());
+        saveNpcs();
+    }
+
+    public void addShopNpc(Location location, String team, String type, String skin) {
+        if (!citizens) return;
+        String baseName = type.equalsIgnoreCase("upgrade") ? MessageManager.get("game.upgrade-npc-name") : MessageManager.get("game.shop-npc-name");
+        String name = ChatColor.translateAlternateColorCodes('&', baseName);
+        NPC npc = CitizensAPI.getNPCRegistry().createNPC(EntityType.PLAYER, name);
+        npc.spawn(location);
+        npc.setProtected(true);
+        npc.getOrAddTrait(SkinTrait.class).setSkinName(skin);
+        shopNpcs.put(npc.getId(), new ShopInfo(team, type.toLowerCase()));
+        saveNpcs();
+    }
+
+    public String getJoinMode(Entity entity) {
+        if (citizens && entity.hasMetadata("NPC")) {
+            NPC npc = CitizensAPI.getNPCRegistry().getNPC(entity);
+            if (npc != null) {
+                return joinNpcs.get(npc.getId());
+            }
+        }
         for (String tag : entity.getScoreboardTags()) {
             if (tag.startsWith("joinnpc_")) {
                 return tag.substring("joinnpc_".length());
@@ -128,12 +156,28 @@ public class NpcManager {
         return null;
     }
 
-    private static class NpcInfo {
-        final Location location;
-        final String mode;
-        NpcInfo(Location location, String mode) {
-            this.location = location;
-            this.mode = mode;
+    public ShopInfo getShopInfo(Entity entity) {
+        if (citizens && entity.hasMetadata("NPC")) {
+            NPC npc = CitizensAPI.getNPCRegistry().getNPC(entity);
+            if (npc != null) {
+                return shopNpcs.get(npc.getId());
+            }
         }
+        return null;
+    }
+
+    private String capitalize(String input) {
+        if (input == null || input.isEmpty()) return "";
+        return input.substring(0, 1).toUpperCase() + input.substring(1).toLowerCase();
+    }
+
+    /**
+     * Information about a shop NPC.
+     *
+     * @param team team identifier
+     * @param type shop type (item or upgrade)
+     */
+    public record ShopInfo(String team, String type) {
     }
 }
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: ${project.version}
 main: com.heneria.bedwars.HeneriaBedwars
 api-version: '1.21'
 author: tomashb
+softdepend: [Citizens]
 
 commands:
   bedwars:
@@ -21,4 +22,7 @@ permissions:
     default: op
   heneriabw.admin.setjoinnpc:
     description: Place un PNJ de sélection d'arène.
+    default: op
+  heneriabw.admin.setshopnpc:
+    description: Place un PNJ de boutique.
     default: op


### PR DESCRIPTION
## Summary
- integrate optional Citizens API via Maven and plugin metadata
- allow admins to spawn join and shop NPCs with custom skins
- recognize Citizens NPC clicks in join and shop listeners

## Testing
- `mvn -q package` *(fails: Could not transfer artifact maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e95200ec832992e4f9c0a88d4008