### PR TITLE
refactor(npc)!: Remove Citizens integration and revert to Villager NPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [2.1.2] - 2024-05-07
+
+### Modifié
+- Suppression de l'intégration de Citizens et retour à un système de PNJ Villageois pour améliorer la stabilité.
+
 ## [2.1.0] - 2024-05-06
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 2.  Placez le fichier `.jar` téléchargé dans le dossier `plugins` de votre serveur Spigot 1.21.
 3.  Redémarrez votre serveur.
 4.  Les fichiers de configuration par défaut seront générés dans le dossier `plugins/HeneriaBedwars/`.
-5.  *(Optionnel)* Installez le plugin [Citizens](https://www.spigotmc.org/resources/citizens.13811/) pour permettre l'utilisation de PNJ joueurs avec skins personnalisés.
 
 ---
 
@@ -71,11 +70,11 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - `/bw admin setmainlobby`
   - Définit la position du lobby principal BedWars.
   - **Permission :** `heneriabw.admin.setmainlobby`
-- `/bw admin setjoinnpc <mode> <nom_du_skin>`
-  - Fait apparaître un PNJ joueur de sélection d'arène pour le mode donné (ex: `solos`, `duos`) avec le skin choisi.
+- `/bw admin setjoinnpc <mode>`
+  - Fait apparaître un Villageois de sélection d'arène pour le mode donné (ex: `solos`, `duos`).
   - **Permission :** `heneriabw.admin.setjoinnpc`
-- `/bw admin setshopnpc <équipe> <type_boutique> <nom_du_skin>`
-  - Place un PNJ de boutique (`item` ou `upgrade`) pour l'équipe spécifiée avec le skin choisi.
+- `/bw admin setshopnpc <équipe> <type_boutique>`
+  - Place un Villageois de boutique (`item` ou `upgrade`) pour l'équipe spécifiée.
   - **Permission :** `heneriabw.admin.setshopnpc`
 
 ### Commandes Joueurs

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.tomashb</groupId>
     <artifactId>HeneriaBedwars</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.2</version>
     <packaging>jar</packaging>
 
     <name>HeneriaBedwars</name>
@@ -57,10 +57,6 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
-        <repository>
-            <id>citizens-repo</id>
-            <url>https://maven.citizensnpcs.co/repo</url>
-        </repository>
     </repositories>
 
     <dependencies>
@@ -84,13 +80,6 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.citizensnpcs</groupId>
-            <artifactId>citizens-api</artifactId>
-            <version>2.0.33-SNAPSHOT</version>
-            <type>jar</type>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -4,10 +4,6 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.gui.admin.AdminMainMenu;
 import com.heneria.bedwars.utils.MessageManager;
-import net.citizensnpcs.api.CitizensAPI;
-import net.citizensnpcs.api.npc.NPC;
-import net.citizensnpcs.api.trait.traits.SkinTrait;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -70,45 +66,34 @@ public class AdminCommand implements SubCommand {
                 plugin.setMainLobby(player.getLocation());
                 player.sendMessage(ChatColor.GREEN + "Lobby principal défini.");
                 return;
-            } else if (sub.equals("setjoinnpc") && args.length >= 3) {
+            } else if (sub.equals("setjoinnpc") && args.length >= 2) {
                 if (!player.hasPermission("heneriabw.admin.setjoinnpc")) {
                     MessageManager.sendMessage(player, "errors.no-permission");
                     return;
                 }
                 String mode = args[1].toLowerCase();
-                String skin = args[2];
-                plugin.getNpcManager().addNpc(player.getLocation(), mode, skin);
-                player.sendMessage(ChatColor.GREEN + "PNJ de jonction " + mode + " placé avec le skin " + skin + ".");
+                plugin.getNpcManager().addNpc(player.getLocation(), mode);
+                player.sendMessage(ChatColor.GREEN + "PNJ de jonction " + mode + " placé.");
                 return;
-            } else if (sub.equals("setshopnpc") && args.length >= 4) {
+            } else if (sub.equals("setshopnpc") && args.length >= 3) {
                 if (!player.hasPermission("heneriabw.admin.setshopnpc")) {
                     MessageManager.sendMessage(player, "errors.no-permission");
                     return;
                 }
                 String team = args[1];
                 String type = args[2].toLowerCase();
-                String skin = args[3];
-                if (Bukkit.getPluginManager().isPluginEnabled("Citizens")) {
-                    String name = type.equals("upgrade") ? ChatColor.translateAlternateColorCodes('&', MessageManager.get("game.upgrade-npc-name")) : ChatColor.translateAlternateColorCodes('&', MessageManager.get("game.shop-npc-name"));
-                    NPC npc = CitizensAPI.getNPCRegistry().createNPC(EntityType.PLAYER, name);
-                    npc.setProtected(true);
-                    npc.getOrAddTrait(SkinTrait.class).setSkinName(skin);
-                    npc.spawn(player.getLocation());
-                    npc.getEntity().addScoreboardTag(type.equals("upgrade") ? "upgrade_npc" : "shop_npc");
+                Villager npc = (Villager) player.getWorld().spawnEntity(player.getLocation(), EntityType.VILLAGER);
+                npc.setAI(false);
+                npc.setInvulnerable(true);
+                npc.setSilent(true);
+                npc.setCollidable(false);
+                npc.addScoreboardTag(type.equals("upgrade") ? "upgrade_npc" : "shop_npc");
+                if (type.equals("upgrade")) {
+                    npc.setCustomName(MessageManager.get("game.upgrade-npc-name"));
                 } else {
-                    Villager npc = (Villager) player.getWorld().spawnEntity(player.getLocation(), EntityType.VILLAGER);
-                    npc.setAI(false);
-                    npc.setInvulnerable(true);
-                    npc.setSilent(true);
-                    npc.setCollidable(false);
-                    npc.addScoreboardTag(type.equals("upgrade") ? "upgrade_npc" : "shop_npc");
-                    if (type.equals("upgrade")) {
-                        npc.setCustomName(MessageManager.get("game.upgrade-npc-name"));
-                    } else {
-                        npc.setCustomName(MessageManager.get("game.shop-npc-name"));
-                    }
-                    npc.setCustomNameVisible(true);
+                    npc.setCustomName(MessageManager.get("game.shop-npc-name"));
                 }
+                npc.setCustomNameVisible(true);
                 player.sendMessage(ChatColor.GREEN + "PNJ de boutique " + type + " pour l'équipe " + team + " placé.");
                 return;
             }
@@ -138,17 +123,11 @@ public class AdminCommand implements SubCommand {
         if (args.length == 2 && args[0].equalsIgnoreCase("setjoinnpc")) {
             return Arrays.asList("solos", "duos", "trios", "quads");
         }
-        if (args.length == 3 && args[0].equalsIgnoreCase("setjoinnpc")) {
-            return Collections.singletonList("<skin>");
-        }
         if (args.length == 2 && args[0].equalsIgnoreCase("setshopnpc")) {
             return Collections.singletonList("<team>");
         }
         if (args.length == 3 && args[0].equalsIgnoreCase("setshopnpc")) {
             return Arrays.asList("item", "upgrade");
-        }
-        if (args.length == 4 && args[0].equalsIgnoreCase("setshopnpc")) {
-            return Collections.singletonList("<skin>");
         }
         return Collections.emptyList();
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,6 @@ version: ${project.version}
 main: com.heneria.bedwars.HeneriaBedwars
 api-version: '1.21'
 author: tomashb
-softdepend: [Citizens]
 
 commands:
   bedwars:


### PR DESCRIPTION
## Summary
- remove Citizens plugin dependency and related code
- spawn invulnerable villager NPCs and save their locations
- document simplified NPC commands and citizens removal

## Testing
- `mvn -q -e package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fc62c8e88329acae3a6775e07302