### PR TITLE
feat(npc)!: Replace Villager NPCs with custom skinned Armor Stands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [2.2.0] - 2024-05-08
+
+### Modifié
+- Remplacement des PNJ Villageois par un système de Supports d'Armure personnalisables.
+
 ## [2.1.2] - 2024-05-07
 
 ### Modifié

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - `/bw admin setmainlobby`
   - Définit la position du lobby principal BedWars.
   - **Permission :** `heneriabw.admin.setmainlobby`
-- `/bw admin setjoinnpc <mode>`
-  - Fait apparaître un Villageois de sélection d'arène pour le mode donné (ex: `solos`, `duos`).
-  - **Permission :** `heneriabw.admin.setjoinnpc`
-- `/bw admin setshopnpc <équipe> <type_boutique>`
-  - Place un Villageois de boutique (`item` ou `upgrade`) pour l'équipe spécifiée.
-  - **Permission :** `heneriabw.admin.setshopnpc`
+  - `/bw admin setjoinnpc <mode> <nom_du_skin> <item_en_main> <nom_du_pnj>`
+    - Crée un PNJ de sélection d'arène (support d'armure) pour le mode donné avec le skin, l'item et le nom spécifiés.
+    - **Permission :** `heneriabw.admin.setjoinnpc`
+  - `/bw admin setshopnpc <équipe> <type_boutique>`
+    - Place un PNJ de boutique (`item` ou `upgrade`) sous forme de support d'armure pour l'équipe spécifiée.
+    - **Permission :** `heneriabw.admin.setshopnpc`
 
 ### Commandes Joueurs
 

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -59,11 +59,13 @@ public final class HeneriaBedwars extends JavaPlugin {
     private NpcManager npcManager;
     private Location mainLobby;
     private static NamespacedKey itemTypeKey;
+    private static NamespacedKey npcKey;
 
     @Override
     public void onEnable() {
         instance = this;
         itemTypeKey = new NamespacedKey(this, "heneria_item_type");
+        npcKey = new NamespacedKey(this, "heneria_npc");
         saveDefaultConfig();
         mainLobby = getConfig().getLocation("main-lobby");
         MessageManager.init(this);
@@ -174,6 +176,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public static NamespacedKey getItemTypeKey() {
         return itemTypeKey;
+    }
+
+    public static NamespacedKey getNpcKey() {
+        return npcKey;
     }
 
     public PlayerProgressionManager getPlayerProgressionManager() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -22,11 +22,14 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.EnderDragon;
 import org.bukkit.World;
 import org.bukkit.GameRule;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -374,14 +377,21 @@ public class Arena {
         if (specialNpcLocation == null || specialNpc != null) {
             return;
         }
-        Villager npc = (Villager) specialNpcLocation.getWorld().spawnEntity(specialNpcLocation, EntityType.VILLAGER);
-        npc.setAI(false);
+        ArmorStand npc = (ArmorStand) specialNpcLocation.getWorld().spawnEntity(specialNpcLocation, EntityType.ARMOR_STAND);
+        npc.setInvisible(true);
         npc.setInvulnerable(true);
-        npc.setSilent(true);
-        npc.setCollidable(false);
-        npc.addScoreboardTag("special_npc");
+        npc.setGravity(false);
+        npc.setBasePlate(false);
+        npc.setArms(true);
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta meta = (SkullMeta) head.getItemMeta();
+        meta.setOwningPlayer(Bukkit.getOfflinePlayer("MHF_Villager"));
+        head.setItemMeta(meta);
+        npc.getEquipment().setHelmet(head);
+        npc.getEquipment().setItemInMainHand(new ItemStack(Material.BLAZE_ROD));
         npc.setCustomName(ChatColor.translateAlternateColorCodes('&', "&5Marchand Mystérieux"));
         npc.setCustomNameVisible(true);
+        npc.getPersistentDataContainer().set(HeneriaBedwars.getNpcKey(), PersistentDataType.STRING, "special");
         liveNpcs.add(npc);
         specialNpc = npc;
     }
@@ -625,25 +635,39 @@ public class Arena {
 
         for (Team team : this.getTeams().values()) {
             if (team.getItemShopNpcLocation() != null) {
-                Villager npc = (Villager) team.getItemShopNpcLocation().getWorld().spawnEntity(team.getItemShopNpcLocation(), EntityType.VILLAGER);
-                npc.setAI(false);
+                ArmorStand npc = (ArmorStand) team.getItemShopNpcLocation().getWorld().spawnEntity(team.getItemShopNpcLocation(), EntityType.ARMOR_STAND);
+                npc.setInvisible(true);
                 npc.setInvulnerable(true);
-                npc.setSilent(true);
-                npc.setCollidable(false);
-                npc.addScoreboardTag("shop_npc");
+                npc.setGravity(false);
+                npc.setBasePlate(false);
+                npc.setArms(true);
+                ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+                SkullMeta meta = (SkullMeta) head.getItemMeta();
+                meta.setOwningPlayer(Bukkit.getOfflinePlayer("MHF_Villager"));
+                head.setItemMeta(meta);
+                npc.getEquipment().setHelmet(head);
+                npc.getEquipment().setItemInMainHand(new ItemStack(Material.EMERALD));
                 npc.setCustomName(MessageManager.get("game.shop-npc-name"));
                 npc.setCustomNameVisible(true);
+                npc.getPersistentDataContainer().set(HeneriaBedwars.getNpcKey(), PersistentDataType.STRING, "shop");
                 liveNpcs.add(npc);
             }
             if (team.getUpgradeShopNpcLocation() != null) {
-                Villager npc = (Villager) team.getUpgradeShopNpcLocation().getWorld().spawnEntity(team.getUpgradeShopNpcLocation(), EntityType.VILLAGER);
-                npc.setAI(false);
+                ArmorStand npc = (ArmorStand) team.getUpgradeShopNpcLocation().getWorld().spawnEntity(team.getUpgradeShopNpcLocation(), EntityType.ARMOR_STAND);
+                npc.setInvisible(true);
                 npc.setInvulnerable(true);
-                npc.setSilent(true);
-                npc.setCollidable(false);
-                npc.addScoreboardTag("upgrade_npc");
+                npc.setGravity(false);
+                npc.setBasePlate(false);
+                npc.setArms(true);
+                ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+                SkullMeta meta = (SkullMeta) head.getItemMeta();
+                meta.setOwningPlayer(Bukkit.getOfflinePlayer("MHF_Villager"));
+                head.setItemMeta(meta);
+                npc.getEquipment().setHelmet(head);
+                npc.getEquipment().setItemInMainHand(new ItemStack(Material.NETHER_STAR));
                 npc.setCustomName(MessageManager.get("game.upgrade-npc-name"));
                 npc.setCustomNameVisible(true);
+                npc.getPersistentDataContainer().set(HeneriaBedwars.getNpcKey(), PersistentDataType.STRING, "upgrade");
                 liveNpcs.add(npc);
             }
         }

--- a/src/main/java/com/heneria/bedwars/listeners/JoinNpcListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/JoinNpcListener.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 
 /**
  * Opens the arena selector menu when clicking a join NPC.
@@ -14,7 +14,7 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 public class JoinNpcListener implements Listener {
 
     @EventHandler
-    public void onInteract(PlayerInteractEntityEvent event) {
+    public void onInteract(PlayerInteractAtEntityEvent event) {
         Entity entity = event.getRightClicked();
         String mode = HeneriaBedwars.getInstance().getNpcManager().getMode(entity);
         if (mode == null) {

--- a/src/main/java/com/heneria/bedwars/listeners/ShopListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/ShopListener.java
@@ -6,7 +6,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.persistence.PersistentDataType;
 
 /**
  * Handles player interaction with shop NPCs.
@@ -14,9 +15,10 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 public class ShopListener implements Listener {
 
     @EventHandler
-    public void onInteract(PlayerInteractEntityEvent event) {
+    public void onInteract(PlayerInteractAtEntityEvent event) {
         Entity entity = event.getRightClicked();
-        if (!entity.getScoreboardTags().contains("shop_npc")) {
+        String type = entity.getPersistentDataContainer().get(HeneriaBedwars.getNpcKey(), PersistentDataType.STRING);
+        if (!"shop".equals(type)) {
             return;
         }
         event.setCancelled(true);

--- a/src/main/java/com/heneria/bedwars/listeners/SpecialNpcListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SpecialNpcListener.java
@@ -7,7 +7,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.persistence.PersistentDataType;
 
 /**
  * Opens the special shop menu when interacting with the special NPC.
@@ -15,9 +16,10 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 public class SpecialNpcListener implements Listener {
 
     @EventHandler
-    public void onInteract(PlayerInteractEntityEvent event) {
+    public void onInteract(PlayerInteractAtEntityEvent event) {
         Entity entity = event.getRightClicked();
-        if (!entity.getScoreboardTags().contains("special_npc")) {
+        String type = entity.getPersistentDataContainer().get(HeneriaBedwars.getNpcKey(), PersistentDataType.STRING);
+        if (!"special".equals(type)) {
             return;
         }
         event.setCancelled(true);

--- a/src/main/java/com/heneria/bedwars/listeners/UpgradeListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/UpgradeListener.java
@@ -9,7 +9,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.persistence.PersistentDataType;
 
 /**
  * Handles interaction with upgrade shop NPCs.
@@ -17,9 +18,10 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 public class UpgradeListener implements Listener {
 
     @EventHandler
-    public void onInteract(PlayerInteractEntityEvent event) {
+    public void onInteract(PlayerInteractAtEntityEvent event) {
         Entity entity = event.getRightClicked();
-        if (!entity.getScoreboardTags().contains("upgrade_npc")) {
+        String type = entity.getPersistentDataContainer().get(HeneriaBedwars.getNpcKey(), PersistentDataType.STRING);
+        if (!"upgrade".equals(type)) {
             return;
         }
         event.setCancelled(true);

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -4,10 +4,15 @@ import com.heneria.bedwars.HeneriaBedwars;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Villager;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +30,7 @@ public class NpcManager {
     private final File file;
     private final YamlConfiguration config;
     private final List<NpcInfo> npcs = new ArrayList<>();
+    private final NamespacedKey npcKey;
 
     public NpcManager(HeneriaBedwars plugin) {
         this.plugin = plugin;
@@ -38,6 +44,7 @@ public class NpcManager {
             }
         }
         this.config = YamlConfiguration.loadConfiguration(file);
+        this.npcKey = HeneriaBedwars.getNpcKey();
         loadNpcs();
     }
 
@@ -63,7 +70,21 @@ public class NpcManager {
                     (float) getDouble(map, "yaw"),
                     (float) getDouble(map, "pitch"));
             String mode = (String) map.get("mode");
-            NpcInfo info = new NpcInfo(loc, mode);
+            String skin = (String) map.getOrDefault("skin", "Steve");
+            String name = (String) map.getOrDefault("name", "&a" + capitalize(mode));
+            String itemStr = (String) map.get("item");
+            Material item = itemStr != null ? Material.matchMaterial(itemStr) : null;
+            List<String> armorList = (List<String>) map.get("armor");
+            List<Material> armor = new ArrayList<>();
+            if (armorList != null) {
+                for (String s : armorList) {
+                    Material m = Material.matchMaterial(s);
+                    if (m != null) {
+                        armor.add(m);
+                    }
+                }
+            }
+            NpcInfo info = new NpcInfo(loc, mode, skin, name, item, armor);
             spawnNpc(info);
             npcs.add(info);
         }
@@ -71,13 +92,38 @@ public class NpcManager {
 
     public void spawnNpc(NpcInfo info) {
         if (info.location == null || info.mode == null) return;
-        Villager npc = (Villager) info.location.getWorld().spawnEntity(info.location, EntityType.VILLAGER);
-        npc.setAI(false);
+        ArmorStand npc = (ArmorStand) info.location.getWorld().spawnEntity(info.location, EntityType.ARMOR_STAND);
+        npc.setInvisible(true);
         npc.setInvulnerable(true);
-        npc.setSilent(true);
-        npc.setCollidable(false);
-        npc.setCustomName(ChatColor.translateAlternateColorCodes('&', "&a" + capitalize(info.mode)));
+        npc.setGravity(false);
+        npc.setBasePlate(false);
+        npc.setArms(true);
+        npc.setCustomName(ChatColor.translateAlternateColorCodes('&', info.name));
         npc.setCustomNameVisible(true);
+        npc.getPersistentDataContainer().set(npcKey, PersistentDataType.STRING, info.mode);
+
+        // Head with skin
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta meta = (SkullMeta) head.getItemMeta();
+        meta.setOwningPlayer(Bukkit.getOfflinePlayer(info.skin));
+        head.setItemMeta(meta);
+        npc.getEquipment().setHelmet(head);
+
+        if (info.item != null) {
+            npc.getEquipment().setItemInMainHand(new ItemStack(info.item));
+        }
+        // Equip armor pieces if provided
+        if (!info.armor.isEmpty()) {
+            if (info.armor.size() > 0 && info.armor.get(0) != null) {
+                npc.getEquipment().setChestplate(new ItemStack(info.armor.get(0)));
+            }
+            if (info.armor.size() > 1 && info.armor.get(1) != null) {
+                npc.getEquipment().setLeggings(new ItemStack(info.armor.get(1)));
+            }
+            if (info.armor.size() > 2 && info.armor.get(2) != null) {
+                npc.getEquipment().setBoots(new ItemStack(info.armor.get(2)));
+            }
+        }
     }
 
     private String capitalize(String input) {
@@ -85,8 +131,8 @@ public class NpcManager {
         return input.substring(0, 1).toUpperCase() + input.substring(1).toLowerCase();
     }
 
-    public void addNpc(Location location, String mode) {
-        NpcInfo info = new NpcInfo(location, mode);
+    public void addNpc(Location location, String mode, String skin, Material item, String name, List<Material> armor) {
+        NpcInfo info = new NpcInfo(location, mode, skin, name, item, armor);
         npcs.add(info);
         spawnNpc(info);
         saveNpcs();
@@ -104,6 +150,18 @@ public class NpcManager {
             map.put("yaw", loc.getYaw());
             map.put("pitch", loc.getPitch());
             map.put("mode", info.mode);
+            map.put("skin", info.skin);
+            map.put("name", info.name);
+            if (info.item != null) {
+                map.put("item", info.item.name());
+            }
+            if (!info.armor.isEmpty()) {
+                List<String> armor = new ArrayList<>();
+                for (Material m : info.armor) {
+                    armor.add(m.name());
+                }
+                map.put("armor", armor);
+            }
             list.add(map);
         }
         config.set("npcs", list);
@@ -121,29 +179,28 @@ public class NpcManager {
      * @return mode string or {@code null}
      */
     public String getMode(Entity entity) {
-        if (entity.getType() != EntityType.VILLAGER) {
+        if (entity.getType() != EntityType.ARMOR_STAND) {
             return null;
         }
-        Location loc = entity.getLocation();
-        for (NpcInfo info : npcs) {
-            Location iLoc = info.location;
-            if (loc.getWorld().equals(iLoc.getWorld())
-                    && loc.getBlockX() == iLoc.getBlockX()
-                    && loc.getBlockY() == iLoc.getBlockY()
-                    && loc.getBlockZ() == iLoc.getBlockZ()) {
-                return info.mode;
-            }
-        }
-        return null;
+        String mode = entity.getPersistentDataContainer().get(npcKey, PersistentDataType.STRING);
+        return mode;
     }
 
     private static class NpcInfo {
         final Location location;
         final String mode;
+        final String skin;
+        final String name;
+        final Material item;
+        final List<Material> armor;
 
-        NpcInfo(Location location, String mode) {
+        NpcInfo(Location location, String mode, String skin, String name, Material item, List<Material> armor) {
             this.location = location;
             this.mode = mode;
+            this.skin = skin;
+            this.name = name;
+            this.item = item;
+            this.armor = armor;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace villager NPCs with configurable armor stand counterparts
- update join and shop NPC commands to support skins and items
- switch NPC interactions to PlayerInteractAtEntityEvent with persistent tags

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5805c31588329885ac1f0cc4d9dea