### PR TITLE
fix(build): Correct unsafe type casting in NpcManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Modifié
 - Suppression de l'intégration de Citizens et retour à un système de PNJ Villageois pour améliorer la stabilité.
 
+### Corrigé
+- Correction d'une erreur de compilation dans le `NpcManager` liée au typage des données de configuration.
+
 ## [2.1.0] - 2024-05-06
 
 ### Corrigé

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -70,8 +70,10 @@ public class NpcManager {
                     (float) getDouble(map, "yaw"),
                     (float) getDouble(map, "pitch"));
             String mode = (String) map.get("mode");
-            String skin = (String) map.getOrDefault("skin", "Steve");
-            String name = (String) map.getOrDefault("name", "&a" + capitalize(mode));
+            Object skinObj = map.get("skin");
+            String skin = skinObj != null ? String.valueOf(skinObj) : "Steve";
+            Object nameObj = map.get("name");
+            String name = nameObj != null ? String.valueOf(nameObj) : "&a" + capitalize(mode);
             String itemStr = (String) map.get("item");
             Material item = itemStr != null ? Material.matchMaterial(itemStr) : null;
             List<String> armorList = (List<String>) map.get("armor");


### PR DESCRIPTION
## Summary
- prevent generic map type errors by safely converting skin and name entries to strings
- note compilation fix for NPC manager configuration handling

## Testing
- `mvn -B package --file pom.xml` *(fails: Could not transfer artifact from Maven central; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a583c748188329b8a5497b1d6c33a0