### PR TITLE
feat(admin): Add command to remove NPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [2.2.1] - 2024-05-09
+
+### Ajouté
+- Ajout de la commande /bw admin removenpc pour supprimer les PNJ du lobby.
+
 ## [2.2.0] - 2024-05-08
 
 ### Modifié

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
   - `/bw admin setshopnpc <équipe> <type_boutique>`
     - Place un PNJ de boutique (`item` ou `upgrade`) sous forme de support d'armure pour l'équipe spécifiée.
     - **Permission :** `heneriabw.admin.setshopnpc`
+  - `/bw admin removenpc`
+    - Supprime le PNJ HeneriaBedwars le plus proche de vous dans le lobby.
+    - **Permission :** `heneriabw.admin.removenpc`
 
 ### Commandes Joueurs
 

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -112,6 +112,18 @@ public class AdminCommand implements SubCommand {
                 npc.setCustomNameVisible(true);
                 player.sendMessage(ChatColor.GREEN + "PNJ de boutique " + type + " pour l'équipe " + team + " placé.");
                 return;
+            } else if (sub.equals("removenpc")) {
+                if (!player.hasPermission("heneriabw.admin.removenpc")) {
+                    MessageManager.sendMessage(player, "errors.no-permission");
+                    return;
+                }
+                boolean removed = plugin.getNpcManager().removeNearestNpc(player, 10);
+                if (removed) {
+                    player.sendMessage(ChatColor.GREEN + "Le PNJ le plus proche a été supprimé.");
+                } else {
+                    player.sendMessage(ChatColor.RED + "Aucun PNJ HeneriaBedwars trouvé à proximité.");
+                }
+                return;
             }
         }
 
@@ -125,7 +137,7 @@ public class AdminCommand implements SubCommand {
     @Override
     public List<String> tabComplete(Player player, String[] args) {
         if (args.length == 1) {
-            return Arrays.asList("delete", "confirmdelete", "setmainlobby", "setjoinnpc", "setshopnpc");
+            return Arrays.asList("delete", "confirmdelete", "setmainlobby", "setjoinnpc", "setshopnpc", "removenpc");
         }
         if (args.length == 2 && (args[0].equalsIgnoreCase("delete") || args[0].equalsIgnoreCase("confirmdelete"))) {
             List<String> names = new ArrayList<>();


### PR DESCRIPTION
## Summary
- add `/bw admin removenpc` command protected by `heneriabw.admin.removenpc`
- remove the nearest lobby NPC and its config entry
- document the new removal command

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68a58929ad148329a5c7b38aa7f6ecc3