### PR TITLE
feat(npc)!: Replace Villager NPCs with custom skinned Armor Stands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - `/bw admin setmainlobby`
   - Définit la position du lobby principal BedWars.
   - **Permission :** `heneriabw.admin.setmainlobby`
-  - `/bw admin setjoinnpc <mode> <nom_du_skin> <item_en_main> <nom_du_pnj>`
-    - Crée un PNJ de sélection d'arène (support d'armure) pour le mode donné avec le skin, l'item et le nom spécifiés.
+  - `/bw admin setjoinnpc <mode> <nom_du_skin> <item_en_main> <nom_du_pnj> [<plastron> <jambieres> <bottes>]`
+    - Crée un PNJ de sélection d'arène (support d'armure) pour le mode donné avec le skin, l'item, le nom et éventuellement un set d'armure personnalisée.
     - **Permission :** `heneriabw.admin.setjoinnpc`
   - `/bw admin setshopnpc <équipe> <type_boutique>`
     - Place un PNJ de boutique (`item` ou `upgrade`) sous forme de support d'armure pour l'équipe spécifiée.

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -79,8 +79,15 @@ public class AdminCommand implements SubCommand {
                 String mode = args[1].toLowerCase();
                 String skin = args[2];
                 Material item = Material.matchMaterial(args[3].toUpperCase());
-                String name = ChatColor.translateAlternateColorCodes('&', String.join(" ", Arrays.copyOfRange(args, 4, args.length)));
-                plugin.getNpcManager().addNpc(player.getLocation(), mode, skin, item, name, new ArrayList<>());
+                String name = ChatColor.translateAlternateColorCodes('&', args[4]);
+                List<Material> armor = new ArrayList<>();
+                for (int i = 5; i < args.length; i++) {
+                    Material m = Material.matchMaterial(args[i].toUpperCase());
+                    if (m != null) {
+                        armor.add(m);
+                    }
+                }
+                plugin.getNpcManager().addNpc(player.getLocation(), mode, skin, item, name, armor);
                 player.sendMessage(ChatColor.GREEN + "PNJ de jonction " + mode + " placé.");
                 return;
             } else if (sub.equals("setshopnpc") && args.length >= 3) {


### PR DESCRIPTION
## Summary
- allow join NPC creation command to define optional armor for custom skinned armor stands
- document extended NPC command syntax and customization options

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a58b5108a88329a89bc7c462611193