### PR TITLE
feat(npc): Allow equipping armor on Armor Stand NPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Ajouté
 - Ajout de la commande /bw admin removenpc pour supprimer les PNJ du lobby.
+- Ajout de la possibilité d'équiper les PNJ avec une armure.
 
 ## [2.2.0] - 2024-05-08
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
   - `/bw admin setjoinnpc <mode> <nom_du_skin> <item_en_main> <nom_du_pnj> [<plastron> <jambieres> <bottes>]`
     - Crée un PNJ de sélection d'arène (support d'armure) pour le mode donné avec le skin, l'item, le nom et éventuellement un set d'armure personnalisée.
     - **Permission :** `heneriabw.admin.setjoinnpc`
-  - `/bw admin setshopnpc <équipe> <type_boutique>`
-    - Place un PNJ de boutique (`item` ou `upgrade`) sous forme de support d'armure pour l'équipe spécifiée.
+  - `/bw admin setshopnpc <équipe> <type_boutique> [<plastron> <jambieres> <bottes>]`
+    - Place un PNJ de boutique (`item` ou `upgrade`) sous forme de support d'armure pour l'équipe spécifiée. L'armure en cuir est automatiquement teinte à la couleur de l'équipe.
     - **Permission :** `heneriabw.admin.setshopnpc`
   - `/bw admin removenpc`
     - Supprime le PNJ HeneriaBedwars le plus proche de vous dans le lobby.

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -29,6 +29,7 @@ import org.bukkit.World;
 import org.bukkit.GameRule;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
@@ -650,6 +651,7 @@ public class Arena {
                 npc.setCustomName(MessageManager.get("game.shop-npc-name"));
                 npc.setCustomNameVisible(true);
                 npc.getPersistentDataContainer().set(HeneriaBedwars.getNpcKey(), PersistentDataType.STRING, "shop");
+                equipNpcArmor(npc, team.getItemShopChestplate(), team.getItemShopLeggings(), team.getItemShopBoots(), team.getColor());
                 liveNpcs.add(npc);
             }
             if (team.getUpgradeShopNpcLocation() != null) {
@@ -668,12 +670,39 @@ public class Arena {
                 npc.setCustomName(MessageManager.get("game.upgrade-npc-name"));
                 npc.setCustomNameVisible(true);
                 npc.getPersistentDataContainer().set(HeneriaBedwars.getNpcKey(), PersistentDataType.STRING, "upgrade");
+                equipNpcArmor(npc, team.getUpgradeShopChestplate(), team.getUpgradeShopLeggings(), team.getUpgradeShopBoots(), team.getColor());
                 liveNpcs.add(npc);
             }
         }
         System.out.println("[DEBUG-STARTGAME] Apparition des PNJ terminée.");
 
         System.out.println("[DEBUG-STARTGAME] La méthode startGame a terminé son exécution SANS ERREUR.");
+    }
+
+    private void equipNpcArmor(ArmorStand npc, Material chestplate, Material leggings, Material boots, TeamColor color) {
+        if (chestplate != null) {
+            ItemStack item = new ItemStack(chestplate);
+            tintLeather(item, color);
+            npc.getEquipment().setChestplate(item);
+        }
+        if (leggings != null) {
+            ItemStack item = new ItemStack(leggings);
+            tintLeather(item, color);
+            npc.getEquipment().setLeggings(item);
+        }
+        if (boots != null) {
+            ItemStack item = new ItemStack(boots);
+            tintLeather(item, color);
+            npc.getEquipment().setBoots(item);
+        }
+    }
+
+    private void tintLeather(ItemStack item, TeamColor color) {
+        if (item.getType().name().startsWith("LEATHER_")) {
+            LeatherArmorMeta meta = (LeatherArmorMeta) item.getItemMeta();
+            meta.setColor(color.getLeatherColor());
+            item.setItemMeta(meta);
+        }
     }
 
     /**

--- a/src/main/java/com/heneria/bedwars/arena/elements/Team.java
+++ b/src/main/java/com/heneria/bedwars/arena/elements/Team.java
@@ -2,6 +2,7 @@ package com.heneria.bedwars.arena.elements;
 
 import com.heneria.bedwars.arena.enums.TeamColor;
 import org.bukkit.Location;
+import org.bukkit.Material;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +20,13 @@ public class Team {
     private Location spawnLocation;
     private Location bedLocation;
     private Location itemShopNpcLocation;
+    private Material itemShopChestplate;
+    private Material itemShopLeggings;
+    private Material itemShopBoots;
     private Location upgradeShopNpcLocation;
+    private Material upgradeShopChestplate;
+    private Material upgradeShopLeggings;
+    private Material upgradeShopBoots;
     private boolean hasBed = true;
     private final Map<String, Integer> upgradeLevels = new HashMap<>();
     private final Map<String, Boolean> traps = new HashMap<>();
@@ -133,6 +140,30 @@ public class Team {
         this.itemShopNpcLocation = itemShopNpcLocation;
     }
 
+    public Material getItemShopChestplate() {
+        return itemShopChestplate;
+    }
+
+    public void setItemShopChestplate(Material itemShopChestplate) {
+        this.itemShopChestplate = itemShopChestplate;
+    }
+
+    public Material getItemShopLeggings() {
+        return itemShopLeggings;
+    }
+
+    public void setItemShopLeggings(Material itemShopLeggings) {
+        this.itemShopLeggings = itemShopLeggings;
+    }
+
+    public Material getItemShopBoots() {
+        return itemShopBoots;
+    }
+
+    public void setItemShopBoots(Material itemShopBoots) {
+        this.itemShopBoots = itemShopBoots;
+    }
+
     /**
      * Gets the location of the team's upgrade shop NPC.
      *
@@ -149,6 +180,30 @@ public class Team {
      */
     public void setUpgradeShopNpcLocation(Location upgradeShopNpcLocation) {
         this.upgradeShopNpcLocation = upgradeShopNpcLocation;
+    }
+
+    public Material getUpgradeShopChestplate() {
+        return upgradeShopChestplate;
+    }
+
+    public void setUpgradeShopChestplate(Material upgradeShopChestplate) {
+        this.upgradeShopChestplate = upgradeShopChestplate;
+    }
+
+    public Material getUpgradeShopLeggings() {
+        return upgradeShopLeggings;
+    }
+
+    public void setUpgradeShopLeggings(Material upgradeShopLeggings) {
+        this.upgradeShopLeggings = upgradeShopLeggings;
+    }
+
+    public Material getUpgradeShopBoots() {
+        return upgradeShopBoots;
+    }
+
+    public void setUpgradeShopBoots(Material upgradeShopBoots) {
+        this.upgradeShopBoots = upgradeShopBoots;
     }
 
     /**

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -11,8 +11,10 @@ import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataType;
+import com.heneria.bedwars.arena.enums.TeamColor;
 
 import java.util.*;
 
@@ -80,14 +82,10 @@ public class AdminCommand implements SubCommand {
                 String skin = args[2];
                 Material item = Material.matchMaterial(args[3].toUpperCase());
                 String name = ChatColor.translateAlternateColorCodes('&', args[4]);
-                List<Material> armor = new ArrayList<>();
-                for (int i = 5; i < args.length; i++) {
-                    Material m = Material.matchMaterial(args[i].toUpperCase());
-                    if (m != null) {
-                        armor.add(m);
-                    }
-                }
-                plugin.getNpcManager().addNpc(player.getLocation(), mode, skin, item, name, armor);
+                Material chestplate = args.length > 5 ? Material.matchMaterial(args[5].toUpperCase()) : null;
+                Material leggings = args.length > 6 ? Material.matchMaterial(args[6].toUpperCase()) : null;
+                Material boots = args.length > 7 ? Material.matchMaterial(args[7].toUpperCase()) : null;
+                plugin.getNpcManager().addNpc(player.getLocation(), mode, skin, item, name, chestplate, leggings, boots);
                 player.sendMessage(ChatColor.GREEN + "PNJ de jonction " + mode + " placé.");
                 return;
             } else if (sub.equals("setshopnpc") && args.length >= 3) {
@@ -97,6 +95,9 @@ public class AdminCommand implements SubCommand {
                 }
                 String team = args[1];
                 String type = args[2].toLowerCase();
+                Material chestplate = args.length > 3 ? Material.matchMaterial(args[3].toUpperCase()) : null;
+                Material leggings = args.length > 4 ? Material.matchMaterial(args[4].toUpperCase()) : null;
+                Material boots = args.length > 5 ? Material.matchMaterial(args[5].toUpperCase()) : null;
                 ArmorStand npc = (ArmorStand) player.getWorld().spawnEntity(player.getLocation(), EntityType.ARMOR_STAND);
                 npc.setInvisible(true);
                 npc.setInvulnerable(true);
@@ -115,6 +116,38 @@ public class AdminCommand implements SubCommand {
                 } else {
                     npc.setCustomName(MessageManager.get("game.shop-npc-name"));
                     npc.getEquipment().setItemInMainHand(new ItemStack(Material.EMERALD));
+                }
+                TeamColor teamColor = null;
+                try {
+                    teamColor = TeamColor.valueOf(team.toUpperCase());
+                } catch (IllegalArgumentException ignored) {
+                }
+                if (chestplate != null) {
+                    ItemStack item = new ItemStack(chestplate);
+                    if (teamColor != null && item.getType().name().startsWith("LEATHER_")) {
+                        LeatherArmorMeta am = (LeatherArmorMeta) item.getItemMeta();
+                        am.setColor(teamColor.getLeatherColor());
+                        item.setItemMeta(am);
+                    }
+                    npc.getEquipment().setChestplate(item);
+                }
+                if (leggings != null) {
+                    ItemStack item = new ItemStack(leggings);
+                    if (teamColor != null && item.getType().name().startsWith("LEATHER_")) {
+                        LeatherArmorMeta am = (LeatherArmorMeta) item.getItemMeta();
+                        am.setColor(teamColor.getLeatherColor());
+                        item.setItemMeta(am);
+                    }
+                    npc.getEquipment().setLeggings(item);
+                }
+                if (boots != null) {
+                    ItemStack item = new ItemStack(boots);
+                    if (teamColor != null && item.getType().name().startsWith("LEATHER_")) {
+                        LeatherArmorMeta am = (LeatherArmorMeta) item.getItemMeta();
+                        am.setColor(teamColor.getLeatherColor());
+                        item.setItemMeta(am);
+                    }
+                    npc.getEquipment().setBoots(item);
                 }
                 npc.setCustomNameVisible(true);
                 player.sendMessage(ChatColor.GREEN + "PNJ de boutique " + type + " pour l'équipe " + team + " placé.");

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -11,6 +11,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 
@@ -135,6 +136,15 @@ public class ArenaManager {
                             team.setItemShopNpcLocation(loc);
                         }
                     }
+                    if (config.contains("teams." + key + ".npc.shop.chestplate")) {
+                        team.setItemShopChestplate(Material.matchMaterial(config.getString("teams." + key + ".npc.shop.chestplate")));
+                    }
+                    if (config.contains("teams." + key + ".npc.shop.leggings")) {
+                        team.setItemShopLeggings(Material.matchMaterial(config.getString("teams." + key + ".npc.shop.leggings")));
+                    }
+                    if (config.contains("teams." + key + ".npc.shop.boots")) {
+                        team.setItemShopBoots(Material.matchMaterial(config.getString("teams." + key + ".npc.shop.boots")));
+                    }
                     if (config.contains("teams." + key + ".npc.upgrade.world")) {
                         World w = Bukkit.getWorld(config.getString("teams." + key + ".npc.upgrade.world"));
                         if (w != null) {
@@ -146,6 +156,15 @@ public class ArenaManager {
                                     (float) config.getDouble("teams." + key + ".npc.upgrade.pitch"));
                             team.setUpgradeShopNpcLocation(loc);
                         }
+                    }
+                    if (config.contains("teams." + key + ".npc.upgrade.chestplate")) {
+                        team.setUpgradeShopChestplate(Material.matchMaterial(config.getString("teams." + key + ".npc.upgrade.chestplate")));
+                    }
+                    if (config.contains("teams." + key + ".npc.upgrade.leggings")) {
+                        team.setUpgradeShopLeggings(Material.matchMaterial(config.getString("teams." + key + ".npc.upgrade.leggings")));
+                    }
+                    if (config.contains("teams." + key + ".npc.upgrade.boots")) {
+                        team.setUpgradeShopBoots(Material.matchMaterial(config.getString("teams." + key + ".npc.upgrade.boots")));
                     }
                     arena.getTeams().put(color, team);
                 }
@@ -248,6 +267,15 @@ public class ArenaManager {
                     config.set(base + "npc.shop.yaw", loc.getYaw());
                     config.set(base + "npc.shop.pitch", loc.getPitch());
                 }
+                if (team.getItemShopChestplate() != null) {
+                    config.set(base + "npc.shop.chestplate", team.getItemShopChestplate().name());
+                }
+                if (team.getItemShopLeggings() != null) {
+                    config.set(base + "npc.shop.leggings", team.getItemShopLeggings().name());
+                }
+                if (team.getItemShopBoots() != null) {
+                    config.set(base + "npc.shop.boots", team.getItemShopBoots().name());
+                }
                 if (team.getUpgradeShopNpcLocation() != null) {
                     Location loc = team.getUpgradeShopNpcLocation();
                     config.set(base + "npc.upgrade.world", Objects.requireNonNull(loc.getWorld()).getName());
@@ -256,6 +284,15 @@ public class ArenaManager {
                     config.set(base + "npc.upgrade.z", loc.getZ());
                     config.set(base + "npc.upgrade.yaw", loc.getYaw());
                     config.set(base + "npc.upgrade.pitch", loc.getPitch());
+                }
+                if (team.getUpgradeShopChestplate() != null) {
+                    config.set(base + "npc.upgrade.chestplate", team.getUpgradeShopChestplate().name());
+                }
+                if (team.getUpgradeShopLeggings() != null) {
+                    config.set(base + "npc.upgrade.leggings", team.getUpgradeShopLeggings().name());
+                }
+                if (team.getUpgradeShopBoots() != null) {
+                    config.set(base + "npc.upgrade.boots", team.getUpgradeShopBoots().name());
                 }
             }
         }

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -77,17 +77,21 @@ public class NpcManager {
             String name = nameObj != null ? String.valueOf(nameObj) : "&a" + capitalize(mode);
             String itemStr = (String) map.get("item");
             Material item = itemStr != null ? Material.matchMaterial(itemStr) : null;
-            List<String> armorList = (List<String>) map.get("armor");
-            List<Material> armor = new ArrayList<>();
-            if (armorList != null) {
-                for (String s : armorList) {
-                    Material m = Material.matchMaterial(s);
-                    if (m != null) {
-                        armor.add(m);
-                    }
+            String chest = (String) map.get("chestplate");
+            Material chestplate = chest != null ? Material.matchMaterial(chest) : null;
+            String legs = (String) map.get("leggings");
+            Material leggings = legs != null ? Material.matchMaterial(legs) : null;
+            String bootsStr = (String) map.get("boots");
+            Material boots = bootsStr != null ? Material.matchMaterial(bootsStr) : null;
+            if (chestplate == null && leggings == null && boots == null) {
+                List<String> armorList = (List<String>) map.get("armor");
+                if (armorList != null) {
+                    if (armorList.size() > 0) chestplate = Material.matchMaterial(armorList.get(0));
+                    if (armorList.size() > 1) leggings = Material.matchMaterial(armorList.get(1));
+                    if (armorList.size() > 2) boots = Material.matchMaterial(armorList.get(2));
                 }
             }
-            NpcInfo info = new NpcInfo(loc, mode, skin, name, item, armor);
+            NpcInfo info = new NpcInfo(loc, mode, skin, name, item, chestplate, leggings, boots);
             spawnNpc(info);
             npcs.add(info);
         }
@@ -116,16 +120,14 @@ public class NpcManager {
             npc.getEquipment().setItemInMainHand(new ItemStack(info.item));
         }
         // Equip armor pieces if provided
-        if (!info.armor.isEmpty()) {
-            if (info.armor.size() > 0 && info.armor.get(0) != null) {
-                npc.getEquipment().setChestplate(new ItemStack(info.armor.get(0)));
-            }
-            if (info.armor.size() > 1 && info.armor.get(1) != null) {
-                npc.getEquipment().setLeggings(new ItemStack(info.armor.get(1)));
-            }
-            if (info.armor.size() > 2 && info.armor.get(2) != null) {
-                npc.getEquipment().setBoots(new ItemStack(info.armor.get(2)));
-            }
+        if (info.chestplate != null) {
+            npc.getEquipment().setChestplate(new ItemStack(info.chestplate));
+        }
+        if (info.leggings != null) {
+            npc.getEquipment().setLeggings(new ItemStack(info.leggings));
+        }
+        if (info.boots != null) {
+            npc.getEquipment().setBoots(new ItemStack(info.boots));
         }
     }
 
@@ -134,8 +136,9 @@ public class NpcManager {
         return input.substring(0, 1).toUpperCase() + input.substring(1).toLowerCase();
     }
 
-    public void addNpc(Location location, String mode, String skin, Material item, String name, List<Material> armor) {
-        NpcInfo info = new NpcInfo(location, mode, skin, name, item, armor);
+    public void addNpc(Location location, String mode, String skin, Material item, String name,
+                       Material chestplate, Material leggings, Material boots) {
+        NpcInfo info = new NpcInfo(location, mode, skin, name, item, chestplate, leggings, boots);
         npcs.add(info);
         spawnNpc(info);
         saveNpcs();
@@ -158,12 +161,14 @@ public class NpcManager {
             if (info.item != null) {
                 map.put("item", info.item.name());
             }
-            if (!info.armor.isEmpty()) {
-                List<String> armor = new ArrayList<>();
-                for (Material m : info.armor) {
-                    armor.add(m.name());
-                }
-                map.put("armor", armor);
+            if (info.chestplate != null) {
+                map.put("chestplate", info.chestplate.name());
+            }
+            if (info.leggings != null) {
+                map.put("leggings", info.leggings.name());
+            }
+            if (info.boots != null) {
+                map.put("boots", info.boots.name());
             }
             list.add(map);
         }
@@ -233,15 +238,20 @@ public class NpcManager {
         final String skin;
         final String name;
         final Material item;
-        final List<Material> armor;
+        final Material chestplate;
+        final Material leggings;
+        final Material boots;
 
-        NpcInfo(Location location, String mode, String skin, String name, Material item, List<Material> armor) {
+        NpcInfo(Location location, String mode, String skin, String name, Material item,
+                Material chestplate, Material leggings, Material boots) {
             this.location = location;
             this.mode = mode;
             this.skin = skin;
             this.name = name;
             this.item = item;
-            this.armor = armor;
+            this.chestplate = chestplate;
+            this.leggings = leggings;
+            this.boots = boots;
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring chestplate, leggings and boots for lobby and team shop NPCs
- tint leather armor to team colors when spawning shop NPCs
- document and log NPC armor support

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a58f2c6904832996365b0999f98c84