### PR TITLE
fix(npc): Correctly parse and apply armor arguments in NPC creation commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Ajout de la commande /bw admin removenpc pour supprimer les PNJ du lobby.
 - Ajout de la possibilité d'équiper les PNJ avec une armure.
 
+### Corrigé
+- Correction d'un bug où l'armure n'était pas appliquée aux PNJ lors de leur création par commande.
+
 ## [2.2.0] - 2024-05-08
 
 ### Modifié

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -81,10 +81,22 @@ public class AdminCommand implements SubCommand {
                 String mode = args[1].toLowerCase();
                 String skin = args[2];
                 Material item = Material.matchMaterial(args[3].toUpperCase());
-                String name = ChatColor.translateAlternateColorCodes('&', args[4]);
-                Material chestplate = args.length > 5 ? Material.matchMaterial(args[5].toUpperCase()) : null;
-                Material leggings = args.length > 6 ? Material.matchMaterial(args[6].toUpperCase()) : null;
-                Material boots = args.length > 7 ? Material.matchMaterial(args[7].toUpperCase()) : null;
+
+                int end = args.length;
+                List<Material> armor = new ArrayList<>();
+                while (armor.size() < 3 && end > 5) {
+                    Material m = Material.matchMaterial(args[end - 1].toUpperCase());
+                    if (m == null) {
+                        break;
+                    }
+                    armor.add(0, m);
+                    end--;
+                }
+                String name = ChatColor.translateAlternateColorCodes('&', String.join(" ", Arrays.copyOfRange(args, 4, end)));
+                Material chestplate = armor.size() > 0 ? armor.get(0) : null;
+                Material leggings = armor.size() > 1 ? armor.get(1) : null;
+                Material boots = armor.size() > 2 ? armor.get(2) : null;
+
                 plugin.getNpcManager().addNpc(player.getLocation(), mode, skin, item, name, chestplate, leggings, boots);
                 player.sendMessage(ChatColor.GREEN + "PNJ de jonction " + mode + " placé.");
                 return;


### PR DESCRIPTION
## Summary
- allow `/bw admin setjoinnpc` to parse optional armor arguments from the end, keeping multi-word names intact
- document the armor application fix

## Testing
- `mvn -q test` *(fails: Could not resolve org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a593b520388329b32604b15f9d24e8