### PR TITLE
feat(admin)!: Implement GUI-based lobby NPC management system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [2.3.0] - 2024-??-??
+
+### Ajouté
+- Ajout d'une interface graphique complète pour la gestion des PNJ du lobby via `/bw admin lobby`.
+
 ## [2.2.1] - 2024-05-09
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -70,15 +70,12 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - `/bw admin setmainlobby`
   - Définit la position du lobby principal BedWars.
   - **Permission :** `heneriabw.admin.setmainlobby`
-  - `/bw admin setjoinnpc <mode> <nom_du_skin> <item_en_main> <nom_du_pnj> [<plastron> <jambieres> <bottes>]`
-    - Crée un PNJ de sélection d'arène (support d'armure) pour le mode donné avec le skin, l'item, le nom et éventuellement un set d'armure personnalisée.
-    - **Permission :** `heneriabw.admin.setjoinnpc`
-  - `/bw admin setshopnpc <équipe> <type_boutique> [<plastron> <jambieres> <bottes>]`
-    - Place un PNJ de boutique (`item` ou `upgrade`) sous forme de support d'armure pour l'équipe spécifiée. L'armure en cuir est automatiquement teinte à la couleur de l'équipe.
-    - **Permission :** `heneriabw.admin.setshopnpc`
-  - `/bw admin removenpc`
-    - Supprime le PNJ HeneriaBedwars le plus proche de vous dans le lobby.
-    - **Permission :** `heneriabw.admin.removenpc`
+- `/bw admin lobby`
+  - Ouvre le panneau de contrôle pour gérer les PNJ du lobby (création, édition, suppression).
+  - **Permission :** `heneriabw.admin.lobby`
+- `/bw admin setshopnpc <équipe> <type_boutique> [<plastron> <jambieres> <bottes>]`
+  - Place un PNJ de boutique (`item` ou `upgrade`) sous forme de support d'armure pour l'équipe spécifiée. L'armure en cuir est automatiquement teinte à la couleur de l'équipe.
+  - **Permission :** `heneriabw.admin.setshopnpc`
 
 ### Commandes Joueurs
 

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -3,6 +3,7 @@ package com.heneria.bedwars.commands.subcommands;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.gui.admin.AdminMainMenu;
+import com.heneria.bedwars.gui.admin.LobbyNPCManagerMenu;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -65,6 +66,13 @@ public class AdminCommand implements SubCommand {
                     MessageManager.sendMessage(player, "errors.arena-not-found");
                 }
                 return;
+            } else if (sub.equals("lobby")) {
+                if (!player.hasPermission("heneriabw.admin.lobby")) {
+                    MessageManager.sendMessage(player, "errors.no-permission");
+                    return;
+                }
+                new LobbyNPCManagerMenu().open(player);
+                return;
             } else if (sub.equals("setmainlobby")) {
                 if (!player.hasPermission("heneriabw.admin.setmainlobby")) {
                     MessageManager.sendMessage(player, "errors.no-permission");
@@ -72,33 +80,6 @@ public class AdminCommand implements SubCommand {
                 }
                 plugin.setMainLobby(player.getLocation());
                 player.sendMessage(ChatColor.GREEN + "Lobby principal défini.");
-                return;
-            } else if (sub.equals("setjoinnpc") && args.length >= 5) {
-                if (!player.hasPermission("heneriabw.admin.setjoinnpc")) {
-                    MessageManager.sendMessage(player, "errors.no-permission");
-                    return;
-                }
-                String mode = args[1].toLowerCase();
-                String skin = args[2];
-                Material item = Material.matchMaterial(args[3].toUpperCase());
-
-                int end = args.length;
-                List<Material> armor = new ArrayList<>();
-                while (armor.size() < 3 && end > 5) {
-                    Material m = Material.matchMaterial(args[end - 1].toUpperCase());
-                    if (m == null) {
-                        break;
-                    }
-                    armor.add(0, m);
-                    end--;
-                }
-                String name = ChatColor.translateAlternateColorCodes('&', String.join(" ", Arrays.copyOfRange(args, 4, end)));
-                Material chestplate = armor.size() > 0 ? armor.get(0) : null;
-                Material leggings = armor.size() > 1 ? armor.get(1) : null;
-                Material boots = armor.size() > 2 ? armor.get(2) : null;
-
-                plugin.getNpcManager().addNpc(player.getLocation(), mode, skin, item, name, chestplate, leggings, boots);
-                player.sendMessage(ChatColor.GREEN + "PNJ de jonction " + mode + " placé.");
                 return;
             } else if (sub.equals("setshopnpc") && args.length >= 3) {
                 if (!player.hasPermission("heneriabw.admin.setshopnpc")) {
@@ -164,18 +145,6 @@ public class AdminCommand implements SubCommand {
                 npc.setCustomNameVisible(true);
                 player.sendMessage(ChatColor.GREEN + "PNJ de boutique " + type + " pour l'équipe " + team + " placé.");
                 return;
-            } else if (sub.equals("removenpc")) {
-                if (!player.hasPermission("heneriabw.admin.removenpc")) {
-                    MessageManager.sendMessage(player, "errors.no-permission");
-                    return;
-                }
-                boolean removed = plugin.getNpcManager().removeNearestNpc(player, 10);
-                if (removed) {
-                    player.sendMessage(ChatColor.GREEN + "Le PNJ le plus proche a été supprimé.");
-                } else {
-                    player.sendMessage(ChatColor.RED + "Aucun PNJ HeneriaBedwars trouvé à proximité.");
-                }
-                return;
             }
         }
 
@@ -189,7 +158,7 @@ public class AdminCommand implements SubCommand {
     @Override
     public List<String> tabComplete(Player player, String[] args) {
         if (args.length == 1) {
-            return Arrays.asList("delete", "confirmdelete", "setmainlobby", "setjoinnpc", "setshopnpc", "removenpc");
+            return Arrays.asList("delete", "confirmdelete", "setmainlobby", "setshopnpc", "lobby");
         }
         if (args.length == 2 && (args[0].equalsIgnoreCase("delete") || args[0].equalsIgnoreCase("confirmdelete"))) {
             List<String> names = new ArrayList<>();
@@ -199,9 +168,6 @@ public class AdminCommand implements SubCommand {
                 }
             }
             return names;
-        }
-        if (args.length == 2 && args[0].equalsIgnoreCase("setjoinnpc")) {
-            return Arrays.asList("solos", "duos", "trios", "quads");
         }
         if (args.length == 2 && args[0].equalsIgnoreCase("setshopnpc")) {
             return Collections.singletonList("<team>");

--- a/src/main/java/com/heneria/bedwars/gui/admin/LobbyNPCManagerMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/LobbyNPCManagerMenu.java
@@ -1,0 +1,102 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.gui.PaginatedMenu;
+import com.heneria.bedwars.managers.NpcManager;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Central menu for managing lobby join NPCs.
+ */
+public class LobbyNPCManagerMenu extends PaginatedMenu {
+
+    private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+    private final Map<Integer, NpcManager.NpcInfo> npcSlots = new HashMap<>();
+
+    @Override
+    public String getTitle() {
+        return ChatColor.GREEN + "Gestion des PNJ";
+    }
+
+    @Override
+    public int getSize() {
+        return 54;
+    }
+
+    @Override
+    protected int getItemStartSlot() {
+        return 10;
+    }
+
+    @Override
+    protected int getItemsPerPage() {
+        return 28;
+    }
+
+    @Override
+    protected List<ItemStack> getPaginatedItems() {
+        List<ItemStack> items = new ArrayList<>();
+        npcSlots.clear();
+        for (NpcManager.NpcInfo info : plugin.getNpcManager().getNpcs()) {
+            ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            SkullMeta meta = (SkullMeta) head.getItemMeta();
+            meta.setOwningPlayer(Bukkit.getOfflinePlayer(info.skin));
+            meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', info.name));
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.GRAY + "Mode: " + info.mode);
+            meta.setLore(lore);
+            head.setItemMeta(meta);
+            items.add(head);
+        }
+        return items;
+    }
+
+    @Override
+    protected void onItemSet(int index, int slot) {
+        List<NpcManager.NpcInfo> list = plugin.getNpcManager().getNpcs();
+        if (index < list.size()) {
+            npcSlots.put(slot, list.get(index));
+        }
+    }
+
+    @Override
+    public void setupItems() {
+        super.setupItems();
+        inventory.setItem(getSize() - 5, new ItemBuilder(Material.EMERALD)
+                .setName("&aCréer un PNJ")
+                .addLore("&7Lancer l'assistant de création")
+                .build());
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, filler());
+            }
+        }
+    }
+
+    @Override
+    protected void handleMenuClick(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+        int slot = event.getRawSlot();
+        if (slot == getSize() - 5) {
+            player.closeInventory();
+            player.sendMessage(ChatColor.YELLOW + "Assistant de création de PNJ non implémenté.");
+            return;
+        }
+        NpcManager.NpcInfo info = npcSlots.get(slot);
+        if (info != null) {
+            new NPCEditMenu(info).open(player, this);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/admin/NPCDeleteConfirmMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/NPCDeleteConfirmMenu.java
@@ -1,0 +1,57 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.managers.NpcManager;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+/**
+ * Confirmation menu to delete a lobby NPC.
+ */
+public class NPCDeleteConfirmMenu extends Menu {
+
+    private final NpcManager.NpcInfo info;
+
+    public NPCDeleteConfirmMenu(NpcManager.NpcInfo info) {
+        this.info = info;
+    }
+
+    @Override
+    public String getTitle() {
+        return ChatColor.RED + "Confirmer la suppression";
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        inventory.setItem(11, new ItemBuilder(Material.RED_CONCRETE).setName("&cConfirmer").build());
+        inventory.setItem(15, new ItemBuilder(Material.LIME_CONCRETE).setName("&aAnnuler").build());
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build());
+            }
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+        int slot = event.getRawSlot();
+        if (slot == 11) {
+            player.closeInventory();
+            HeneriaBedwars.getInstance().getNpcManager().removeNpc(info);
+            player.sendMessage(ChatColor.GREEN + "PNJ supprimé.");
+        } else if (slot == 15) {
+            previousMenu.open(player, previousMenu.previousMenu);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/admin/NPCEditMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/NPCEditMenu.java
@@ -1,0 +1,67 @@
+package com.heneria.bedwars.gui.admin;
+
+import com.heneria.bedwars.gui.Menu;
+import com.heneria.bedwars.managers.NpcManager;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+/**
+ * Menu allowing basic edition of a lobby NPC.
+ */
+public class NPCEditMenu extends Menu {
+
+    private final NpcManager.NpcInfo info;
+
+    public NPCEditMenu(NpcManager.NpcInfo info) {
+        this.info = info;
+    }
+
+    @Override
+    public String getTitle() {
+        return ChatColor.YELLOW + "Éditer le PNJ";
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        inventory.setItem(10, new ItemBuilder(Material.PLAYER_HEAD).setName("&eChanger le Skin").build());
+        inventory.setItem(11, new ItemBuilder(Material.NAME_TAG).setName("&eChanger le Nom").build());
+        inventory.setItem(12, new ItemBuilder(Material.DIAMOND_SWORD).setName("&eChanger l'Objet en Main").build());
+        inventory.setItem(14, new ItemBuilder(Material.ENDER_PEARL).setName("&eSe Téléporter au PNJ").build());
+        inventory.setItem(16, new ItemBuilder(Material.BARRIER).setName("&cSupprimer le PNJ").build());
+        for (int i = 0; i < getSize(); i++) {
+            if (inventory.getItem(i) == null) {
+                inventory.setItem(i, new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build());
+            }
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
+        Player player = (Player) event.getWhoClicked();
+        int slot = event.getRawSlot();
+        if (slot == 10) {
+            player.sendMessage(ChatColor.YELLOW + "Changement de skin non implémenté.");
+        } else if (slot == 11) {
+            player.sendMessage(ChatColor.YELLOW + "Changement de nom non implémenté.");
+        } else if (slot == 12) {
+            player.sendMessage(ChatColor.YELLOW + "Changement d'objet non implémenté.");
+        } else if (slot == 14) {
+            player.closeInventory();
+            player.teleport(info.location);
+        } else if (slot == 16) {
+            new NPCDeleteConfirmMenu(info).open(player, this);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -17,10 +17,7 @@ import org.bukkit.persistence.PersistentDataType;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Manages persistent join NPCs for the main lobby.
@@ -144,6 +141,34 @@ public class NpcManager {
         saveNpcs();
     }
 
+    /**
+     * Returns an immutable view of the configured lobby NPCs.
+     *
+     * @return list of NPC information
+     */
+    public List<NpcInfo> getNpcs() {
+        return Collections.unmodifiableList(npcs);
+    }
+
+    /**
+     * Removes the provided NPC from the world and configuration.
+     *
+     * @param info the NPC to remove
+     */
+    public void removeNpc(NpcInfo info) {
+        for (Entity entity : info.location.getWorld().getNearbyEntities(info.location, 1, 1, 1)) {
+            if (entity.getType() == EntityType.ARMOR_STAND) {
+                String mode = entity.getPersistentDataContainer().get(npcKey, PersistentDataType.STRING);
+                if (mode != null && mode.equals(info.mode)) {
+                    entity.remove();
+                    break;
+                }
+            }
+        }
+        npcs.remove(info);
+        saveNpcs();
+    }
+
     public void saveNpcs() {
         List<Map<String, Object>> list = new ArrayList<>();
         for (NpcInfo info : npcs) {
@@ -232,15 +257,18 @@ public class NpcManager {
         return mode;
     }
 
-    private static class NpcInfo {
-        final Location location;
-        final String mode;
-        final String skin;
-        final String name;
-        final Material item;
-        final Material chestplate;
-        final Material leggings;
-        final Material boots;
+    /**
+     * Represents a lobby NPC and its configuration.
+     */
+    public static class NpcInfo {
+        public final Location location;
+        public final String mode;
+        public final String skin;
+        public final String name;
+        public final Material item;
+        public final Material chestplate;
+        public final Material leggings;
+        public final Material boots;
 
         NpcInfo(Location location, String mode, String skin, String name, Material item,
                 Material chestplate, Material leggings, Material boots) {


### PR DESCRIPTION
## Summary
- add GUI-driven lobby NPC management command `/bw admin lobby`
- introduce menus for listing, editing and deleting lobby NPCs
- document new interface and update changelog

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5973ab8a88329859d6669bcf8cd8b