### PR TITLE
fix(build): expose previousMenu via getter to resolve protected access error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Ajouté
 - Ajout d'une interface graphique complète pour la gestion des PNJ du lobby via `/bw admin lobby`.
 
+### Corrigé
+- Correction d'une erreur de compilation liée à un accès protégé dans les menus.
+
 ## [2.2.1] - 2024-05-09
 
 ### Ajouté

--- a/src/main/java/com/heneria/bedwars/gui/Menu.java
+++ b/src/main/java/com/heneria/bedwars/gui/Menu.java
@@ -68,6 +68,15 @@ public abstract class Menu implements InventoryHolder {
         open(player, null);
     }
 
+    /**
+     * Gets the previous menu.
+     *
+     * @return previous menu, or {@code null} if none
+     */
+    public Menu getPreviousMenu() {
+        return this.previousMenu;
+    }
+
     protected int getBackButtonSlot() {
         return getSize() - 9;
     }

--- a/src/main/java/com/heneria/bedwars/gui/admin/NPCDeleteConfirmMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/NPCDeleteConfirmMenu.java
@@ -51,7 +51,7 @@ public class NPCDeleteConfirmMenu extends Menu {
             HeneriaBedwars.getInstance().getNpcManager().removeNpc(info);
             player.sendMessage(ChatColor.GREEN + "PNJ supprimé.");
         } else if (slot == 15) {
-            previousMenu.open(player, previousMenu.previousMenu);
+            previousMenu.open(player, previousMenu.getPreviousMenu());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add public `getPreviousMenu` accessor to `Menu`
- use getter when returning from `NPCDeleteConfirmMenu`
- document protected access compile fix in changelog

## Testing
- `mvn -B package --file pom.xml` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a59a0405408329a2e80af247b5396b