### PR TITLE
feat(admin): Complete NPC creation wizard via chat conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Ajouté
 - Ajout d'une interface graphique complète pour la gestion des PNJ du lobby via `/bw admin lobby`.
+- Finalisation de l'assistant de création de PNJ par conversation chat.
 
 ### Corrigé
 - Correction d'une erreur de compilation liée à un accès protégé dans les menus.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
 
 - ⚔️ **Gestion 100% en Jeu** : Créez, gérez et configurez vos arènes sans jamais avoir à éditer de fichiers manuellement grâce à une interface graphique complète (`/bw admin`).
 - 🧙‍♂️ **Assistant de Création Intuitif** : Un système de création d'arène simple via le chat vous guide pour définir les paramètres de base.
+- 🧍 **Assistant PNJ Guidé** : Créez des PNJ du lobby via une conversation étape par étape dans le chat.
 - 📍 **Configuration Précise** : Utilisez un outil de positionnement en jeu pour définir avec précision l'emplacement du lobby, des lits, des points de spawn, des générateurs et des PNJ pour chaque équipe.
 - ⚙️ **Haute Personnalisation** : Prenez le contrôle total du gameplay en modifiant les fichiers de configuration dédiés :
   - `generators.yml` : Réglez la vitesse et la quantité de chaque générateur de ressources.
@@ -73,9 +74,14 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - `/bw admin lobby`
   - Ouvre le panneau de contrôle pour gérer les PNJ du lobby (création, édition, suppression).
   - **Permission :** `heneriabw.admin.lobby`
+- `/bw admin confirmnpc`
+  - Finalise la création d'un PNJ du lobby à votre position actuelle.
+  - **Permission :** `heneriabw.admin.lobby`
 - `/bw admin setshopnpc <équipe> <type_boutique> [<plastron> <jambieres> <bottes>]`
   - Place un PNJ de boutique (`item` ou `upgrade`) sous forme de support d'armure pour l'équipe spécifiée. L'armure en cuir est automatiquement teinte à la couleur de l'équipe.
   - **Permission :** `heneriabw.admin.setshopnpc`
+
+Pour créer un PNJ de sélection d'arène, ouvrez le menu `/bw admin lobby`, cliquez sur « Créer un PNJ » puis répondez aux questions dans le chat (skin, mode, nom, équipement...). Placez-vous à l'endroit souhaité et validez avec `/bw admin confirmnpc`.
 
 ### Commandes Joueurs
 

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -4,6 +4,8 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.gui.admin.AdminMainMenu;
 import com.heneria.bedwars.gui.admin.LobbyNPCManagerMenu;
+import com.heneria.bedwars.managers.SetupManager;
+import com.heneria.bedwars.setup.NpcCreationProcess;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -145,6 +147,21 @@ public class AdminCommand implements SubCommand {
                 npc.setCustomNameVisible(true);
                 player.sendMessage(ChatColor.GREEN + "PNJ de boutique " + type + " pour l'équipe " + team + " placé.");
                 return;
+            } else if (sub.equals("confirmnpc")) {
+                if (!player.hasPermission("heneriabw.admin.lobby")) {
+                    MessageManager.sendMessage(player, "errors.no-permission");
+                    return;
+                }
+                SetupManager setupManager = plugin.getSetupManager();
+                NpcCreationProcess process = setupManager.getNpcCreation(player.getUniqueId());
+                if (process == null || process.getStep() != NpcCreationProcess.Step.WAITING_CONFIRM) {
+                    player.sendMessage(ChatColor.RED + "Aucune création de PNJ en cours.");
+                    return;
+                }
+                plugin.getNpcManager().addNpc(player.getLocation(), process.getMode(), process.getSkin(), process.getItem(), process.getName(), process.getChestplate(), process.getLeggings(), process.getBoots());
+                setupManager.clearNpcCreation(player);
+                player.sendMessage(ChatColor.GREEN + "PNJ créé.");
+                return;
             }
         }
 
@@ -158,7 +175,7 @@ public class AdminCommand implements SubCommand {
     @Override
     public List<String> tabComplete(Player player, String[] args) {
         if (args.length == 1) {
-            return Arrays.asList("delete", "confirmdelete", "setmainlobby", "setshopnpc", "lobby");
+            return Arrays.asList("delete", "confirmdelete", "setmainlobby", "setshopnpc", "lobby", "confirmnpc");
         }
         if (args.length == 2 && (args[0].equalsIgnoreCase("delete") || args[0].equalsIgnoreCase("confirmdelete"))) {
             List<String> names = new ArrayList<>();

--- a/src/main/java/com/heneria/bedwars/gui/admin/LobbyNPCManagerMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/admin/LobbyNPCManagerMenu.java
@@ -91,7 +91,7 @@ public class LobbyNPCManagerMenu extends PaginatedMenu {
         int slot = event.getRawSlot();
         if (slot == getSize() - 5) {
             player.closeInventory();
-            player.sendMessage(ChatColor.YELLOW + "Assistant de création de PNJ non implémenté.");
+            HeneriaBedwars.getInstance().getSetupManager().startNpcCreation(player);
             return;
         }
         NpcManager.NpcInfo info = npcSlots.get(slot);

--- a/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
@@ -3,8 +3,12 @@ package com.heneria.bedwars.listeners;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.gui.admin.creation.ArenaSettingsMenu;
 import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.managers.SetupManager;
+import com.heneria.bedwars.setup.NpcCreationProcess;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -15,6 +19,85 @@ public class ChatListener implements Listener {
     @EventHandler
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         Player player = event.getPlayer();
+        SetupManager setupManager = HeneriaBedwars.getInstance().getSetupManager();
+        NpcCreationProcess process = setupManager.getNpcCreation(player.getUniqueId());
+        if (process != null) {
+            event.setCancelled(true);
+            String msg = event.getMessage();
+            if (msg.equalsIgnoreCase("annuler")) {
+                setupManager.clearNpcCreation(player);
+                player.sendMessage(ChatColor.RED + "Création de PNJ annulée.");
+                return;
+            }
+            switch (process.getStep()) {
+                case SKIN -> {
+                    process.setSkin(msg);
+                    process.setStep(NpcCreationProcess.Step.MODE);
+                    player.sendMessage(ChatColor.YELLOW + "Pour quel mode ce PNJ doit-il servir ?");
+                }
+                case MODE -> {
+                    process.setMode(msg);
+                    process.setStep(NpcCreationProcess.Step.NAME);
+                    player.sendMessage(ChatColor.YELLOW + "Quel nom doit afficher le PNJ ?");
+                }
+                case NAME -> {
+                    process.setName(msg);
+                    process.setStep(NpcCreationProcess.Step.ITEM);
+                    player.sendMessage(ChatColor.YELLOW + "Quel objet doit-il tenir ? (aucun)");
+                }
+                case ITEM -> {
+                    if (!msg.equalsIgnoreCase("aucun") && !msg.equalsIgnoreCase("aucune")) {
+                        Material mat = Material.matchMaterial(msg.toUpperCase());
+                        if (mat == null) {
+                            player.sendMessage(ChatColor.RED + "Objet invalide, réessayez.");
+                            return;
+                        }
+                        process.setItem(mat);
+                    }
+                    process.setStep(NpcCreationProcess.Step.CHESTPLATE);
+                    player.sendMessage(ChatColor.YELLOW + "Quel plastron ? (aucun)");
+                }
+                case CHESTPLATE -> {
+                    if (!msg.equalsIgnoreCase("aucun") && !msg.equalsIgnoreCase("aucune")) {
+                        Material mat = Material.matchMaterial(msg.toUpperCase());
+                        if (mat == null) {
+                            player.sendMessage(ChatColor.RED + "Plastron invalide, réessayez.");
+                            return;
+                        }
+                        process.setChestplate(mat);
+                    }
+                    process.setStep(NpcCreationProcess.Step.LEGGINGS);
+                    player.sendMessage(ChatColor.YELLOW + "Quel pantalon ? (aucun)");
+                }
+                case LEGGINGS -> {
+                    if (!msg.equalsIgnoreCase("aucun") && !msg.equalsIgnoreCase("aucune")) {
+                        Material mat = Material.matchMaterial(msg.toUpperCase());
+                        if (mat == null) {
+                            player.sendMessage(ChatColor.RED + "Pantalon invalide, réessayez.");
+                            return;
+                        }
+                        process.setLeggings(mat);
+                    }
+                    process.setStep(NpcCreationProcess.Step.BOOTS);
+                    player.sendMessage(ChatColor.YELLOW + "Quelles bottes ? (aucune)");
+                }
+                case BOOTS -> {
+                    if (!msg.equalsIgnoreCase("aucun") && !msg.equalsIgnoreCase("aucune")) {
+                        Material mat = Material.matchMaterial(msg.toUpperCase());
+                        if (mat == null) {
+                            player.sendMessage(ChatColor.RED + "Bottes invalides, réessayez.");
+                            return;
+                        }
+                        process.setBoots(mat);
+                    }
+                    process.setStep(NpcCreationProcess.Step.WAITING_CONFIRM);
+                    player.sendMessage(ChatColor.GREEN + "Placez-vous et tapez /bw admin confirmnpc pour valider.");
+                }
+                case WAITING_CONFIRM -> player.sendMessage(ChatColor.YELLOW + "Tapez /bw admin confirmnpc pour finaliser ou 'annuler' pour annuler.");
+            }
+            return;
+        }
+
         ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
 
         if (arenaManager.isPlayerInCreationMode(player)) {

--- a/src/main/java/com/heneria/bedwars/managers/SetupManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/SetupManager.java
@@ -1,6 +1,8 @@
 package com.heneria.bedwars.managers;
 
 import com.heneria.bedwars.setup.SetupAction;
+import com.heneria.bedwars.setup.NpcCreationProcess;
+import org.bukkit.ChatColor;
 import com.heneria.bedwars.utils.ItemBuilder;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -15,6 +17,7 @@ import java.util.UUID;
 public class SetupManager {
 
     private final Map<UUID, SetupAction> setups = new HashMap<>();
+    private final Map<UUID, NpcCreationProcess> npcCreations = new HashMap<>();
 
     /**
      * Puts a player in setup mode with the given action and gives them the setup tool.
@@ -39,6 +42,10 @@ public class SetupManager {
         return setups.get(uuid);
     }
 
+    public NpcCreationProcess getNpcCreation(UUID uuid) {
+        return npcCreations.get(uuid);
+    }
+
     /**
      * Removes a player from setup mode.
      *
@@ -46,5 +53,14 @@ public class SetupManager {
      */
     public void clear(Player player) {
         setups.remove(player.getUniqueId());
+    }
+
+    public void clearNpcCreation(Player player) {
+        npcCreations.remove(player.getUniqueId());
+    }
+
+    public void startNpcCreation(Player player) {
+        npcCreations.put(player.getUniqueId(), new NpcCreationProcess());
+        player.sendMessage(ChatColor.YELLOW + "Quel skin voulez-vous lui donner ?");
     }
 }

--- a/src/main/java/com/heneria/bedwars/setup/NpcCreationProcess.java
+++ b/src/main/java/com/heneria/bedwars/setup/NpcCreationProcess.java
@@ -1,0 +1,94 @@
+package com.heneria.bedwars.setup;
+
+import org.bukkit.Material;
+
+/**
+ * Holds the temporary data while an admin goes through the NPC creation wizard.
+ */
+public class NpcCreationProcess {
+
+    public enum Step {
+        SKIN,
+        MODE,
+        NAME,
+        ITEM,
+        CHESTPLATE,
+        LEGGINGS,
+        BOOTS,
+        WAITING_CONFIRM
+    }
+
+    private Step step = Step.SKIN;
+    private String skin;
+    private String mode;
+    private String name;
+    private Material item;
+    private Material chestplate;
+    private Material leggings;
+    private Material boots;
+
+    public Step getStep() {
+        return step;
+    }
+
+    public void setStep(Step step) {
+        this.step = step;
+    }
+
+    public String getSkin() {
+        return skin;
+    }
+
+    public void setSkin(String skin) {
+        this.skin = skin;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Material getItem() {
+        return item;
+    }
+
+    public void setItem(Material item) {
+        this.item = item;
+    }
+
+    public Material getChestplate() {
+        return chestplate;
+    }
+
+    public void setChestplate(Material chestplate) {
+        this.chestplate = chestplate;
+    }
+
+    public Material getLeggings() {
+        return leggings;
+    }
+
+    public void setLeggings(Material leggings) {
+        this.leggings = leggings;
+    }
+
+    public Material getBoots() {
+        return boots;
+    }
+
+    public void setBoots(Material boots) {
+        this.boots = boots;
+    }
+}
+


### PR DESCRIPTION
## Summary
- track per-admin NPC creation state and prompt for skin, mode, name and equipment
- listen to chat answers and add `/bw admin confirmnpc` to finalize NPC placement
- document chat-based NPC setup in README and changelog

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a59ca160f483299d60b34ae65ed00b