### PR TITLE
fix(npc): validate skin length to prevent packet error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [2.3.1] - 2024-??-??
+
+### Corrigé
+- Correction d'un crash lors de la création de PNJ avec un nom ou un skin trop long.
+
 ## [2.3.0] - 2024-??-??
 
 ### Ajouté

--- a/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
@@ -31,6 +31,14 @@ public class ChatListener implements Listener {
             }
             switch (process.getStep()) {
                 case SKIN -> {
+                    // Player heads rely on the underlying game profile name
+                    // which is limited to 16 characters. Reject longer skin
+                    // names to avoid packet encoding errors during NPC
+                    // creation.
+                    if (msg.length() > 16) {
+                        player.sendMessage(ChatColor.RED + "Nom de skin trop long (16 caractères max).");
+                        return;
+                    }
                     process.setSkin(msg);
                     process.setStep(NpcCreationProcess.Step.MODE);
                     player.sendMessage(ChatColor.YELLOW + "Pour quel mode ce PNJ doit-il servir ?");

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -109,7 +109,16 @@ public class NpcManager {
         // Head with skin
         ItemStack head = new ItemStack(Material.PLAYER_HEAD);
         SkullMeta meta = (SkullMeta) head.getItemMeta();
-        meta.setOwningPlayer(Bukkit.getOfflinePlayer(info.skin));
+        // Only apply a skin owner if the provided name fits within the
+        // legacy 16 character limit used by player profiles. This prevents
+        // the server from sending an oversized string through the equipment
+        // packet which would otherwise result in an EncoderException.
+        if (info.skin != null && info.skin.length() <= 16) {
+            meta.setOwningPlayer(Bukkit.getOfflinePlayer(info.skin));
+        }
+        // Ensure the item itself carries no custom display name; the visible
+        // name for the NPC is handled via the ArmorStand's custom name.
+        meta.setDisplayName(null);
         head.setItemMeta(meta);
         npc.getEquipment().setHelmet(head);
 


### PR DESCRIPTION
## Summary
- prevent NPC head item from carrying long skin names and display names that break packets
- reject skin names longer than 16 characters during NPC creation
- document fix in changelog

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a26a075883299e9a77a1b80aeedd