### PR TITLE
feat(npc): add static pose and breathing animation to Armor Stand NPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 ### Corrigé
 - Correction d'une erreur de compilation liée à un accès protégé dans les menus.
 
+## [2.2.2] - 2024-??-??
+
+### Ajouté
+- Ajout d'animations (pose statique et respiration) pour les PNJ.
+
 ## [2.2.1] - 2024-05-09
 
 ### Ajouté

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -36,6 +36,7 @@ import com.heneria.bedwars.managers.EventManager;
 import com.heneria.bedwars.managers.PlayerProgressionManager;
 import com.heneria.bedwars.managers.BountyManager;
 import com.heneria.bedwars.managers.NpcManager;
+import com.heneria.bedwars.managers.NpcAnimationManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -57,6 +58,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private PlayerProgressionManager playerProgressionManager;
     private BountyManager bountyManager;
     private NpcManager npcManager;
+    private NpcAnimationManager npcAnimationManager;
     private Location mainLobby;
     private static NamespacedKey itemTypeKey;
     private static NamespacedKey npcKey;
@@ -86,6 +88,8 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.playerProgressionManager = new PlayerProgressionManager();
         this.bountyManager = new BountyManager(3, 5);
         this.npcManager = new NpcManager(this);
+        this.npcAnimationManager = new NpcAnimationManager(this, this.npcManager);
+        this.npcAnimationManager.start();
 
         // Enregistrement des commandes
         CommandManager commandManager = new CommandManager(this);
@@ -101,6 +105,9 @@ public final class HeneriaBedwars extends JavaPlugin {
     public void onDisable() {
         if (statsManager != null) {
             statsManager.saveAll();
+        }
+        if (npcAnimationManager != null) {
+            npcAnimationManager.stop();
         }
         getLogger().info("HeneriaBedwars a été désactivé.");
     }
@@ -192,6 +199,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public NpcManager getNpcManager() {
         return npcManager;
+    }
+
+    public NpcAnimationManager getNpcAnimationManager() {
+        return npcAnimationManager;
     }
 
     public Location getMainLobby() {

--- a/src/main/java/com/heneria/bedwars/managers/NpcAnimationManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcAnimationManager.java
@@ -1,0 +1,69 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.EulerAngle;
+
+/**
+ * Runs subtle animations for lobby NPCs.
+ */
+public class NpcAnimationManager {
+
+    private final HeneriaBedwars plugin;
+    private final NpcManager npcManager;
+    private BukkitRunnable task;
+    private int tick;
+
+    public NpcAnimationManager(HeneriaBedwars plugin, NpcManager npcManager) {
+        this.plugin = plugin;
+        this.npcManager = npcManager;
+    }
+
+    /**
+     * Starts the breathing animation task.
+     */
+    public void start() {
+        if (task != null) return;
+        task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                tick++;
+                double offset = Math.sin(tick / 20.0) * Math.toRadians(1.5);
+                NamespacedKey npcKey = HeneriaBedwars.getNpcKey();
+                for (NpcManager.NpcInfo info : npcManager.getNpcs()) {
+                    ArmorStand stand = findStand(info, npcKey);
+                    if (stand == null) continue;
+                    EulerAngle body = stand.getBodyPose();
+                    stand.setBodyPose(new EulerAngle(offset, body.getY(), body.getZ()));
+                }
+            }
+        };
+        task.runTaskTimer(plugin, 0L, 1L);
+    }
+
+    /**
+     * Stops the animation task.
+     */
+    public void stop() {
+        if (task != null) {
+            task.cancel();
+            task = null;
+        }
+    }
+
+    private ArmorStand findStand(NpcManager.NpcInfo info, NamespacedKey npcKey) {
+        for (Entity entity : info.location.getWorld().getNearbyEntities(info.location, 1, 1, 1)) {
+            if (entity instanceof ArmorStand stand) {
+                String mode = stand.getPersistentDataContainer().get(npcKey, PersistentDataType.STRING);
+                if (mode != null && mode.equals(info.mode)) {
+                    return stand;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.EulerAngle;
 
 import java.io.File;
 import java.io.IOException;
@@ -135,6 +136,13 @@ public class NpcManager {
         if (info.boots != null) {
             npc.getEquipment().setBoots(new ItemStack(info.boots));
         }
+
+        // Apply a more natural default pose
+        npc.setHeadPose(new EulerAngle(Math.toRadians(-5), 0, 0));
+        npc.setRightArmPose(new EulerAngle(Math.toRadians(-10), 0, 0));
+        npc.setLeftArmPose(new EulerAngle(Math.toRadians(-15), 0, 0));
+        npc.setRightLegPose(new EulerAngle(Math.toRadians(-2), 0, 0));
+        npc.setLeftLegPose(new EulerAngle(Math.toRadians(2), 0, 0));
     }
 
     private String capitalize(String input) {


### PR DESCRIPTION
## Summary
- animate lobby Armor Stand NPCs with a subtle breathing effect via a centralized task
- give newly spawned NPCs a natural default pose
- document the new NPC animation system

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a766af1c8329bdd15d1c8811c6e4