### PR TITLE
feat(lobby)!: Rework join menu into a Game Hub with stats and reconnect system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - HeneriaBedwars
 
+## [2.4.0] - 2024-??-??
+
+### Ajouté
+- Nouveau **Hub de Jeu** remplaçant la liste d'arènes avec accès rapide au jeu, aux statistiques et à la reconnexion.
+- Système expérimental de reconnexion permettant aux joueurs de revenir en partie pendant une courte durée.
+
 ## [2.3.1] - 2024-??-??
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 ### Pour les Joueurs
 
 - 🎡 **Lobby Principal Immersif** : Les joueurs apparaissent dans un lobby central et choisissent leur mode via des PNJ interactifs.
+- 🎮 **Hub de Jeu Intuitif** : En cliquant sur un PNJ de mode, un menu propose de lancer une partie, consulter ses statistiques ou se reconnecter.
 - 🕹️ **Cycle de Jeu Complet** : Rejoignez une arène, attendez dans le lobby avec un décompte, et lancez-vous dans la bataille.
 - 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.
 - 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, et détruisez celui de vos ennemis pour les éliminer définitivement.

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -22,6 +22,7 @@ import com.heneria.bedwars.listeners.TemperedGlassListener;
 import com.heneria.bedwars.listeners.LeaveItemListener;
 import com.heneria.bedwars.listeners.JoinNpcListener;
 import com.heneria.bedwars.listeners.MainLobbyListener;
+import com.heneria.bedwars.listeners.ReconnectListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -36,6 +37,7 @@ import com.heneria.bedwars.managers.PlayerProgressionManager;
 import com.heneria.bedwars.managers.BountyManager;
 import com.heneria.bedwars.managers.NpcManager;
 import com.heneria.bedwars.managers.NpcAnimationManager;
+import com.heneria.bedwars.managers.ReconnectManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -58,6 +60,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private BountyManager bountyManager;
     private NpcManager npcManager;
     private NpcAnimationManager npcAnimationManager;
+    private ReconnectManager reconnectManager;
     private Location mainLobby;
     private static NamespacedKey itemTypeKey;
     private static NamespacedKey npcKey;
@@ -89,6 +92,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.npcManager = new NpcManager(this);
         this.npcAnimationManager = new NpcAnimationManager(this, this.npcManager);
         this.npcAnimationManager.start();
+        this.reconnectManager = new ReconnectManager(this);
 
         // Enregistrement des commandes
         CommandManager commandManager = new CommandManager(this);
@@ -133,6 +137,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new TemperedGlassListener(), this);
         getServer().getPluginManager().registerEvents(new JoinNpcListener(), this);
         getServer().getPluginManager().registerEvents(new MainLobbyListener(), this);
+        getServer().getPluginManager().registerEvents(new ReconnectListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {
@@ -197,6 +202,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public NpcManager getNpcManager() {
         return npcManager;
+    }
+
+    public ReconnectManager getReconnectManager() {
+        return reconnectManager;
     }
 
     public NpcAnimationManager getNpcAnimationManager() {

--- a/src/main/java/com/heneria/bedwars/gui/GameHubMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/GameHubMenu.java
@@ -1,0 +1,97 @@
+package com.heneria.bedwars.gui;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ReconnectManager;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Small hub menu offering quick join, stats and reconnect options.
+ */
+public class GameHubMenu extends Menu {
+
+    private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+    private final ReconnectManager reconnectManager = plugin.getReconnectManager();
+    private Player viewer;
+
+    @Override
+    public void open(Player player, Menu previousMenu) {
+        this.viewer = player;
+        super.open(player, previousMenu);
+    }
+
+    @Override
+    public String getTitle() {
+        return "Hub de Jeu";
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            inventory.setItem(i, filler);
+        }
+        inventory.setItem(13, new ItemBuilder(Material.RED_BED)
+                .setName("&aJouer")
+                .addLore("&7Trouver une partie rapidement")
+                .build());
+        inventory.setItem(11, new ItemBuilder(Material.PAPER)
+                .setName("&eStatistiques")
+                .addLore("&7Voir vos statistiques")
+                .build());
+        if (viewer != null && reconnectManager.hasPending(viewer.getUniqueId())) {
+            Arena arena = reconnectManager.getArena(viewer.getUniqueId());
+            inventory.setItem(15, new ItemBuilder(Material.ENDER_PEARL)
+                    .setName("&dReconnexion")
+                    .addLore("&7Retourner dans l'arène &b" + arena.getName())
+                    .build());
+        }
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        if (handleBack(event)) {
+            return;
+        }
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        int slot = event.getRawSlot();
+        if (slot == 13) {
+            quickJoin(player);
+            player.closeInventory();
+        } else if (slot == 11) {
+            new PlayerStatsMenu().open(player, this);
+        } else if (slot == 15 && reconnectManager.hasPending(player.getUniqueId())) {
+            reconnectManager.reconnect(player);
+            player.closeInventory();
+        }
+    }
+
+    private void quickJoin(Player player) {
+        Arena best = null;
+        for (Arena arena : plugin.getArenaManager().getAllArenas()) {
+            if (arena.getState() == GameState.WAITING || arena.getState() == GameState.STARTING) {
+                if (best == null || arena.getPlayers().size() > best.getPlayers().size()) {
+                    best = arena;
+                }
+            }
+        }
+        if (best != null) {
+            best.addPlayer(player);
+        } else {
+            player.sendMessage("Aucune partie disponible pour le moment");
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/PlayerStatsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/PlayerStatsMenu.java
@@ -1,0 +1,60 @@
+package com.heneria.bedwars.gui;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.stats.PlayerStats;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Displays a player's statistics.
+ */
+public class PlayerStatsMenu extends Menu {
+
+    private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+    private Player viewer;
+
+    @Override
+    public void open(Player player, Menu previousMenu) {
+        this.viewer = player;
+        super.open(player, previousMenu);
+    }
+
+    @Override
+    public String getTitle() {
+        return "Statistiques";
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        ItemStack filler = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            inventory.setItem(i, filler);
+        }
+        PlayerStats stats = plugin.getStatsManager().getStats(viewer);
+        ItemBuilder builder = new ItemBuilder(Material.BOOK).setName("&eVos Statistiques");
+        if (stats != null) {
+            builder
+                    .addLore("&7Kills: &b" + stats.getKills())
+                    .addLore("&7Morts: &b" + stats.getDeaths())
+                    .addLore("&7Victoires: &b" + stats.getWins())
+                    .addLore("&7Défaites: &b" + stats.getLosses())
+                    .addLore("&7Lits détruits: &b" + stats.getBedsBroken())
+                    .addLore("&7Parties jouées: &b" + stats.getGamesPlayed());
+        }
+        inventory.setItem(13, builder.build());
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        handleBack(event);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/JoinNpcListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/JoinNpcListener.java
@@ -1,7 +1,7 @@
 package com.heneria.bedwars.listeners;
 
 import com.heneria.bedwars.HeneriaBedwars;
-import com.heneria.bedwars.gui.ArenaSelectorMenu;
+import com.heneria.bedwars.gui.GameHubMenu;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -16,12 +16,11 @@ public class JoinNpcListener implements Listener {
     @EventHandler
     public void onInteract(PlayerInteractAtEntityEvent event) {
         Entity entity = event.getRightClicked();
-        String mode = HeneriaBedwars.getInstance().getNpcManager().getMode(entity);
-        if (mode == null) {
+        if (HeneriaBedwars.getInstance().getNpcManager().getMode(entity) == null) {
             return;
         }
         event.setCancelled(true);
         Player player = event.getPlayer();
-        new ArenaSelectorMenu(mode).open(player);
+        new GameHubMenu().open(player);
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/ReconnectListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/ReconnectListener.java
@@ -1,0 +1,30 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.managers.ReconnectManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Captures disconnects to offer a reconnection window.
+ */
+public class ReconnectListener implements Listener {
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+    private final ReconnectManager reconnectManager = HeneriaBedwars.getInstance().getReconnectManager();
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        Arena arena = arenaManager.getArena(player);
+        if (arena != null && arena.getState() == GameState.PLAYING) {
+            reconnectManager.markDisconnected(player, arena);
+            arena.removePlayer(player);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/ReconnectManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ReconnectManager.java
@@ -1,0 +1,55 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks players who disconnected mid-game and allows them to reconnect.
+ */
+public class ReconnectManager {
+
+    private final HeneriaBedwars plugin;
+    private final Map<UUID, Pending> pending = new ConcurrentHashMap<>();
+
+    public ReconnectManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+    }
+
+    public void markDisconnected(Player player, Arena arena) {
+        UUID uuid = player.getUniqueId();
+        BukkitTask task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                pending.remove(uuid);
+            }
+        }.runTaskLater(plugin, 20L * 120); // 2 minutes
+        pending.put(uuid, new Pending(arena, task));
+    }
+
+    public boolean hasPending(UUID uuid) {
+        return pending.containsKey(uuid);
+    }
+
+    public Arena getArena(UUID uuid) {
+        Pending p = pending.get(uuid);
+        return p != null ? p.arena : null;
+    }
+
+    public void reconnect(Player player) {
+        UUID uuid = player.getUniqueId();
+        Pending p = pending.remove(uuid);
+        if (p != null) {
+            p.task.cancel();
+            p.arena.addPlayer(player);
+        }
+    }
+
+    private record Pending(Arena arena, BukkitTask task) {}
+}


### PR DESCRIPTION
## Summary
- replace arena list with GameHubMenu offering quick join, stats view and reconnection
- add PlayerStatsMenu and ReconnectManager with listener for disconnects
- document new game hub in README and changelog

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5be4e14288329ac8051c32825430c