### PR TITLE
feat(core): Implement per-arena chat and tablist isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [2.5.0] - 2024-??-??
+
+### Ajouté
+- Ajout de l'isolation du chat et de la tablist par arène.
+
 ## [2.4.2] - 2024-??-??
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
   - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby d'attente et de la partie via les sections `lobby` et `game`.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
-  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`).
+  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`) et personnalisez le format du chat via `chat-format`.
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
 
@@ -32,6 +32,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🎮 **Hub de Jeu Intuitif** : En cliquant sur un PNJ de mode, un menu propose de lancer une partie, consulter ses statistiques ou se reconnecter.
 - 🕹️ **Cycle de Jeu Complet** : Rejoignez une arène, attendez dans le lobby avec un décompte, et lancez-vous dans la bataille.
 - 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.
+- 💬 **Chat et Tablist isolés** : Les messages et la liste des joueurs sont limités à votre partie pour éviter le spam entre arènes.
 - 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, et détruisez celui de vos ennemis pour les éliminer définitivement.
 - 💰 **Système Économique** : Collectez du Fer, de l'Or, des Diamants et des Émeraudes à des vitesses différentes pour acheter de l'équipement.
 - 🔥 **Forge évolutive** : Améliorez la Forge de votre équipe pour accélérer le Fer et l'Or, le dernier niveau produisant même des Émeraudes sur votre île.

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -259,6 +259,19 @@ public class Arena {
         if (players.size() >= minPlayers && state == GameState.WAITING) {
             startCountdown();
         }
+        for (Player online : Bukkit.getOnlinePlayers()) {
+            if (online.equals(player)) {
+                continue;
+            }
+            Arena other = HeneriaBedwars.getInstance().getArenaManager().getArena(online);
+            if (other != this) {
+                online.hidePlayer(HeneriaBedwars.getInstance(), player);
+                player.hidePlayer(HeneriaBedwars.getInstance(), online);
+            } else {
+                online.showPlayer(HeneriaBedwars.getInstance(), player);
+                player.showPlayer(HeneriaBedwars.getInstance(), online);
+            }
+        }
     }
 
     /**
@@ -289,6 +302,19 @@ public class Arena {
         if (lobby != null) {
             player.teleport(lobby);
             player.setGameMode(GameMode.ADVENTURE);
+        }
+        for (Player online : Bukkit.getOnlinePlayers()) {
+            if (online.equals(player)) {
+                continue;
+            }
+            Arena other = HeneriaBedwars.getInstance().getArenaManager().getArena(online);
+            if (other == null) {
+                online.showPlayer(HeneriaBedwars.getInstance(), player);
+                player.showPlayer(HeneriaBedwars.getInstance(), online);
+            } else {
+                online.hidePlayer(HeneriaBedwars.getInstance(), player);
+                player.hidePlayer(HeneriaBedwars.getInstance(), online);
+            }
         }
     }
 

--- a/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
@@ -2,6 +2,8 @@ package com.heneria.bedwars.listeners;
 
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.gui.admin.creation.ArenaSettingsMenu;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.elements.Team;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.setup.NpcCreationProcess;
@@ -13,6 +15,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+import java.util.UUID;
 
 public class ChatListener implements Listener {
 
@@ -134,5 +138,41 @@ public class ChatListener implements Listener {
                 new ArenaSettingsMenu(arenaName).open(player);
             });
         }
+
+        Arena arena = arenaManager.getArena(player);
+        if (arena != null) {
+            event.getRecipients().clear();
+            for (UUID id : arena.getPlayers()) {
+                Player p = Bukkit.getPlayer(id);
+                if (p != null) {
+                    event.getRecipients().add(p);
+                }
+            }
+            Team team = arena.getTeam(player);
+            String format = HeneriaBedwars.getInstance().getConfig().getString("chat-format", "[{team_color}{team_name}] {player_name}: {message}");
+            ChatColor color = team != null ? team.getColor().getChatColor() : ChatColor.WHITE;
+            String teamName = team != null ? team.getColor().getDisplayName() : "";
+            format = ChatColor.translateAlternateColorCodes('&', format
+                    .replace("{team_color}", color.toString())
+                    .replace("{team_name}", teamName)
+                    .replace("{player_name}", "%1$s")
+                    .replace("{message}", "%2$s"));
+            event.setFormat(format);
+            return;
+        }
+
+        event.getRecipients().clear();
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            if (arenaManager.getArena(p) == null) {
+                event.getRecipients().add(p);
+            }
+        }
+        String format = HeneriaBedwars.getInstance().getConfig().getString("chat-format", "{player_name}: {message}");
+        format = ChatColor.translateAlternateColorCodes('&', format
+                .replace("{team_color}", "")
+                .replace("{team_name}", "")
+                .replace("{player_name}", "%1$s")
+                .replace("{message}", "%2$s"));
+        event.setFormat(format);
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/MainLobbyListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/MainLobbyListener.java
@@ -2,6 +2,7 @@ package com.heneria.bedwars.listeners;
 
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -23,12 +24,24 @@ public class MainLobbyListener implements Listener {
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
+        Player joining = event.getPlayer();
         Location lobby = plugin.getMainLobby();
         if (lobby != null) {
-            Player player = event.getPlayer();
-            player.teleport(lobby);
-            player.setGameMode(GameMode.ADVENTURE);
-            player.setFoodLevel(20);
+            joining.teleport(lobby);
+            joining.setGameMode(GameMode.ADVENTURE);
+            joining.setFoodLevel(20);
+        }
+        for (Player online : Bukkit.getOnlinePlayers()) {
+            if (online.equals(joining)) {
+                continue;
+            }
+            if (arenaManager.getArena(online) != null) {
+                online.hidePlayer(plugin, joining);
+                joining.hidePlayer(plugin, online);
+            } else {
+                online.showPlayer(plugin, joining);
+                joining.showPlayer(plugin, online);
+            }
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 main-lobby: {}
 void-kill-height: 0
 trap-radius: 10
+chat-format: "[{team_color}{team_name}] {player_name}: {message}"
 
 database:
     type: sqlite # sqlite or mysql


### PR DESCRIPTION
## Summary
- isolate chat messages to each arena or lobby with configurable formatting
- hide players across arenas to isolate TAB lists and visibility
- document chat/tab isolation and new `chat-format` option

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e90111dc8329b6a4d2a5a244067b