### PR TITLE
fix(gameflow): Correct post-game visibility, block reset, and full arena join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - HeneriaBedwars
 
+## [3.0.1] - 2024-??-??
+
+### Corrigé
+- Rétablissement de la visibilité des joueurs après les parties.
+- Suppression des blocs placés lors du reset d'arène.
+- Empêchement de rejoindre une arène pleine ou déjà en cours.
+
 ## [2.5.0] - 2024-??-??
 
 ### Ajouté

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -184,6 +184,15 @@ public class Arena {
         this.maxPlayers = maxPlayers;
     }
 
+    /**
+     * Determines whether a new player can join the arena.
+     *
+     * @return true if the arena is waiting and not full
+     */
+    public boolean canJoin() {
+        return state == GameState.WAITING && players.size() < maxPlayers;
+    }
+
     public int getMaxBuildY() {
         return maxBuildY;
     }
@@ -865,6 +874,14 @@ public class Arena {
                     p.teleport(mainLobby);
                 }
                 HeneriaBedwars.getInstance().getScoreboardManager().removeScoreboard(p);
+                // Restore visibility with all other players
+                for (Player other : Bukkit.getOnlinePlayers()) {
+                    if (other.equals(p)) {
+                        continue;
+                    }
+                    p.showPlayer(HeneriaBedwars.getInstance(), other);
+                    other.showPlayer(HeneriaBedwars.getInstance(), p);
+                }
             }
         }
         players.clear();
@@ -884,10 +901,15 @@ public class Arena {
         dragons.clear();
         purchaseCounts.clear();
         HeneriaBedwars.getInstance().getGeneratorManager().resetGenerators(this);
-        for (Block block : placedBlocks) {
-            block.setType(Material.AIR);
+        if (!placedBlocks.isEmpty()) {
+            HeneriaBedwars.getInstance().getLogger().info("[DEBUG] Clearing " + placedBlocks.size() + " placed blocks in arena " + name);
+            for (Block block : placedBlocks) {
+                HeneriaBedwars.getInstance().getLogger().info("[DEBUG] Reset block at " + block.getLocation());
+                block.setType(Material.AIR);
+            }
+            placedBlocks.clear();
+            HeneriaBedwars.getInstance().getLogger().info("[DEBUG] Placed blocks list cleared for arena " + name);
         }
-        placedBlocks.clear();
 
         for (BlockState state : originalBedStates.values()) {
             state.update(true, false);

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/JoinCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/JoinCommand.java
@@ -2,7 +2,6 @@ package com.heneria.bedwars.commands.subcommands;
 
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
-import com.heneria.bedwars.arena.enums.GameState;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.entity.Player;
@@ -37,8 +36,12 @@ public class JoinCommand implements SubCommand {
             MessageManager.sendMessage(player, "errors.arena-not-found");
             return;
         }
-        if (!arena.isEnabled() || arena.getState() != GameState.WAITING) {
+        if (!arena.isEnabled()) {
             MessageManager.sendMessage(player, "errors.arena-not-available");
+            return;
+        }
+        if (!arena.canJoin()) {
+            MessageManager.sendMessage(player, "errors.arena-full-or-started");
             return;
         }
         if (manager.getArenaByPlayer(player.getUniqueId()) != null) {

--- a/src/main/java/com/heneria/bedwars/gui/ArenaSelectorMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/ArenaSelectorMenu.java
@@ -4,6 +4,7 @@ import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.enums.GameState;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -91,9 +92,11 @@ public class ArenaSelectorMenu extends Menu {
         if (arena == null) {
             return;
         }
-        if (arena.getState() == GameState.WAITING || arena.getState() == GameState.STARTING) {
+        if (arena.canJoin()) {
             player.closeInventory();
             arena.addPlayer(player);
+        } else {
+            MessageManager.sendMessage(player, "errors.arena-full-or-started");
         }
     }
 }

--- a/src/main/java/com/heneria/bedwars/gui/GameHubMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/GameHubMenu.java
@@ -2,9 +2,9 @@ package com.heneria.bedwars.gui;
 
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
-import com.heneria.bedwars.arena.enums.GameState;
 import com.heneria.bedwars.managers.ReconnectManager;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -82,7 +82,7 @@ public class GameHubMenu extends Menu {
     private void quickJoin(Player player) {
         Arena best = null;
         for (Arena arena : plugin.getArenaManager().getAllArenas()) {
-            if (arena.getState() == GameState.WAITING || arena.getState() == GameState.STARTING) {
+            if (arena.canJoin()) {
                 if (best == null || arena.getPlayers().size() > best.getPlayers().size()) {
                     best = arena;
                 }
@@ -91,7 +91,7 @@ public class GameHubMenu extends Menu {
         if (best != null) {
             best.addPlayer(player);
         } else {
-            player.sendMessage("Aucune partie disponible pour le moment");
+            MessageManager.sendMessage(player, "errors.arena-full-or-started");
         }
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -20,6 +20,7 @@ errors:
   team-incomplete: "&cToutes les équipes n'ont pas leur spawn et leur lit définis."
   no-teams-configured: "&cAucune équipe configurée."
   build-outside-boundaries: "&cVous ne pouvez pas construire en dehors de la zone autorisée."
+  arena-full-or-started: "&cCette arène est pleine ou déjà en cours."
 
 commands:
   main-usage: "&eUsage: /{label} <admin|join|leave>"


### PR DESCRIPTION
## Summary
- Restore player visibility and clear placed blocks with debug logs after arena reset
- Prevent joining arenas that are full or not waiting via command, menu, and quick join
- Document bug fixes and add user-facing message for full or started arenas

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a60dbcf258832981c0af3799757c1e