### PR TITLE
feat(lobby): Add main lobby scoreboard and welcome message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - HeneriaBedwars
 
+## [3.1.0] - 2024-??-??
+
+### Ajouté
+- Message de bienvenue configurable à la connexion.
+- Scoreboard du lobby principal affichant les statistiques des joueurs.
+
 ## [3.0.1] - 2024-??-??
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `generators.yml` : Réglez la vitesse et la quantité de chaque générateur de ressources.
   - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
-  - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby d'attente et de la partie via les sections `lobby` et `game`.
+  - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby principal, du lobby d'attente et de la partie via les sections `main-lobby`, `lobby` et `game`.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
   - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`) et personnalisez le format du chat via `chat-format`.
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
@@ -28,7 +28,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 
 ### Pour les Joueurs
 
-- 🎡 **Lobby Principal Immersif** : Les joueurs apparaissent dans un lobby central et choisissent leur mode via des PNJ interactifs.
+- 🎡 **Lobby Principal Immersif** : Les joueurs apparaissent dans un lobby central et choisissent leur mode via des PNJ interactifs. Un message de bienvenue personnalisé et un scoreboard de statistiques les accueillent.
 - 🎮 **Hub de Jeu Intuitif** : En cliquant sur un PNJ de mode, un menu propose de lancer une partie, consulter ses statistiques ou se reconnecter.
 - 🕹️ **Cycle de Jeu Complet** : Rejoignez une arène, attendez dans le lobby avec un décompte, et lancez-vous dans la bataille.
 - 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.
@@ -269,14 +269,28 @@ items:
 
 ### Configuration du Scoreboard
 
-Le fichier `scoreboard.yml` est divisé en deux sections : `lobby` pour le lobby d'attente et `game` pour la partie. Chaque section possède son propre `title` et sa liste de `lines`, avec des placeholders dédiés.
+Le fichier `scoreboard.yml` est divisé en trois sections : `main-lobby` pour le lobby principal, `lobby` pour le lobby d'attente et `game` pour la partie. Chaque section possède son propre `title` et sa liste de `lines`, avec des placeholders dédiés.
 
-- **Lobby :** `{date}`, `{map_name}`, `{current_players}`, `{max_players}`, `{status}`
-- **Jeu :** `{date}`, `{next_event_name}`, `{next_event_time}`, `{team_status}`
+- **Lobby principal :** `{player}`, `{wins}`, `{kills}`, `{beds_broken}`
+- **Lobby d'attente :** `{date}`, `{map_name}`, `{current_players}`, `{max_players}`, `{status}`
+- **En jeu :** `{date}`, `{next_event_name}`, `{next_event_time}`, `{team_status}`
 
 Exemple complet :
 
 ```yaml
+# Scoreboard pour le lobby principal
+main-lobby:
+  title: "&b&lHeneria Network"
+  lines:
+    - "&7Joueur: &f{player}"
+    - "&1"
+    - "&f&lStatistiques"
+    - " &fVictoires: &a{wins}"
+    - " &fKills: &a{kills}"
+    - " &fLits détruits: &a{beds_broken}"
+    - "&2"
+    - "&eplay.votreserveur.com"
+
 # Scoreboard pour le lobby d'attente
 lobby:
   title: "&b&lHeneria BedWars"
@@ -298,7 +312,7 @@ game:
     - "&7{date}"
     - "&1"
     - "Prochain événement:"
-    - "&a{next_event_name} &fen &a{next_event_time}"
+    - "&a{next_event_name} &fdans &a{next_event_time}"
     - "&2"
     - "{team_status}"
     - "&3"

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -302,7 +302,7 @@ public class Arena {
         player.setLevel(0);
         player.setExp(0f);
         broadcast("game.player-leave-arena", "player", player.getName());
-        HeneriaBedwars.getInstance().getScoreboardManager().removeScoreboard(player);
+        HeneriaBedwars.getInstance().getScoreboardManager().setScoreboard(player);
         HeneriaBedwars.getInstance().getPlayerProgressionManager().removePlayer(player.getUniqueId());
         if (state == GameState.STARTING && players.size() < minPlayers) {
             cancelCountdown();
@@ -873,7 +873,7 @@ public class Arena {
                 if (mainLobby != null) {
                     p.teleport(mainLobby);
                 }
-                HeneriaBedwars.getInstance().getScoreboardManager().removeScoreboard(p);
+                HeneriaBedwars.getInstance().getScoreboardManager().setScoreboard(p);
                 // Restore visibility with all other players
                 for (Player other : Bukkit.getOnlinePlayers()) {
                     if (other.equals(p)) {

--- a/src/main/java/com/heneria/bedwars/listeners/MainLobbyListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/MainLobbyListener.java
@@ -13,6 +13,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import com.heneria.bedwars.utils.MessageManager;
 
 /**
  * Handles player spawning and protection in the main lobby.
@@ -30,6 +31,10 @@ public class MainLobbyListener implements Listener {
             joining.teleport(lobby);
             joining.setGameMode(GameMode.ADVENTURE);
             joining.setFoodLevel(20);
+        }
+        plugin.getScoreboardManager().setScoreboard(joining);
+        for (String line : MessageManager.getList("on-join.welcome-message")) {
+            joining.sendMessage(line.replace("{player}", joining.getName()));
         }
         for (Player online : Bukkit.getOnlinePlayers()) {
             if (online.equals(joining)) {

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -26,6 +26,13 @@ commands:
   main-usage: "&eUsage: /{label} <admin|join|leave>"
   join-usage: "&eUsage: /bw join <arène>"
 
+on-join:
+  welcome-message:
+    - "&1"
+    - "&b&lHeneria &7» &fBienvenue, &e{player}&f !"
+    - "&7Utilisez les PNJ pour rejoindre une partie."
+    - "&2"
+
 game:
   team-joined: "&aVous avez rejoint l'équipe {team}"
   player-join-arena: "&e{player} a rejoint l'arène. (&b{current_players}&e/{max_players})"

--- a/src/main/resources/scoreboard.yml
+++ b/src/main/resources/scoreboard.yml
@@ -1,3 +1,16 @@
+# Scoreboard pour le lobby principal
+main-lobby:
+  title: "&b&lHeneria Network"
+  lines:
+    - "&7Joueur: &f{player}"
+    - "&1"
+    - "&f&lStatistiques"
+    - " &fVictoires: &a{wins}"
+    - " &fKills: &a{kills}"
+    - " &fLits détruits: &a{beds_broken}"
+    - "&2"
+    - "&eplay.votreserveur.com"
+
 # Scoreboard pour le lobby d'attente
 lobby:
   title: "&b&lHeneria BedWars"


### PR DESCRIPTION
## Summary
- greet players on join using configurable multiline message
- show main lobby scoreboard with personal stats
- document new `main-lobby` scoreboard section

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b460c3e7248329874c83834e15638c