### PR TITLE
feat: enhance main lobby scoreboard with new info section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [3.1.1] - 2024-??-??
+
+### Modifié
+- Amélioration du scoreboard du lobby principal avec de nouveaux placeholders.
+
 ## [3.1.0] - 2024-??-??
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `generators.yml` : Réglez la vitesse et la quantité de chaque générateur de ressources.
   - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
-  - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby principal, du lobby d'attente et de la partie via les sections `main-lobby`, `lobby` et `game`.
+  - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby principal, du lobby d'attente et de la partie via les sections `main-lobby`, `lobby` et `game`. La section `main-lobby` inclut une rubrique `Infos` (grade, rang, Elo, Henacoins) reposant sur PlaceholderAPI (`%luckperms_prefix%`, `%vault_eco_balance_formatted%`).
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
   - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`) et personnalisez le format du chat via `chat-format`.
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
@@ -57,6 +57,14 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 2.  Placez le fichier `.jar` téléchargé dans le dossier `plugins` de votre serveur Spigot 1.21.
 3.  Redémarrez votre serveur.
 4.  Les fichiers de configuration par défaut seront générés dans le dossier `plugins/HeneriaBedwars/`.
+
+## 🔌 Placeholders et dépendances optionnelles
+
+Le scoreboard du lobby principal utilise [PlaceholderAPI](https://github.com/PlaceholderAPI/PlaceholderAPI) pour afficher des informations dynamiques :
+- `%luckperms_prefix%` : grade du joueur (nécessite LuckPerms).
+- `%vault_eco_balance_formatted%` : solde de l'économie (nécessite Vault et un plugin d'économie compatible).
+
+Ces plugins restent facultatifs mais sont recommandés pour profiter pleinement du scoreboard.
 
 ---
 

--- a/src/main/resources/scoreboard.yml
+++ b/src/main/resources/scoreboard.yml
@@ -1,15 +1,21 @@
 # Scoreboard pour le lobby principal
 main-lobby:
-  title: "&b&lHeneria Network"
+  title: "&b&lHENERIA"
   lines:
     - "&7Joueur: &f{player}"
     - "&1"
-    - "&f&lStatistiques"
+    - "&f&lInfos"
+    - " &fGrade: %luckperms_prefix%"
+    - " &fRang: &cNon classé"
+    - " &fElo: &eN/A"
+    - " &fHenacoins: &6%vault_eco_balance_formatted%"
+    - "&2"
+    - "&f&lStatistiques BedWars"
     - " &fVictoires: &a{wins}"
     - " &fKills: &a{kills}"
     - " &fLits détruits: &a{beds_broken}"
-    - "&2"
-    - "&eplay.votreserveur.com"
+    - "&3"
+    - "&bheneria.com"
 
 # Scoreboard pour le lobby d'attente
 lobby:


### PR DESCRIPTION
## Summary
- expand main lobby scoreboard with info section displaying grade, rank, elo, and Henacoins placeholders
- document new placeholders and optional dependencies (PlaceholderAPI, LuckPerms, Vault)
- record scoreboard enhancement in changelog

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b46e0cddb48329abd06cf900322b1f