### PR TITLE
feat(lobby): Add custom tablist and void teleport protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - HeneriaBedwars
 
+## [3.1.2] - 2024-??-??
+
+### Ajouté
+- Tablist personnalisée pour le lobby principal avec support de PlaceholderAPI.
+- Protection contre le vide téléportant les joueurs au spawn du lobby.
+
 ## [3.1.1] - 2024-??-??
 
 ### Modifié

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
   - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby principal, du lobby d'attente et de la partie via les sections `main-lobby`, `lobby` et `game`. La section `main-lobby` inclut une rubrique `Infos` (grade, rang, Elo, Henacoins) reposant sur PlaceholderAPI (`%luckperms_prefix%`, `%vault_eco_balance_formatted%`).
+  - `tablist.yml` : Configurez l'en-tête et le pied de page de la liste des joueurs du lobby avec couleurs, sauts de ligne (`\n`) et placeholders.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
-  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`) et personnalisez le format du chat via `chat-format`.
+  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`), la hauteur de téléportation anti-vide (`void-teleport-height`) et personnalisez le format du chat via `chat-format`.
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
 

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -22,6 +22,7 @@ import com.heneria.bedwars.listeners.TemperedGlassListener;
 import com.heneria.bedwars.listeners.LeaveItemListener;
 import com.heneria.bedwars.listeners.MainLobbyListener;
 import com.heneria.bedwars.listeners.ReconnectListener;
+import com.heneria.bedwars.listeners.LobbyVoidListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -38,6 +39,7 @@ import com.heneria.bedwars.managers.NpcManager;
 import com.heneria.bedwars.managers.NpcAnimationManager;
 import com.heneria.bedwars.managers.ReconnectManager;
 import com.heneria.bedwars.managers.HologramManager;
+import com.heneria.bedwars.managers.TablistManager;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -54,6 +56,7 @@ public final class HeneriaBedwars extends JavaPlugin {
     private SpecialShopManager specialShopManager;
     private UpgradeManager upgradeManager;
     private ScoreboardManager scoreboardManager;
+    private TablistManager tablistManager;
     private EventManager eventManager;
     private DatabaseManager databaseManager;
     private StatsManager statsManager;
@@ -87,6 +90,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.upgradeManager = new UpgradeManager(this);
         this.eventManager = new EventManager(this);
         this.scoreboardManager = new ScoreboardManager(this);
+        this.tablistManager = new TablistManager(this);
         this.databaseManager = new DatabaseManager(this);
         this.statsManager = new StatsManager(this, this.databaseManager);
         this.playerProgressionManager = new PlayerProgressionManager();
@@ -133,6 +137,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new HungerListener(), this);
         getServer().getPluginManager().registerEvents(new VoidKillListener(), this);
         getServer().getPluginManager().registerEvents(new LobbyProtectionListener(), this);
+        getServer().getPluginManager().registerEvents(new LobbyVoidListener(), this);
         getServer().getPluginManager().registerEvents(new TeamSelectorListener(), this);
         getServer().getPluginManager().registerEvents(new LeaveItemListener(), this);
         getServer().getPluginManager().registerEvents(new HealerMilkListener(), this);
@@ -175,6 +180,10 @@ public final class HeneriaBedwars extends JavaPlugin {
 
     public ScoreboardManager getScoreboardManager() {
         return scoreboardManager;
+    }
+
+    public TablistManager getTablistManager() {
+        return tablistManager;
     }
 
     public EventManager getEventManager() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -265,6 +265,7 @@ public class Arena {
         }
         broadcast("game.player-join-arena", "player", player.getName(), "current_players", String.valueOf(players.size()), "max_players", String.valueOf(maxPlayers));
         HeneriaBedwars.getInstance().getScoreboardManager().setScoreboard(player);
+        HeneriaBedwars.getInstance().getTablistManager().updatePlayer(player);
         HeneriaBedwars.getInstance().getPlayerProgressionManager().initPlayer(player.getUniqueId());
         if (players.size() >= minPlayers && state == GameState.WAITING) {
             startCountdown();
@@ -303,6 +304,7 @@ public class Arena {
         player.setExp(0f);
         broadcast("game.player-leave-arena", "player", player.getName());
         HeneriaBedwars.getInstance().getScoreboardManager().setScoreboard(player);
+        HeneriaBedwars.getInstance().getTablistManager().updatePlayer(player);
         HeneriaBedwars.getInstance().getPlayerProgressionManager().removePlayer(player.getUniqueId());
         if (state == GameState.STARTING && players.size() < minPlayers) {
             cancelCountdown();

--- a/src/main/java/com/heneria/bedwars/listeners/LobbyVoidListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/LobbyVoidListener.java
@@ -1,0 +1,43 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+/**
+ * Teleports players back to the lobby if they fall into the void.
+ */
+public class LobbyVoidListener implements Listener {
+
+    private final HeneriaBedwars plugin = HeneriaBedwars.getInstance();
+    private final ArenaManager arenaManager = plugin.getArenaManager();
+    private final int voidTeleportHeight;
+
+    public LobbyVoidListener() {
+        this.voidTeleportHeight = plugin.getConfig().getInt("void-teleport-height", 0);
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        if (arenaManager.getArena(player) != null) {
+            return;
+        }
+        if (event.getTo() == null) {
+            return;
+        }
+        if (event.getTo().getY() >= event.getFrom().getY()) {
+            return;
+        }
+        if (event.getTo().getY() < voidTeleportHeight) {
+            Location lobby = plugin.getMainLobby();
+            if (lobby != null) {
+                player.teleport(lobby);
+            }
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/listeners/MainLobbyListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/MainLobbyListener.java
@@ -33,6 +33,7 @@ public class MainLobbyListener implements Listener {
             joining.setFoodLevel(20);
         }
         plugin.getScoreboardManager().setScoreboard(joining);
+        plugin.getTablistManager().updatePlayer(joining);
         for (String line : MessageManager.getList("on-join.welcome-message")) {
             joining.sendMessage(line.replace("{player}", joining.getName()));
         }

--- a/src/main/java/com/heneria/bedwars/managers/TablistManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/TablistManager.java
@@ -1,0 +1,80 @@
+package com.heneria.bedwars.managers;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.io.File;
+
+/**
+ * Handles lobby tablist header and footer updates.
+ */
+public class TablistManager {
+
+    private final HeneriaBedwars plugin;
+    private final ArenaManager arenaManager;
+    private String header;
+    private String footer;
+
+    public TablistManager(HeneriaBedwars plugin) {
+        this.plugin = plugin;
+        this.arenaManager = plugin.getArenaManager();
+        loadConfig();
+        startTask();
+    }
+
+    private void loadConfig() {
+        File file = new File(plugin.getDataFolder(), "tablist.yml");
+        if (!file.exists()) {
+            plugin.saveResource("tablist.yml", false);
+        }
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        this.header = config.getString("header", "");
+        this.footer = config.getString("footer", "");
+    }
+
+    private void startTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                updateAll();
+            }
+        }.runTaskTimer(plugin, 0L, 100L);
+    }
+
+    /**
+     * Updates the tablist for a specific player based on their location.
+     *
+     * @param player target player
+     */
+    public void updatePlayer(Player player) {
+        Arena arena = arenaManager.getArena(player);
+        if (arena == null) {
+            player.setPlayerListHeaderFooter(format(header, player), format(footer, player));
+        } else {
+            player.setPlayerListHeaderFooter(null, null);
+        }
+    }
+
+    private void updateAll() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            updatePlayer(player);
+        }
+    }
+
+    private String format(String text, Player player) {
+        if (text == null || text.isEmpty()) {
+            return "";
+        }
+        text = text.replace("\\n", "\n");
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            text = PlaceholderAPI.setPlaceholders(player, text);
+        }
+        return ChatColor.translateAlternateColorCodes('&', text);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 main-lobby: {}
 void-kill-height: 0
+void-teleport-height: 0
 trap-radius: 10
 chat-format: "[{team_color}{team_name}] {player_name}: {message}"
 

--- a/src/main/resources/tablist.yml
+++ b/src/main/resources/tablist.yml
@@ -1,0 +1,6 @@
+header: |
+  &b&lHENERIA BEDWARS
+  &7Vous êtes sur le serveur &eBedWars-1
+footer: |
+  &7Joueurs en ligne: &a%server_online%/%server_max_players%
+  &bheneria.com


### PR DESCRIPTION
## Summary
- introduce configurable TablistManager for lobby header/footer with PlaceholderAPI support
- teleport players falling into the lobby void back to spawn
- document new lobby features and configuration files

## Testing
- `mvn package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b47139b1348329a3971aac4104ad73