### PR TITLE
feat(polish): Implement 1.8 pvp, message overhaul, and shop color improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - HeneriaBedwars
 
+## [3.2.0] - 2024-??-??
+
+### Ajouté
+- Messages personnalisés de connexion (`server.join-message`) et de déconnexion (`server.leave-message`).
+
+### Modifié
+- Coûts des objets dans la boutique affichés avec la couleur du minerai correspondant.
+- Système de combat sans délai de recharge (PvP 1.8) via l'ajustement de la vitesse d'attaque.
+- Préfixe du plugin vide par défaut dans `messages.yml`.
+
 ## [3.1.2] - 2024-??-??
 
 ### Modifié

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
   - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`), la hauteur de téléportation anti-vide (`void-teleport-height`), personnalisez le format du chat via `chat-format` et contrôlez les animations du lobby via `animations.lobby-npc` (`enable`, `levitation-strength`, `presentation-speed`).
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
-  - `messages.yml` : Traduisez et personnalisez tous les messages du plugin.
+  - `messages.yml` : Traduisez et personnalisez tous les messages du plugin, y compris `server.join-message` et `server.leave-message` (préfixe vide par défaut).
 
 Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le plugin à n'importe quelle langue ou style.
 
@@ -32,6 +32,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🎡 **Lobby Principal Immersif** : Les joueurs apparaissent dans un lobby central et choisissent leur mode via des PNJ interactifs. Un message de bienvenue personnalisé et un scoreboard de statistiques les accueillent.
 - 🎮 **Hub de Jeu Intuitif** : En cliquant sur un PNJ de mode, un menu propose de lancer une partie, consulter ses statistiques ou se reconnecter.
 - 🕹️ **Cycle de Jeu Complet** : Rejoignez une arène, attendez dans le lobby avec un décompte, et lancez-vous dans la bataille.
+- ⚔️ **PvP 1.8** : Combat sans délai de recharge pour des affrontements plus dynamiques.
 - 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.
 - 💬 **Chat et Tablist isolés** : Les messages et la liste des joueurs sont limités à votre partie pour éviter le spam entre arènes.
 - 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, et détruisez celui de vos ennemis pour les éliminer définitivement.

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -22,6 +22,7 @@ import com.heneria.bedwars.listeners.TemperedGlassListener;
 import com.heneria.bedwars.listeners.LeaveItemListener;
 import com.heneria.bedwars.listeners.MainLobbyListener;
 import com.heneria.bedwars.listeners.ReconnectListener;
+import com.heneria.bedwars.listeners.JoinQuitMessageListener;
 import com.heneria.bedwars.listeners.LobbyVoidListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
@@ -148,6 +149,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new TemperedGlassListener(), this);
         getServer().getPluginManager().registerEvents(new MainLobbyListener(), this);
         getServer().getPluginManager().registerEvents(new ReconnectListener(), this);
+        getServer().getPluginManager().registerEvents(new JoinQuitMessageListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -18,6 +18,8 @@ import org.bukkit.Material;
 import org.bukkit.GameMode;
 import com.heneria.bedwars.listeners.TeamSelectorListener;
 import com.heneria.bedwars.listeners.LeaveItemListener;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Bed;
@@ -251,6 +253,10 @@ public class Arena {
     public void addPlayer(Player player) {
         addPlayer(player.getUniqueId());
         savedStates.put(player.getUniqueId(), new PlayerData(player));
+        AttributeInstance speed = player.getAttribute(Attribute.GENERIC_ATTACK_SPEED);
+        if (speed != null) {
+            speed.setBaseValue(1024.0D);
+        }
         player.getInventory().clear();
         player.teleport(lobbyLocation);
         player.setLevel(0);

--- a/src/main/java/com/heneria/bedwars/arena/PlayerData.java
+++ b/src/main/java/com/heneria/bedwars/arena/PlayerData.java
@@ -2,6 +2,8 @@ package com.heneria.bedwars.arena;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -16,6 +18,7 @@ public class PlayerData {
     private final float exp;
     private final int level;
     private final GameMode gameMode;
+    private final double attackSpeed;
 
     /**
      * Captures the current state of the given player.
@@ -29,6 +32,8 @@ public class PlayerData {
         this.exp = player.getExp();
         this.level = player.getLevel();
         this.gameMode = player.getGameMode();
+        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_ATTACK_SPEED);
+        this.attackSpeed = attr != null ? attr.getBaseValue() : 4.0D;
     }
 
     /**
@@ -43,6 +48,10 @@ public class PlayerData {
         player.setExp(exp);
         player.setLevel(level);
         player.setGameMode(gameMode);
+        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_ATTACK_SPEED);
+        if (attr != null) {
+            attr.setBaseValue(attackSpeed);
+        }
     }
 }
 

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopItemsMenu.java
@@ -87,7 +87,7 @@ public class ShopItemsMenu extends Menu {
             ItemBuilder builder = new ItemBuilder(display.material())
                     .setName(display.name())
                     .addLore("&7Quantité: &f" + display.amount())
-                    .addLore("&7Coût: &f" + display.costAmount() + " " + display.costResource().getDisplayName());
+                    .addLore("&7Coût: " + display.costResource().getColor() + display.costAmount() + " " + display.costResource().getDisplayName());
             ItemStack stack = builder.build();
             stack.setAmount(display.amount());
             inventory.setItem(slot, stack);

--- a/src/main/java/com/heneria/bedwars/gui/special/SpecialShopMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/special/SpecialShopMenu.java
@@ -48,7 +48,7 @@ public class SpecialShopMenu extends Menu {
             for (String line : item.lore()) {
                 builder.addLore(line);
             }
-            builder.addLore("&7Coût: &f" + item.costAmount() + " " + item.costResource().getDisplayName());
+            builder.addLore("&7Coût: " + item.costResource().getColor() + item.costAmount() + " " + item.costResource().getDisplayName());
             if (item.purchaseLimit() > 0) {
                 builder.addLore("&7Limite: &f" + item.purchaseLimit());
             }

--- a/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
@@ -64,7 +64,7 @@ public class TeamUpgradesMenu extends Menu {
             ItemBuilder builder = new ItemBuilder(upgrade.item()).setName(upgrade.name());
             if (tier != null) {
                 builder.addLore(tier.description())
-                        .addLore("&7Coût: &b" + tier.cost() + " Diamants");
+                        .addLore("&7Coût: " + ResourceType.DIAMOND.getColor() + tier.cost() + " Diamants");
             } else {
                 builder.addLore("&7Amélioration maximale atteinte");
             }
@@ -76,7 +76,7 @@ public class TeamUpgradesMenu extends Menu {
         for (Trap trap : category.traps().values()) {
             ItemBuilder builder = new ItemBuilder(trap.item()).setName(trap.name()).setLore(trap.description());
             if (!team.isTrapActive(trap.id())) {
-                builder.addLore("&7Coût: &b" + trap.cost() + " Diamants");
+                builder.addLore("&7Coût: " + ResourceType.DIAMOND.getColor() + trap.cost() + " Diamants");
             } else {
                 builder.addLore("&7Piège acheté");
             }

--- a/src/main/java/com/heneria/bedwars/listeners/JoinQuitMessageListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/JoinQuitMessageListener.java
@@ -1,0 +1,33 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.utils.MessageManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Handles broadcasting of custom join and quit messages.
+ */
+public class JoinQuitMessageListener implements Listener {
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        event.setJoinMessage(null);
+        String name = event.getPlayer().getName();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            MessageManager.sendRawMessage(player, "server.join-message", "player", name);
+        }
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        event.setQuitMessage(null);
+        String name = event.getPlayer().getName();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            MessageManager.sendRawMessage(player, "server.leave-message", "player", name);
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/ResourceType.java
+++ b/src/main/java/com/heneria/bedwars/managers/ResourceType.java
@@ -1,26 +1,29 @@
 package com.heneria.bedwars.managers;
 
 import org.bukkit.Material;
+import org.bukkit.ChatColor;
 
 /**
  * Types of resources used in the item shop.
  */
 public enum ResourceType {
     /** Iron ingot resource. */
-    IRON(Material.IRON_INGOT, "Fer"),
+    IRON(Material.IRON_INGOT, "Fer", ChatColor.GRAY),
     /** Gold ingot resource. */
-    GOLD(Material.GOLD_INGOT, "Or"),
+    GOLD(Material.GOLD_INGOT, "Or", ChatColor.GOLD),
     /** Diamond resource. */
-    DIAMOND(Material.DIAMOND, "Diamant"),
+    DIAMOND(Material.DIAMOND, "Diamant", ChatColor.AQUA),
     /** Emerald resource. */
-    EMERALD(Material.EMERALD, "Émeraude");
+    EMERALD(Material.EMERALD, "Émeraude", ChatColor.GREEN);
 
     private final Material material;
     private final String displayName;
+    private final ChatColor color;
 
-    ResourceType(Material material, String displayName) {
+    ResourceType(Material material, String displayName, ChatColor color) {
         this.material = material;
         this.displayName = displayName;
+        this.color = color;
     }
 
     /**
@@ -39,5 +42,14 @@ public enum ResourceType {
      */
     public String getDisplayName() {
         return displayName;
+    }
+
+    /**
+     * Gets the color associated with this resource for display purposes.
+     *
+     * @return chat color linked to the resource
+     */
+    public ChatColor getColor() {
+        return color;
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,4 +1,8 @@
-prefix: "&8[&bHeneriaBedwars&8] &r"
+prefix: ""
+
+server:
+  join-message: "&a+ &7{player}"
+  leave-message: "&c- &7{player}"
 
 errors:
   no-permission: "&cVous n'avez pas la permission d'exécuter cette commande."


### PR DESCRIPTION
## Summary
- color shop item costs to match required resource
- remove attack cooldown with 1.8 style PvP and restore speed on arena exit
- drop plugin prefix, add configurable join/quit messages

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b495d975e48329b7f563db1ede7385