### PR TITLE
feat(gameplay): Implement 1.8 pvp particles, in-game /spawn, and build boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog - HeneriaBedwars
 
+## [4.3.0] - 2024-??-??
+
+### Ajouté
+- Simulation des particules de coup critique pour chaque attaque en PvP 1.8.
+- Commande `/spawn` utilisable en cours de partie pour quitter et déclencher la vérification de victoire.
+- Limites de construction configurables par arène (`boundaries`).
+
 ## [4.2.0] - 2024-??-??
 
 ### Ajouté
@@ -246,7 +253,7 @@
 
 ### Ajouté
 - Réinitialisation complète des arènes avec restauration des lits et nettoyage des items.
-- Limites de construction configurables par arène via `boundaries.max-y`.
+- Limites de construction configurables par arène via `boundaries.max-height`.
 - Mort instantanée dans le vide grâce à `void-kill-height`.
 - Ajout d'un scoreboard distinct et configurable pour le lobby d'attente.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🎡 **Lobby Principal Immersif** : Les joueurs apparaissent dans un lobby central et choisissent leur mode via des PNJ interactifs. Un message de bienvenue personnalisé et un scoreboard de statistiques les accueillent.
 - 🎮 **Hub de Jeu Intuitif** : En cliquant sur un PNJ de mode, un menu propose de lancer une partie, consulter ses statistiques ou se reconnecter.
 - 🕹️ **Cycle de Jeu Complet** : Rejoignez une arène, attendez dans le lobby avec un décompte, et lancez-vous dans la bataille.
-- ⚔️ **PvP 1.8** : Combat sans délai de recharge pour des affrontements plus dynamiques.
+- ⚔️ **PvP 1.8** : Combat sans délai de recharge avec particules de coup critique à chaque attaque pour un ressenti classique.
 - 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.
 - 💬 **Chat et Tablist isolés** : Les messages et la liste des joueurs sont limités à votre partie pour éviter le spam entre arènes.
 - 🎨 **Couleurs d'équipe dynamiques** : Les pseudos des joueurs prennent la couleur de leur équipe dans la tablist et au-dessus de leur tête.
@@ -43,7 +43,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🛒 **Boutiques Fonctionnelles** : Interagissez avec les PNJ pour acheter des objets dans une boutique colorée (vitres teintées par catégorie, section d'achats rapides enrichie) ou des améliorations permanentes pour votre équipe.
 - 🏥 **Soin de Base** : Achetez une aura de régénération autour de votre lit pour soigner vos défenseurs.
 - 🔔 **Alarme Anti-Intrusion** : Un son puissant alerte toute l'équipe lorsqu'un piège est déclenché.
-- 🧱 **Construction de Blocs** : Achetez, placez et cassez des blocs pour bâtir ponts et défenses. La catégorie « Blocs » propose désormais du Grès, de l'Obsidienne, des Échelles et de la Toile d'Araignée.
+- 🧱 **Construction de Blocs** : Achetez, placez et cassez des blocs pour bâtir ponts et défenses. La catégorie « Blocs » propose désormais du Grès, de l'Obsidienne, des Échelles et de la Toile d'Araignée. Des limites configurables empêchent de construire hors de la zone de jeu.
  - 🛡️ **Kit de départ lié** : Vous réapparaissez avec une armure en cuir teintée aux couleurs de votre équipe ainsi qu'une épée, une pioche et une hache en bois impossibles à jeter.
 - 🛡️ **Armures Directes** : Achetez directement l'armure de votre choix (mailles, fer ou diamant) et conservez-la après la mort, tandis que les outils et épées doivent être rachetés.
 - 🗡️ **Catégorie Mêlée** : Progression d'armes de corps à corps, du Bâton de Répulsion à l'Épée en Diamant.
@@ -112,7 +112,7 @@ Pour créer un PNJ de sélection d'arène, ouvrez le menu `/bw admin lobby`, cli
   - Affiche vos statistiques ou celles d'un autre joueur.
   - **Permission :** `heneriabw.admin.stats` pour consulter celles d'un autre joueur.
 - `/spawn`
-  - Téléporte le joueur au lobby principal BedWars.
+  - Téléporte le joueur au lobby principal BedWars. Utilisable en jeu pour quitter la partie ; déclenche une vérification de victoire.
 - `/hub`
   - Envoie le joueur vers le serveur lobby principal si BungeeCord est activé, sinon fonctionne comme `/spawn`.
 
@@ -355,7 +355,7 @@ Chaque arène peut définir des limites pour empêcher les constructions abusive
 
 ```yaml
 boundaries:
-  max-y: 150
+  max-height: 150
   max-distance-from-center: 100
 ```
 

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -24,6 +24,7 @@ import com.heneria.bedwars.listeners.MainLobbyListener;
 import com.heneria.bedwars.listeners.ReconnectListener;
 import com.heneria.bedwars.listeners.JoinQuitMessageListener;
 import com.heneria.bedwars.listeners.LobbyVoidListener;
+import com.heneria.bedwars.listeners.PvpListener;
 import com.heneria.bedwars.managers.ArenaManager;
 import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.managers.GeneratorManager;
@@ -150,6 +151,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new MainLobbyListener(), this);
         getServer().getPluginManager().registerEvents(new ReconnectListener(), this);
         getServer().getPluginManager().registerEvents(new JoinQuitMessageListener(), this);
+        getServer().getPluginManager().registerEvents(new PvpListener(), this);
     }
 
     public static HeneriaBedwars getInstance() {

--- a/src/main/java/com/heneria/bedwars/commands/CommandManager.java
+++ b/src/main/java/com/heneria/bedwars/commands/CommandManager.java
@@ -107,11 +107,11 @@ public class CommandManager implements CommandExecutor, TabCompleter {
         ArenaManager manager = plugin.getArenaManager();
         Arena arena = manager.getArenaByPlayer(player.getUniqueId());
         if (arena != null) {
-            if (arena.getState() == GameState.PLAYING) {
-                MessageManager.sendMessage(player, "errors.command-disabled-in-game");
-                return;
-            }
+            boolean wasPlaying = arena.getState() == GameState.PLAYING;
             arena.removePlayer(player);
+            if (wasPlaying) {
+                arena.checkForWinner();
+            }
             return;
         }
         Location lobby = plugin.getMainLobby();

--- a/src/main/java/com/heneria/bedwars/listeners/PvpListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/PvpListener.java
@@ -1,0 +1,34 @@
+package com.heneria.bedwars.listeners;
+
+import com.heneria.bedwars.HeneriaBedwars;
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.arena.enums.GameState;
+import com.heneria.bedwars.managers.ArenaManager;
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+/**
+ * Simulates 1.8 critical hit particles for every successful player hit.
+ */
+public class PvpListener implements Listener {
+
+    private final ArenaManager arenaManager = HeneriaBedwars.getInstance().getArenaManager();
+
+    @EventHandler(ignoreCancelled = true)
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player attacker) || !(event.getEntity() instanceof Player victim)) {
+            return;
+        }
+        Arena arena = arenaManager.getArena(attacker);
+        if (arena == null || arena.getState() != GameState.PLAYING) {
+            return;
+        }
+        if (!arena.getPlayers().contains(victim.getUniqueId())) {
+            return;
+        }
+        victim.getWorld().spawnParticle(Particle.CRIT, victim.getLocation().add(0, 1, 0), 10, 0.3, 0.4, 0.3, 0.0);
+    }
+}

--- a/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ArenaManager.java
@@ -66,7 +66,9 @@ public class ArenaManager {
             if (config.contains("maxPlayers")) {
                 arena.setMaxPlayers(config.getInt("maxPlayers"));
             }
-            if (config.contains("boundaries.max-y")) {
+            if (config.contains("boundaries.max-height")) {
+                arena.setMaxBuildY(config.getInt("boundaries.max-height"));
+            } else if (config.contains("boundaries.max-y")) {
                 arena.setMaxBuildY(config.getInt("boundaries.max-y"));
             }
             if (config.contains("boundaries.max-distance-from-center")) {
@@ -213,7 +215,7 @@ public class ArenaManager {
         config.set("enabled", arena.isEnabled());
         config.set("minPlayers", arena.getMinPlayers());
         config.set("maxPlayers", arena.getMaxPlayers());
-        config.set("boundaries.max-y", arena.getMaxBuildY());
+        config.set("boundaries.max-height", arena.getMaxBuildY());
         config.set("boundaries.max-distance-from-center", arena.getMaxBuildDistance());
         if (arena.getWorldName() != null) {
             config.set("world", arena.getWorldName());


### PR DESCRIPTION
## Summary
- simulate 1.8 PvP with critical hit particles
- allow `/spawn` during matches and trigger winner checks
- read/write arena build boundaries in configs and document usage

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f41775dc832994a4f984a3899814