### PR TITLE
fix(polish): Final polish pass for spectator camera, NPCs, messages and shop

### DIFF
--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -110,7 +110,7 @@ public class AdminCommand implements SubCommand {
                 npc.setArms(true);
                 ItemStack head = new ItemStack(Material.PLAYER_HEAD);
                 SkullMeta meta = (SkullMeta) head.getItemMeta();
-                meta.setOwningPlayer(Bukkit.getOfflinePlayer("MHF_Villager"));
+                meta.setOwningPlayer(player);
                 head.setItemMeta(meta);
                 npc.getEquipment().setHelmet(head);
                 String pdcValue = (type.equals("upgrade") ? "UPGRADE_SHOP" : "ITEM_SHOP") + ":" + team.toUpperCase();

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -10,6 +10,7 @@ import com.heneria.bedwars.managers.StatsManager;
 import com.heneria.bedwars.stats.PlayerStats;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.GameMode;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.entity.Player;
@@ -153,7 +154,10 @@ public class GameListener implements Listener {
         if (playerTeam.hasBed()) {
             GameUtils.removeUpgradedToolsAndSwords(player);
             player.setGameMode(GameMode.SPECTATOR);
-            player.teleport(playerTeam.getSpawnLocation());
+            Location lobbyView = arena.getLobbyLocation() != null
+                    ? arena.getLobbyLocation().clone().add(0, 20, 0)
+                    : playerTeam.getSpawnLocation();
+            player.teleport(lobbyView);
             new BukkitRunnable() {
                 int countdown = 5;
                 public void run() {
@@ -173,7 +177,10 @@ public class GameListener implements Listener {
             arena.eliminatePlayer(player);
             player.setGameMode(GameMode.SPECTATOR);
             player.getInventory().clear();
-            player.teleport(playerTeam.getSpawnLocation());
+            Location lobbyView = arena.getLobbyLocation() != null
+                    ? arena.getLobbyLocation().clone().add(0, 20, 0)
+                    : playerTeam.getSpawnLocation();
+            player.teleport(lobbyView);
             arena.broadcastTitle("game.elimination-title", "game.elimination-subtitle", 10, 70, 20, "player", player.getName());
             plugin.getPlayerProgressionManager().removePlayer(player.getUniqueId());
             arena.checkForWinner();

--- a/src/main/java/com/heneria/bedwars/managers/NpcAnimationManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcAnimationManager.java
@@ -81,7 +81,7 @@ public class NpcAnimationManager {
         for (Entity entity : info.location.getWorld().getNearbyEntities(info.location, 1, 1, 1)) {
             if (entity instanceof ArmorStand stand) {
                 String tag = stand.getPersistentDataContainer().get(npcKey, PersistentDataType.STRING);
-                if (tag != null && tag.equals("JOIN_NPC:" + info.mode)) {
+                if (tag != null && tag.equals("JOIN_NPC:" + info.id)) {
                     return stand;
                 }
             }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,4 +1,4 @@
-prefix: "&b[HBW]&r "
+prefix: ""
 
 server:
   join-message: "&a+ &7{player}"

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -139,7 +139,7 @@ quick-buy-items:
     cost:
       resource: GOLD
       amount: 4
-    slot: 26
+    slot: 29
   iron-sword:
     material: IRON_SWORD
     name: "&f&lÉpée en Fer"
@@ -149,7 +149,79 @@ quick-buy-items:
     cost:
       resource: GOLD
       amount: 7
+    slot: 28
+  filler-18:
+    material: GRAY_STAINED_GLASS_PANE
+    name: " "
+    amount: 1
+    cost:
+      resource: IRON
+      amount: 0
+    slot: 18
+  filler-26:
+    material: GRAY_STAINED_GLASS_PANE
+    name: " "
+    amount: 1
+    cost:
+      resource: IRON
+      amount: 0
+    slot: 26
+  filler-27:
+    material: GRAY_STAINED_GLASS_PANE
+    name: " "
+    amount: 1
+    cost:
+      resource: IRON
+      amount: 0
     slot: 27
+  filler-30:
+    material: GRAY_STAINED_GLASS_PANE
+    name: " "
+    amount: 1
+    cost:
+      resource: IRON
+      amount: 0
+    slot: 30
+  filler-31:
+    material: GRAY_STAINED_GLASS_PANE
+    name: " "
+    amount: 1
+    cost:
+      resource: IRON
+      amount: 0
+    slot: 31
+  filler-32:
+    material: GRAY_STAINED_GLASS_PANE
+    name: " "
+    amount: 1
+    cost:
+      resource: IRON
+      amount: 0
+    slot: 32
+  filler-33:
+    material: GRAY_STAINED_GLASS_PANE
+    name: " "
+    amount: 1
+    cost:
+      resource: IRON
+      amount: 0
+    slot: 33
+  filler-34:
+    material: GRAY_STAINED_GLASS_PANE
+    name: " "
+    amount: 1
+    cost:
+      resource: IRON
+      amount: 0
+    slot: 34
+  filler-35:
+    material: GRAY_STAINED_GLASS_PANE
+    name: " "
+    amount: 1
+    cost:
+      resource: IRON
+      amount: 0
+    slot: 35
 
 shop-categories:
   'blocks_category':


### PR DESCRIPTION
## Summary
- Correct spectator camera placement above arena lobbies after death
- Equip shop NPCs with full player skin and armor
- Remove global message prefix and refine quick buy shop layout
- De-duplicate lobby NPCs on reload via persistent IDs

## Testing
- `mvn -q -e test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b712f9cdf88329b188e463e43063d0