### PR TITLE
fix(build): Correct call to isCancelled in GameListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - HeneriaBedwars
 
+## [4.3.1] - 2024-??-??
+
+### Corrigé
+- Correction d'une erreur de compilation dans le GameListener due à un appel de méthode incorrect.
+
 ## [4.3.0] - 2024-??-??
 
 ### Ajouté

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -64,6 +64,9 @@ public class GameListener implements Listener {
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
         Block block = event.getBlock();
+        if (event.isCancelled()) {
+            return;
+        }
         if (plugin.getSetupManager().isBypassing(player.getUniqueId())) {
             return;
         }


### PR DESCRIPTION
## Summary
- prevent block break handler from calling missing `isCancelled` on player
- document compilation fix in changelog

## Testing
- `mvn -B package --file pom.xml` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68b71eb276fc8329bf98593961085084