### PR TITLE
feat: add mode-specific lobby holograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Simulation des particules de coup critique pour chaque attaque en PvP 1.8.
 - Commande `/spawn` utilisable en cours de partie pour quitter et déclencher la vérification de victoire.
 - Limites de construction configurables par arène (`boundaries`).
+- Hologrammes de mode au-dessus des PNJ du lobby indiquant les joueurs connectés par mode.
 
 ## [4.2.0] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 
 - 🎡 **Lobby Principal Immersif** : Les joueurs apparaissent dans un lobby central et choisissent leur mode via des PNJ interactifs. Un message de bienvenue personnalisé et un scoreboard de statistiques les accueillent.
 - 🎮 **Hub de Jeu Intuitif** : En cliquant sur un PNJ de mode, un menu propose de lancer une partie, consulter ses statistiques ou se reconnecter.
+- 🪧 **Stats par Mode** : Chaque PNJ affiche un hologramme indiquant en temps réel le nombre de joueurs pour son mode.
 - 🕹️ **Cycle de Jeu Complet** : Rejoignez une arène, attendez dans le lobby avec un décompte, et lancez-vous dans la bataille.
 - ⚔️ **PvP 1.8** : Combat sans délai de recharge avec particules de coup critique à chaque attaque pour un ressenti classique.
 - 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -105,6 +105,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.playerProgressionManager = new PlayerProgressionManager();
         this.bountyManager = new BountyManager(3, 5);
         this.npcManager = new NpcManager(this);
+        this.npcManager.startHologramTask();
         this.npcAnimationManager = new NpcAnimationManager(this, this.npcManager);
         this.npcAnimationManager.start();
         this.reconnectManager = new ReconnectManager(this);
@@ -132,6 +133,9 @@ public final class HeneriaBedwars extends JavaPlugin {
         }
         if (npcAnimationManager != null) {
             npcAnimationManager.stop();
+        }
+        if (npcManager != null) {
+            npcManager.stopHologramTask();
         }
         getLogger().info("HeneriaBedwars a été désactivé.");
     }


### PR DESCRIPTION
## Summary
- display per-mode player counts above lobby NPCs via internal hologram system
- refresh NPC holograms periodically and remove them on NPC deletion
- document new lobby NPC hologram feature

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b73e35e2fc832999e3720a9d017fca