### PR TITLE
Fix trap potion constant and clean Maven warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Corrigé
 - Téléportation des spectateurs au-dessus du lobby après la mort pour éviter qu'ils restent sous la carte.
+- Correction d'une erreur de compilation dans `TrapListener` et suppression de plusieurs avertissements Maven.
 
 ## [4.2.0] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -466,3 +466,8 @@ animations:
 2.  Naviguez dans le dossier : `cd HeneriaBW`
 3.  Compilez avec Maven : `mvn clean package`
 4.  Le JAR final se trouvera dans le dossier `target/`.
+
+### Notes de développement
+
+- Correction d'une erreur de compilation en renommant `PotionEffectType.JUMP` en `PotionEffectType.JUMP_BOOST`.
+- Suppression d'avertissements Maven liés à une API dépréciée et à des opérations non vérifiées.

--- a/src/main/java/com/heneria/bedwars/listeners/TrapListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/TrapListener.java
@@ -67,7 +67,7 @@ public class TrapListener implements Listener {
                             Player p = Bukkit.getPlayer(uuid);
                             if (p != null) {
                                 p.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 15 * 20, 1, true, true, true));
-                                p.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 15 * 20, 1, true, true, true));
+                                p.addPotionEffect(new PotionEffect(PotionEffectType.JUMP_BOOST, 15 * 20, 1, true, true, true));
                             }
                         }
                     } else if (entry.getKey().equals("reveal-trap")) {

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -100,11 +100,11 @@ public class NpcManager {
             String bootsStr = (String) map.get("boots");
             Material boots = bootsStr != null ? Material.matchMaterial(bootsStr) : null;
             if (chestplate == null && leggings == null && boots == null) {
-                List<String> armorList = (List<String>) map.get("armor");
-                if (armorList != null) {
-                    if (armorList.size() > 0) chestplate = Material.matchMaterial(armorList.get(0));
-                    if (armorList.size() > 1) leggings = Material.matchMaterial(armorList.get(1));
-                    if (armorList.size() > 2) boots = Material.matchMaterial(armorList.get(2));
+                Object armorObj = map.get("armor");
+                if (armorObj instanceof List<?> armorList) {
+                    if (armorList.size() > 0) chestplate = Material.matchMaterial(String.valueOf(armorList.get(0)));
+                    if (armorList.size() > 1) leggings = Material.matchMaterial(String.valueOf(armorList.get(1)));
+                    if (armorList.size() > 2) boots = Material.matchMaterial(String.valueOf(armorList.get(2)));
                 }
             }
             String id = (String) map.get("id");

--- a/src/main/java/com/heneria/bedwars/managers/ShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ShopManager.java
@@ -5,6 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -143,7 +144,11 @@ public class ShopManager {
 
         Map<Enchantment, Integer> enchantments = new HashMap<>();
         for (Map<?, ?> map : config.getMapList(path + ".enchantments")) {
-            Enchantment ench = Enchantment.getByName(String.valueOf(map.get("type")));
+            Object typeObj = map.get("type");
+            NamespacedKey key = typeObj != null
+                    ? NamespacedKey.minecraft(String.valueOf(typeObj).toLowerCase(Locale.ROOT))
+                    : null;
+            Enchantment ench = key != null ? Enchantment.getByKey(key) : null;
             if (ench != null) {
                 int lvl = map.get("level") instanceof Number n ? n.intValue() : 1;
                 enchantments.put(ench, lvl);

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -749,7 +749,7 @@ shop-categories:
           amount: 1
         slot: 11
         potion-effects:
-          - type: JUMP
+          - type: JUMP_BOOST
             duration: 45
             amplifier: 2
       'invisibility_potion':


### PR DESCRIPTION
## Summary
- replace deprecated `PotionEffectType.JUMP` with `JUMP_BOOST`
- avoid deprecated and unchecked APIs in managers
- document compilation fix in README and changelog

## Testing
- `mvn -e -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b746a20b8483298fa6fe413a33aa2e