### PR TITLE
fix: resolve variable redefinition in ShopManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Corrigé
 - Téléportation des spectateurs au-dessus du lobby après la mort pour éviter qu'ils restent sous la carte.
 - Correction d'une erreur de compilation dans `TrapListener` et suppression de plusieurs avertissements Maven.
+- Correction d'une erreur de compilation due à une variable `key` redéfinie dans `ShopManager#parseItem`.
 
 ## [4.2.0] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -471,3 +471,4 @@ animations:
 
 - Correction d'une erreur de compilation en renommant `PotionEffectType.JUMP` en `PotionEffectType.JUMP_BOOST`.
 - Suppression d'avertissements Maven liés à une API dépréciée et à des opérations non vérifiées.
+- Résolution d'une erreur de compilation due à la redéfinition de la variable `key` dans `ShopManager#parseItem`.

--- a/src/main/java/com/heneria/bedwars/managers/ShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ShopManager.java
@@ -145,10 +145,10 @@ public class ShopManager {
         Map<Enchantment, Integer> enchantments = new HashMap<>();
         for (Map<?, ?> map : config.getMapList(path + ".enchantments")) {
             Object typeObj = map.get("type");
-            NamespacedKey key = typeObj != null
+            NamespacedKey enchKey = typeObj != null
                     ? NamespacedKey.minecraft(String.valueOf(typeObj).toLowerCase(Locale.ROOT))
                     : null;
-            Enchantment ench = key != null ? Enchantment.getByKey(key) : null;
+            Enchantment ench = enchKey != null ? Enchantment.getByKey(enchKey) : null;
             if (ench != null) {
                 int lvl = map.get("level") instanceof Number n ? n.intValue() : 1;
                 enchantments.put(ench, lvl);


### PR DESCRIPTION
## Summary
- rename local variable in `ShopManager#parseItem` to avoid clashing with method parameter
- document compilation fix in README and CHANGELOG

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b747a184188329a839df3c7f9f833d