### PR TITLE
feat: enhance menus and messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - HeneriaBedwars
 
+## [4.3.1] - 2024-??-??
+
+### Modifié
+- Menu "Upgrades & Traps" centré avec descriptions recolorées.
+- Messages d'achat et de commandes admin dotés de préfixes colorés.
+
+### Corrigé
+- Suppression de l'hologramme d'Émeraude sur les générateurs de base.
+
 ## [4.3.0] - 2024-??-??
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
 - ⚔️ **Gestion 100% en Jeu** : Créez, gérez et configurez vos arènes sans jamais avoir à éditer de fichiers manuellement grâce à une interface graphique complète (`/bw admin`).
 - 🧙‍♂️ **Assistant de Création Intuitif** : Un système de création d'arène simple via le chat vous guide pour définir les paramètres de base.
 - 🧍 **Assistant PNJ Guidé** : Créez des PNJ du lobby via une conversation étape par étape dans le chat.
+- 🛑 **Messages Administrateur Lisibles** : Les retours de commandes sont préfixés et colorés pour se distinguer du chat.
 - 📍 **Configuration Précise** : Utilisez un outil de positionnement en jeu pour définir avec précision l'emplacement du lobby, des lits, des points de spawn, des générateurs et des PNJ pour chaque équipe.
 - ⚙️ **Haute Personnalisation** : Prenez le contrôle total du gameplay en modifiant les fichiers de configuration dédiés :
   - `generators.yml` : Réglez la vitesse et la quantité de chaque générateur de ressources.
@@ -45,11 +46,12 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🛒 **Boutiques Fonctionnelles** : Interagissez avec les PNJ pour acheter des objets dans une boutique colorée (vitres teintées par catégorie, section d'achats rapides enrichie) ou des améliorations permanentes pour votre équipe.
 - 🏥 **Soin de Base** : Achetez une aura de régénération autour de votre lit pour soigner vos défenseurs.
 - 🔔 **Alarme Anti-Intrusion** : Un son puissant alerte toute l'équipe lorsqu'un piège est déclenché.
-- 🪤 **Menu "Upgrades & Traps" remanié** : Les améliorations et pièges sont affichés sur deux rangées, les pièges achetés apparaissant dans une barre dédiée.
+- 🪤 **Menu "Upgrades & Traps" remanié** : Les améliorations et pièges sont affichés sur deux rangées centrées avec descriptions colorées, les pièges achetés apparaissant dans une barre dédiée.
   - Blindness Trap : applique Cécité aux intrus.
   - Counter-Offensive Trap : donne Speed II et Jump Boost II aux alliés pendant 15 s.
   - Reveal Trap : révèle et illumine les ennemis invisibles.
   - Miner Fatigue Trap : ralentit le minage des ennemis.
+- 💬 **Messages d'achat stylisés** : chaque achat affiche un message coloré indiquant l'objet et son prix.
 - 🧱 **Construction de Blocs** : Achetez, placez et cassez des blocs pour bâtir ponts et défenses. La catégorie « Blocs » propose désormais du Grès, de l'Obsidienne, des Échelles et de la Toile d'Araignée. Des limites configurables empêchent de construire hors de la zone de jeu.
  - 🛡️ **Kit de départ lié** : Vous réapparaissez avec une armure en cuir teintée aux couleurs de votre équipe ainsi qu'une épée, une pioche et une hache en bois impossibles à jeter.
 - 🛡️ **Armures Directes** : Achetez directement l'armure de votre choix (mailles, fer ou diamant) et conservez-la après la mort, tandis que les outils et épées doivent être rachetés.

--- a/src/main/java/com/heneria/bedwars/arena/elements/Generator.java
+++ b/src/main/java/com/heneria/bedwars/arena/elements/Generator.java
@@ -12,6 +12,7 @@ public class Generator {
     private GeneratorType type;
     private int level;
     private int tier = 1;
+    private boolean hologramEnabled = true;
 
     /**
      * Creates a new generator.
@@ -96,5 +97,23 @@ public class Generator {
      */
     public void setTier(int tier) {
         this.tier = tier;
+    }
+
+    /**
+     * Checks whether holograms are enabled for this generator.
+     *
+     * @return true if holograms should be displayed
+     */
+    public boolean isHologramEnabled() {
+        return hologramEnabled;
+    }
+
+    /**
+     * Sets whether holograms should be displayed for this generator.
+     *
+     * @param hologramEnabled flag indicating hologram usage
+     */
+    public void setHologramEnabled(boolean hologramEnabled) {
+        this.hologramEnabled = hologramEnabled;
     }
 }

--- a/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
+++ b/src/main/java/com/heneria/bedwars/commands/subcommands/AdminCommand.java
@@ -8,7 +8,6 @@ import com.heneria.bedwars.managers.SetupManager;
 import com.heneria.bedwars.setup.NpcCreationProcess;
 import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EntityType;
@@ -90,7 +89,7 @@ public class AdminCommand implements SubCommand {
                     return;
                 }
                 plugin.setMainLobby(player.getLocation());
-                player.sendMessage(ChatColor.GREEN + "Lobby principal défini.");
+                MessageManager.sendMessage(player, "admin.main-lobby-set");
                 return;
             } else if (sub.equals("setshopnpc") && args.length >= 3) {
                 if (!player.hasPermission("heneriabw.admin.setshopnpc")) {
@@ -155,7 +154,7 @@ public class AdminCommand implements SubCommand {
                     npc.getEquipment().setBoots(item);
                 }
                 npc.setCustomNameVisible(true);
-                player.sendMessage(ChatColor.GREEN + "PNJ de boutique " + type + " pour l'équipe " + team + " placé.");
+                MessageManager.sendMessage(player, "admin.shop-npc-placed", "type", type, "team", team);
                 return;
             } else if (sub.equals("confirmnpc")) {
                 if (!player.hasPermission("heneriabw.admin.lobby")) {
@@ -165,12 +164,12 @@ public class AdminCommand implements SubCommand {
                 SetupManager setupManager = plugin.getSetupManager();
                 NpcCreationProcess process = setupManager.getNpcCreation(player.getUniqueId());
                 if (process == null || process.getStep() != NpcCreationProcess.Step.WAITING_CONFIRM) {
-                    player.sendMessage(ChatColor.RED + "Aucune création de PNJ en cours.");
+                    MessageManager.sendMessage(player, "admin.no-pending-npc");
                     return;
                 }
                 plugin.getNpcManager().addNpc(player.getLocation(), process.getMode(), process.getSkin(), process.getItem(), process.getName(), process.getChestplate(), process.getLeggings(), process.getBoots());
                 setupManager.clearNpcCreation(player);
-                player.sendMessage(ChatColor.GREEN + "PNJ créé.");
+                MessageManager.sendMessage(player, "admin.npc-created");
                 return;
             }
         }

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopMenu.java
@@ -161,7 +161,12 @@ public class ShopMenu extends Menu {
         ResourceType type = item.costResource();
         int price = item.costAmount();
         if (ResourceManager.hasResources(clicker, type, price)) {
+            String coloredName = ChatColor.translateAlternateColorCodes('&', item.name());
             ResourceManager.takeResources(clicker, type, price);
+            MessageManager.sendMessage(clicker, "shop.purchase-success",
+                    "item", coloredName,
+                    "price", String.valueOf(price),
+                    "resource", type.getColor() + type.getDisplayName());
             Material material = item.material();
             Arena arena = HeneriaBedwars.getInstance().getArenaManager().getArena(clicker);
             Team team = arena != null ? arena.getTeam(clicker) : null;

--- a/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
@@ -61,19 +61,19 @@ public class TeamUpgradesMenu extends Menu {
             inventory.setItem(i, filler);
         }
 
-        // Row 1
-        setUpgradeItem(0, "sharpness");
-        setUpgradeItem(1, "protection");
-        setUpgradeItem(2, "haste");
-        setTrapItem(3, "blindness-trap");
-        setTrapItem(4, "counter-offensive-trap");
-        setTrapItem(5, "reveal-trap");
+        // Top row - centered
+        setUpgradeItem(10, "sharpness");
+        setUpgradeItem(11, "protection");
+        setUpgradeItem(12, "haste");
+        setTrapItem(14, "blindness-trap");
+        setTrapItem(15, "counter-offensive-trap");
+        setTrapItem(16, "reveal-trap");
 
-        // Row 2
-        setUpgradeItem(9, "forge");
-        setUpgradeItem(10, "heal-pool");
-        setUpgradeItem(11, "speed");
-        setTrapItem(13, "miner-fatigue-trap");
+        // Second row - centered
+        setUpgradeItem(19, "forge");
+        setUpgradeItem(20, "heal-pool");
+        setUpgradeItem(21, "speed");
+        setTrapItem(23, "miner-fatigue-trap");
 
         // Trap slots (row 4)
         ItemStack placeholder = new ItemBuilder(Material.GRAY_WOOL).setName("&7Aucun piège").build();
@@ -98,9 +98,9 @@ public class TeamUpgradesMenu extends Menu {
         ItemBuilder builder = new ItemBuilder(upgrade.item()).setName(upgrade.name());
         if (tier != null) {
             builder.addLore(tier.description())
-                    .addLore("&7Coût: " + ResourceType.DIAMOND.getColor() + tier.cost() + " Diamants");
+                    .addLore("&7Prix: " + ResourceType.DIAMOND.getColor() + tier.cost() + " Diamant" + (tier.cost() > 1 ? "s" : ""));
         } else {
-            builder.addLore("&7Amélioration maximale atteinte");
+            builder.addLore("&aNiveau maximum atteint");
         }
         inventory.setItem(slot, builder.build());
         slotUpgrades.put(slot, upgrade);
@@ -111,9 +111,9 @@ public class TeamUpgradesMenu extends Menu {
         if (trap == null) return;
         ItemBuilder builder = new ItemBuilder(trap.item()).setName(trap.name()).setLore(trap.description());
         if (!team.isTrapActive(id)) {
-            builder.addLore("&7Coût: " + ResourceType.DIAMOND.getColor() + trap.cost() + " Diamants");
+            builder.addLore("&7Prix: " + ResourceType.DIAMOND.getColor() + trap.cost() + " Diamant" + (trap.cost() > 1 ? "s" : ""));
         } else {
-            builder.addLore("&7Piège acheté");
+            builder.addLore("&aPiège actif");
         }
         inventory.setItem(slot, builder.build());
         slotTraps.put(slot, trap);
@@ -143,6 +143,10 @@ public class TeamUpgradesMenu extends Menu {
                 return;
             }
             ResourceManager.takeResources(player, ResourceType.DIAMOND, cost);
+            MessageManager.sendMessage(player, "shop.purchase-success",
+                    "item", upgrade.name(),
+                    "price", String.valueOf(cost),
+                    "resource", ResourceType.DIAMOND.getColor() + ResourceType.DIAMOND.getDisplayName());
             team.setUpgradeLevel(upgrade.id(), current + 1);
             applyUpgradeEffect(upgrade.id(), current + 1);
             player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
@@ -165,6 +169,10 @@ public class TeamUpgradesMenu extends Menu {
             return;
         }
         ResourceManager.takeResources(player, ResourceType.DIAMOND, cost);
+        MessageManager.sendMessage(player, "shop.purchase-success",
+                "item", trap.name(),
+                "price", String.valueOf(cost),
+                "resource", ResourceType.DIAMOND.getColor() + ResourceType.DIAMOND.getDisplayName());
         team.setTrapActive(trap.id(), true);
         for (UUID uuid : team.getMembers()) {
             Player p = Bukkit.getPlayer(uuid);

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -131,7 +131,8 @@ public class GeneratorManager {
                 remaining = getDelayCycles(gen);
             }
             entry.setValue(remaining);
-            if (hologramsEnabled && (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD)) {
+            if (hologramsEnabled && gen.isHologramEnabled()
+                    && (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD)) {
                 Location loc = gen.getLocation();
                 if (loc != null) {
                     int seconds = (int) Math.ceil(remaining * TICK_RATE / 20.0);
@@ -184,7 +185,8 @@ public class GeneratorManager {
 
     public void registerGenerator(Generator gen) {
         counters.put(gen, getDelayCycles(gen));
-        if (hologramsEnabled && (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD)) {
+        if (hologramsEnabled && gen.isHologramEnabled()
+                && (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD)) {
             Location loc = gen.getLocation();
             if (loc != null) {
                 Location holoLoc = hologramLocation(loc);
@@ -201,7 +203,8 @@ public class GeneratorManager {
 
     public void unregisterGenerator(Generator gen) {
         counters.remove(gen);
-        if (hologramsEnabled && (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD)) {
+        if (hologramsEnabled && gen.isHologramEnabled()
+                && (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD)) {
             Location loc = gen.getLocation();
             if (loc != null) {
                 plugin.getHologramManager().removeHologram(hologramLocation(loc));
@@ -250,6 +253,7 @@ public class GeneratorManager {
                     && g.getLocation().distance(spawn) < 10);
             if (!exists) {
                 Generator emerald = new Generator(genLocation.clone(), GeneratorType.EMERALD, 1);
+                emerald.setHologramEnabled(false);
                 arena.getGenerators().add(emerald);
                 registerGenerator(emerald);
             }
@@ -261,7 +265,8 @@ public class GeneratorManager {
         while (it.hasNext()) {
             Generator gen = it.next();
             counters.remove(gen);
-            if (hologramsEnabled && (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD)) {
+            if (hologramsEnabled && gen.isHologramEnabled()
+                    && (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD)) {
                 Location loc = gen.getLocation();
                 if (loc != null) {
                     plugin.getHologramManager().removeHologram(hologramLocation(loc));

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -33,7 +33,7 @@ errors:
 
 shop:
   not-enough-money: "&c✖ &7Vous n'avez pas assez d'argent."
-  purchase-success: "&a✔ &7Achat effectué !"
+  purchase-success: "&8[&6Boutique&8] &7Vous avez acheté &e{item} &7pour &c{price} {resource}&7."
   vault-required: "&c✖ &7Le système d'économie n'est pas disponible."
 
 on-join:
@@ -92,22 +92,26 @@ setup:
   start-generator-setup: "&eClic droit pour définir la position du générateur."
 
 admin:
-  name-prompt: "&aVeuillez entrer le nom de la nouvelle arène dans le chat."
-  cancel-tips: "&7Tapez 'annuler' pour quitter le mode création."
-  creation-cancelled: "&cCréation d'arène annulée."
-  invalid-name: "&cNom invalide (1-16 caractères). Veuillez réessayer ou tapez 'annuler'."
-  name-exists: "&cUne arène avec ce nom existe déjà. Veuillez réessayer ou tapez 'annuler'."
-  name-validated: "&aNom '&e{arena}&a' validé !"
-  arena-created: "&aL'arène '{arena}' a été créée avec succès !"
-  generator-removed: "&cGénérateur supprimé."
-  arena-activated: "&aArène activée."
-  arena-deactivated: "&cArène désactivée."
-  delete-pending: "&eTapez /bw admin confirmdelete {arena} dans 30s pour confirmer la suppression."
-  delete-confirmed: "&aL'arène {arena} a été supprimée."
-  delete-expired: "&cConfirmation expirée pour l'arène {arena}."
-  bypass-enabled: "&aMode bypass activé."
-  bypass-disabled: "&cMode bypass désactivé."
-  bypass-auto-disabled: "&eBypass désactivé automatiquement pour la partie."
+  name-prompt: "&8[&cAdmin&8] &7Veuillez entrer le nom de la nouvelle arène dans le chat."
+  cancel-tips: "&8[&cAdmin&8] &7Tapez 'annuler' pour quitter le mode création."
+  creation-cancelled: "&8[&cAdmin&8] &cCréation d'arène annulée."
+  invalid-name: "&8[&cAdmin&8] &cNom invalide (1-16 caractères). Veuillez réessayer ou tapez 'annuler'."
+  name-exists: "&8[&cAdmin&8] &cUne arène avec ce nom existe déjà. Veuillez réessayer ou tapez 'annuler'."
+  name-validated: "&8[&cAdmin&8] &aNom '&e{arena}&a' validé !"
+  arena-created: "&8[&cAdmin&8] &aL'arène '{arena}' a été créée avec succès !"
+  generator-removed: "&8[&cAdmin&8] &cGénérateur supprimé."
+  arena-activated: "&8[&cAdmin&8] &aArène activée."
+  arena-deactivated: "&8[&cAdmin&8] &cArène désactivée."
+  delete-pending: "&8[&cAdmin&8] &eTapez /bw admin confirmdelete {arena} dans 30s pour confirmer la suppression."
+  delete-confirmed: "&8[&cAdmin&8] &aL'arène {arena} a été supprimée."
+  delete-expired: "&8[&cAdmin&8] &cConfirmation expirée pour l'arène {arena}."
+  bypass-enabled: "&8[&cAdmin&8] &aMode bypass activé."
+  bypass-disabled: "&8[&cAdmin&8] &cMode bypass désactivé."
+  bypass-auto-disabled: "&8[&cAdmin&8] &eBypass désactivé automatiquement pour la partie."
+  main-lobby-set: "&8[&cAdmin&8] &7Lobby principal défini."
+  shop-npc-placed: "&8[&cAdmin&8] &7PNJ de boutique {type} pour l'équipe {team} placé."
+  npc-created: "&8[&cAdmin&8] &7PNJ créé."
+  no-pending-npc: "&8[&cAdmin&8] &cAucune création de PNJ en cours."
 
   menus:
     admin-main-title: "&8HeneriaBedwars - Administration"

--- a/src/main/resources/upgrades.yml
+++ b/src/main/resources/upgrades.yml
@@ -4,7 +4,7 @@ main-menu:
   items:
     'general':
       material: DIAMOND_SWORD
-      name: "&aAméliorations Générales"
+      name: "&6Améliorations Générales"
       slot: 11
       category: 'general'
     'traps':
@@ -15,46 +15,46 @@ main-menu:
 
 upgrade-categories:
   general:
-    title: "Améliorations Générales"
+    title: "&6Améliorations Générales"
     rows: 3
     upgrades:
       sharpness:
-        name: "&aTranchant d'équipe"
+        name: "&6Tranchant d'équipe"
         item: IRON_SWORD
         tiers:
           1:
             cost: 4
-            description: "&7Les épées de l'équipe obtiennent Tranchant I."
+            description: "&7Toutes vos épées gagnent Tranchant I."
       protection:
-        name: "&aProtection d'équipe"
+        name: "&6Protection d'équipe"
         item: IRON_CHESTPLATE
         tiers:
           1:
             cost: 2
-            description: "&7Les armures de l'équipe obtiennent Protection I."
+            description: "&7Toutes les armures gagnent Protection I."
           2:
             cost: 4
-            description: "&7Les armures de l'équipe obtiennent Protection II."
+            description: "&7Toutes les armures gagnent Protection II."
           3:
             cost: 8
-            description: "&7Les armures de l'équipe obtiennent Protection III."
+            description: "&7Toutes les armures gagnent Protection III."
       haste:
-        name: "&aHâte d'équipe"
+        name: "&6Hâte d'équipe"
         item: GOLDEN_PICKAXE
         tiers:
           1:
             cost: 2
-            description: "&7Les joueurs gagnent Hâte I."
+            description: "&7Accorde Hâte I permanente."
           2:
             cost: 4
-            description: "&7Les joueurs gagnent Hâte II."
+            description: "&7Accorde Hâte II permanente."
       heal-pool:
-        name: "&aSoin de Base"
+        name: "&6Soin de Base"
         item: BEACON
         tiers:
           1:
             cost: 5
-            description: "&7Crée une aura de régénération"
+            description: "&7Génère une aura de régénération autour de la base."
             parameters:
               radius: 8
               amplifier: 0
@@ -64,32 +64,32 @@ upgrade-categories:
         tiers:
           1:
             cost: 2
-            description: "&7Vous alerte avec un son strident"
+            description: "&7Émet un signal sonore à l'approche d'un intrus."
             parameters:
               sound: ENTITY_ENDER_DRAGON_GROWL
       forge:
-        name: "&aForge améliorée"
+        name: "&6Forge améliorée"
         item: FURNACE
         tiers:
           1:
             cost: 2
-            description: "&7+25% de vitesse pour le Fer et l'Or."
+            description: "&7Augmente de 25% la production de Fer et d'Or."
           2:
             cost: 4
-            description: "&7+50% de vitesse pour le Fer et l'Or."
+            description: "&7Augmente de 50% la production de Fer et d'Or."
           3:
             cost: 6
-            description: "&7Vitesse maximale pour le Fer et l'Or."
+            description: "&7Double la production de Fer et d'Or."
           4:
             cost: 8
-            description: "&7Active un générateur d'Émeraudes lent."
+            description: "&7Ajoute un générateur d'Émeraudes lent."
       speed:
-        name: "&aVitesse d'équipe"
+        name: "&6Vitesse d'équipe"
         item: DIAMOND_BOOTS
         tiers:
           1:
             cost: 4
-            description: "&7Les joueurs gagnent Speed I permanent."
+            description: "&7Octroie Speed I permanente à l'équipe."
   traps:
     title: "Pièges"
     rows: 3
@@ -99,8 +99,8 @@ upgrade-categories:
         item: IRON_PICKAXE
         cost: 1
         description:
-          - "&7Le prochain ennemi qui entre"
-          - "&7dans votre base recevra Fatigue de Minage."
+          - "&7Le prochain intrus subit"
+          - "&7Fatigue de minage."
         effect:
           type: SLOW_DIGGING
           duration: 10
@@ -110,8 +110,8 @@ upgrade-categories:
         item: IRON_SHOVEL
         cost: 1
         description:
-          - "&7Le prochain ennemi qui entre"
-          - "&7dans votre base deviendra aveugle."
+          - "&7Le prochain intrus devient"
+          - "&7aveugle quelques secondes."
         effect:
           type: BLINDNESS
           duration: 8
@@ -121,8 +121,8 @@ upgrade-categories:
         item: FEATHER
         cost: 1
         description:
-          - "&7Confère Speed II et Jump Boost II"
-          - "&7aux alliés pendant 15 secondes."
+          - "&7Speed II et Jump Boost II"
+          - "&7pour les alliés pendant 15 s."
         effect:
           type: SPEED
           duration: 15


### PR DESCRIPTION
## Summary
- center upgrade and trap menu layout and refresh item lore
- colorize purchase and admin command messages with new prefixes
- prevent emerald holograms on team generators

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b74d8d79308329b74f688fe4bdcd1f