### PR TITLE
feat: improve bounty and dragon behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Changelog - HeneriaBedwars
 
 ## [4.3.2] - 2024-??-??
-
-### Modifié
+\n### Ajouté
+- Système de primes à paliers avec récompenses évolutives.
+\n### Modifié
 - Hologramme du PNJ central du lobby redésigné et synchronisé avec ses mouvements.
 - PNJ de boutique et d'améliorations dotés de skins distincts par défaut.
-
-### Corrigé
+- Message de prime redessiné avec un préfixe dédié.
+\n### Corrigé
 - Les vitres trempées ne sont plus disponibles via les achats rapides.
 - La forge au niveau maximal génère immédiatement des émeraudes dans le générateur de l'équipe.
+- Le texte des hologrammes de générateurs d'Émeraude reste lisible après l'apparition.
+- Les dragons de fin de partie se déplacent et attaquent correctement.
 
 ## [4.3.1] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🎨 **Couleurs d'équipe dynamiques** : Les pseudos des joueurs prennent la couleur de leur équipe dans la tablist et au-dessus de leur tête.
 - 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, et détruisez celui de vos ennemis pour les éliminer définitivement.
 - 💰 **Système Économique** : Collectez du Fer, de l'Or, des Diamants et des Émeraudes à des vitesses différentes pour acheter de l'équipement.
+- 🎯 **Système de primes à paliers** : Devenez recherché en enchaînant les éliminations et offrez des récompenses croissantes à ceux qui vous arrêtent.
 - 📡 **Hologrammes Intégrés** : Compte à rebours dynamique au-dessus des générateurs de Diamants et d'Émeraudes sans dépendance externe.
 - 🔥 **Forge évolutive** : Améliorez la Forge de votre équipe pour accélérer le Fer et l'Or, le dernier niveau produisant même des Émeraudes sur votre île.
 - 🛒 **Boutiques Fonctionnelles** : Interagissez avec les PNJ pour acheter des objets dans une boutique colorée (vitres teintées par catégorie, section d'achats rapides enrichie) ou des améliorations permanentes pour votre équipe.

--- a/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
+++ b/src/main/java/com/heneria/bedwars/HeneriaBedwars.java
@@ -103,7 +103,7 @@ public final class HeneriaBedwars extends JavaPlugin {
         this.databaseManager = new DatabaseManager(this);
         this.statsManager = new StatsManager(this, this.databaseManager);
         this.playerProgressionManager = new PlayerProgressionManager();
-        this.bountyManager = new BountyManager(3, 5);
+        this.bountyManager = new BountyManager();
         this.npcManager = new NpcManager(this);
         this.npcManager.startHologramTask();
         this.npcAnimationManager = new NpcAnimationManager(this, this.npcManager);

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -451,6 +451,11 @@ public class Arena {
             return;
         }
         EnderDragon dragon = center.getWorld().spawn(center, EnderDragon.class);
+        dragon.setAI(true);
+        try {
+            dragon.setPhase(EnderDragon.Phase.CIRCLING);
+        } catch (NoSuchMethodError ignored) {
+        }
         dragons.add(dragon);
         HeneriaBedwars.getInstance().getLogger().info("Arena " + name + " spawned a dragon at " + center);
     }

--- a/src/main/java/com/heneria/bedwars/managers/BountyManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/BountyManager.java
@@ -7,50 +7,94 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
- * Simple manager tracking kill streaks and bounties on players.
+ * Manages kill streaks and tiered bounties on players.
  */
 public class BountyManager {
 
-    private final Map<UUID, Integer> streaks = new HashMap<>();
-    private final Map<UUID, Integer> bounties = new HashMap<>();
-    private final int threshold;
-    private final int reward;
+    private static final String PREFIX = "§6[Prime] §r";
 
-    public BountyManager(int threshold, int reward) {
-        this.threshold = threshold;
-        this.reward = reward;
+    private final Map<UUID, Integer> streaks = new HashMap<>();
+    private final Map<UUID, Integer> bountyLevels = new HashMap<>();
+    private final List<BountyTier> tiers;
+
+    /**
+     * Creates a new bounty manager with default tiers.
+     */
+    public BountyManager() {
+        tiers = List.of(
+                new BountyTier(3, Map.of(Material.GOLD_INGOT, 2, Material.DIAMOND, 1)),
+                new BountyTier(5, Map.of(Material.GOLD_INGOT, 5, Material.DIAMOND, 2)),
+                new BountyTier(8, Map.of(Material.GOLD_INGOT, 10, Material.EMERALD, 1))
+        );
     }
 
+    /**
+     * Handles a kill and updates streaks, bounties and rewards.
+     *
+     * @param killer the player who made the kill
+     * @param victim the player who died
+     * @param arena  the arena context
+     */
     public void handleKill(Player killer, Player victim, Arena arena) {
         UUID killerId = killer.getUniqueId();
         UUID victimId = victim.getUniqueId();
         streaks.put(killerId, streaks.getOrDefault(killerId, 0) + 1);
         streaks.remove(victimId);
 
-        if (bounties.containsKey(victimId)) {
-            int amount = bounties.remove(victimId);
-            killer.getInventory().addItem(new ItemStack(Material.GOLD_INGOT, amount));
-            for (UUID id : arena.getPlayers()) {
-                Player p = Bukkit.getPlayer(id);
-                if (p != null) {
-                    p.sendMessage("§e" + killer.getName() + " a réclamé la prime sur " + victim.getName() + " !");
-                }
+        Integer victimBounty = bountyLevels.remove(victimId);
+        if (victimBounty != null) {
+            BountyTier tier = tiers.get(victimBounty);
+            for (Map.Entry<Material, Integer> entry : tier.rewards().entrySet()) {
+                killer.getInventory().addItem(new ItemStack(entry.getKey(), entry.getValue()));
             }
+            broadcast(arena, "§e" + killer.getName() + " a réclamé la prime sur §c" + victim.getName() + "§e !");
         }
 
         int ks = streaks.get(killerId);
-        if (ks >= threshold && !bounties.containsKey(killerId)) {
-            bounties.put(killerId, reward);
-            for (UUID id : arena.getPlayers()) {
-                Player p = Bukkit.getPlayer(id);
-                if (p != null) {
-                    p.sendMessage("§6" + killer.getName() + " est recherché ! Prime : " + reward + " lingots d'or.");
-                }
+        int current = bountyLevels.getOrDefault(killerId, -1);
+        for (int i = tiers.size() - 1; i >= 0; i--) {
+            BountyTier tier = tiers.get(i);
+            if (ks >= tier.kills() && i > current) {
+                bountyLevels.put(killerId, i);
+                broadcast(arena, "§c" + killer.getName() + " est recherché (Niveau " + (i + 1) + ") ! Prime: " +
+                        formatRewards(tier.rewards()));
+                break;
             }
         }
     }
+
+    private void broadcast(Arena arena, String message) {
+        for (UUID id : arena.getPlayers()) {
+            Player p = Bukkit.getPlayer(id);
+            if (p != null) {
+                p.sendMessage(PREFIX + message);
+            }
+        }
+    }
+
+    private String formatRewards(Map<Material, Integer> rewards) {
+        return rewards.entrySet().stream()
+                .map(e -> e.getValue() + " " + prettyName(e.getKey()))
+                .collect(Collectors.joining(", "));
+    }
+
+    private String prettyName(Material mat) {
+        return switch (mat) {
+            case GOLD_INGOT -> "Or";
+            case DIAMOND -> "Diamant";
+            case EMERALD -> "Émeraude";
+            case IRON_INGOT -> "Fer";
+            default -> mat.name();
+        };
+    }
+
+    private record BountyTier(int kills, Map<Material, Integer> rewards) {
+    }
 }
+

--- a/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/GeneratorManager.java
@@ -158,6 +158,14 @@ public class GeneratorManager {
         Location dropLocation = gen.getLocation().getBlock().getLocation().add(0.5, 1.0, 0.5);
         var item = dropLocation.getWorld().dropItem(dropLocation, new ItemStack(material, gs.amount()));
         item.setVelocity(new org.bukkit.util.Vector(0, 0, 0));
+        if (hologramsEnabled && gen.isHologramEnabled()
+                && (gen.getType() == GeneratorType.DIAMOND || gen.getType() == GeneratorType.EMERALD)) {
+            Location loc = gen.getLocation();
+            if (loc != null) {
+                plugin.getHologramManager().updateHologram(hologramLocation(loc),
+                        formatLines(gen, getDelaySeconds(gen)));
+            }
+        }
         if (gen.getType() == GeneratorType.GOLD) {
             plugin.getLogger().info("[DEBUG] Spawned gold at " + dropLocation);
         }


### PR DESCRIPTION
## Summary
- add tiered bounty system with escalating rewards and redesigned messages
- ensure end-game dragons move and attack players
- refresh emerald generator holograms after each spawn

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b754239ac88329b797659f2a950d9c