### PR TITLE
feat: add in-game tablist and lobby head textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [4.3.2] - 2024-??-??
 \n### Ajouté
 - Système de primes à paliers avec récompenses évolutives.
+- Tablist en jeu affichant la couleur d'équipe et l'état des lits.
+- Icônes du lobby (boutique, sélecteur d'équipe, sortie) converties en têtes personnalisées.
 \n### Modifié
 - Hologramme du PNJ central du lobby redésigné et synchronisé avec ses mouvements.
 - PNJ de boutique et d'améliorations dotés de skins distincts par défaut.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `shop.yml` : Personnalisez entièrement les catégories et les objets de la boutique d'items.
   - `upgrades.yml` : Définissez les améliorations d'équipe et les pièges de base.
   - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby principal, du lobby d'attente et de la partie via les sections `main-lobby`, `lobby` et `game`. La section `main-lobby` inclut une rubrique `Infos` (grade, rang, Elo, Henacoins) reposant sur PlaceholderAPI (`%luckperms_prefix%`, `%vault_eco_balance_formatted%`).
-  - `tablist.yml` : Configurez l'en-tête et le pied de page du lobby principal (`main-lobby`) et du lobby d'attente (`waiting-lobby`) avec couleurs, sauts de ligne (`\n`) et placeholders.
+  - `tablist.yml` : Configurez l'en-tête et le pied de page du lobby principal (`main-lobby`), du lobby d'attente (`waiting-lobby`) et de la partie (`game`) avec couleurs, sauts de ligne (`\n`) et placeholders.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
-  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`), la hauteur de téléportation anti-vide (`void-teleport-height`), personnalisez le format du chat via `chat-format` et contrôlez les animations du lobby via `animations.lobby-npc` (`enable`, `levitation-strength`, `presentation-speed`).
+  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`), la hauteur de téléportation anti-vide (`void-teleport-height`), personnalisez le format du chat via `chat-format`, contrôlez les animations du lobby via `animations.lobby-npc` (`enable`, `levitation-strength`, `presentation-speed`) et définissez les textures des items du lobby (`team-selector-item.skin`, `leave-item.skin`, `lobby-shop-item.skin`).
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin, y compris `server.join-message` et `server.leave-message` (préfixe vide par défaut).
 
@@ -39,6 +39,8 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.
 - 💬 **Chat et Tablist isolés** : Les messages et la liste des joueurs sont limités à votre partie pour éviter le spam entre arènes.
 - 🎨 **Couleurs d'équipe dynamiques** : Les pseudos des joueurs prennent la couleur de leur équipe dans la tablist et au-dessus de leur tête.
+- 📋 **Tablist en Jeu Détaillée** : Affiche pour chaque joueur la couleur de son équipe et l'état de son lit.
+- 🎭 **Icônes de Lobby Personnalisées** : Boutique, sélecteur d'équipe et sortie utilisent des têtes texturées uniques.
 - 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, et détruisez celui de vos ennemis pour les éliminer définitivement.
 - 💰 **Système Économique** : Collectez du Fer, de l'Or, des Diamants et des Émeraudes à des vitesses différentes pour acheter de l'équipement.
 - 🎯 **Système de primes à paliers** : Devenez recherché en enchaînant les éliminations et offrez des récompenses croissantes à ceux qui vous arrêtent.

--- a/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
@@ -31,8 +31,10 @@ public class LeaveItemListener implements Listener {
      * @return the configured ItemStack
      */
     public static ItemStack createLeaveItem() {
-        ItemStack item = new ItemBuilder(Material.RED_BED)
+        String skin = HeneriaBedwars.getInstance().getConfig().getString("leave-item.skin", "MHF_Bed");
+        ItemStack item = new ItemBuilder(Material.PLAYER_HEAD)
                 .setName(MessageManager.get("items.leave-item-name"))
+                .setSkullTexture(skin)
                 .build();
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {

--- a/src/main/java/com/heneria/bedwars/listeners/LobbyShopItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/LobbyShopItemListener.java
@@ -27,7 +27,7 @@ public class LobbyShopItemListener implements Listener {
         var lore = cfg.getStringList("lobby-shop-item.lore");
         ItemBuilder builder = new ItemBuilder(Material.PLAYER_HEAD)
                 .setName(name)
-                .setSkullOwner(skin);
+                .setSkullTexture(skin);
         for (String line : lore) {
             builder.addLore(line);
         }

--- a/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
@@ -29,8 +29,10 @@ public class TeamSelectorListener implements Listener {
     public static final NamespacedKey TEAM_SELECTOR_KEY = new NamespacedKey(HeneriaBedwars.getInstance(), "team-selector");
 
     public static ItemStack createSelectorItem() {
-        ItemStack item = new ItemBuilder(Material.WHITE_BANNER)
+        String skin = HeneriaBedwars.getInstance().getConfig().getString("team-selector-item.skin", "MHF_Banner");
+        ItemStack item = new ItemBuilder(Material.PLAYER_HEAD)
                 .setName(MessageManager.get("items.team-selector-name"))
+                .setSkullTexture(skin)
                 .build();
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {

--- a/src/main/java/com/heneria/bedwars/managers/TablistManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/TablistManager.java
@@ -74,7 +74,8 @@ public class TablistManager {
         } else {
             Team team = arena.getTeam(player);
             if (team != null) {
-                player.setPlayerListName(team.getColor().getChatColor() + player.getName());
+                String bed = team.hasBed() ? MessageManager.get("scoreboard.bed-alive") : MessageManager.get("scoreboard.bed-destroyed");
+                player.setPlayerListName(team.getColor().getChatColor() + bed + " " + player.getName());
             } else {
                 player.setPlayerListName(player.getName());
             }

--- a/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
+++ b/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
@@ -6,6 +6,11 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.Bukkit;
+import org.bukkit.profile.PlayerProfile;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.UUID;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -83,6 +88,38 @@ public class ItemBuilder {
     public ItemBuilder setSkullOwner(String skin) {
         if (skin != null && meta instanceof SkullMeta skullMeta) {
             skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(skin));
+            itemStack.setItemMeta(skullMeta);
+        }
+        return this;
+    }
+
+    /**
+     * Applies a custom texture to a player head using either a skin URL,
+     * a Base64 string or a known player name. Falls back to the skin owner
+     * method if the value is not a URL or Base64 data.
+     *
+     * @param texture the texture data, URL or player name
+     * @return this builder
+     */
+    public ItemBuilder setSkullTexture(String texture) {
+        if (texture == null || !(meta instanceof SkullMeta skullMeta)) {
+            return this;
+        }
+        try {
+            PlayerProfile profile = Bukkit.createProfile(UUID.randomUUID());
+            if (texture.startsWith("http")) {
+                profile.getTextures().setSkin(new URL(texture));
+            } else if (texture.length() > 60) {
+                profile.getTextures().setSkin(texture);
+            } else {
+                skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(texture));
+                itemStack.setItemMeta(skullMeta);
+                return this;
+            }
+            skullMeta.setPlayerProfile(profile);
+            itemStack.setItemMeta(skullMeta);
+        } catch (MalformedURLException e) {
+            skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(texture));
             itemStack.setItemMeta(skullMeta);
         }
         return this;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -44,6 +44,10 @@ generator-holograms:
 npc-skins:
   item-shop: "MHF_Villager"
   upgrade-shop: "MHF_Zombie"
+team-selector-item:
+  skin: "MHF_Banner"
+leave-item:
+  skin: "MHF_Bed"
 lobby-shop-item:
   name: "&aBoutique Cosmétiques"
   lore:


### PR DESCRIPTION
## Summary
- show bed status and team color in the in-game tablist
- use textured player heads for lobby items
- document tablist and lobby item configuration

## Testing
- `mvn -q -e package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b75833f4348329bd5defe412210fc4