### PR TITLE
Fix head texture build errors and remove deprecated PotionEffectType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - La forge au niveau maximal génère immédiatement des émeraudes dans le générateur de l'équipe.
 - Le texte des hologrammes de générateurs d'Émeraude reste lisible après l'apparition.
 - Les dragons de fin de partie se déplacent et attaquent correctement.
+- Correction des erreurs de compilation lors de l'application de textures de têtes personnalisées.
+- Suppression d'un avertissement de dépréciation en remplaçant `PotionEffectType#getByName` par `getByKey`.
 
 ## [4.3.1] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -481,3 +481,5 @@ animations:
 - Correction d'une erreur de compilation en renommant `PotionEffectType.JUMP` en `PotionEffectType.JUMP_BOOST`.
 - Suppression d'avertissements Maven liés à une API dépréciée et à des opérations non vérifiées.
 - Résolution d'une erreur de compilation due à la redéfinition de la variable `key` dans `ShopManager#parseItem`.
+- Mise à jour de la gestion des textures de têtes personnalisées avec `PlayerProfile`.
+- Remplacement de `PotionEffectType#getByName` par `PotionEffectType#getByKey` pour supprimer les avertissements de dépréciation.

--- a/src/main/java/com/heneria/bedwars/managers/ShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ShopManager.java
@@ -134,7 +134,8 @@ public class ShopManager {
 
         List<PotionEffect> potionEffects = new ArrayList<>();
         for (Map<?, ?> map : config.getMapList(path + ".potion-effects")) {
-            PotionEffectType pet = PotionEffectType.getByName(String.valueOf(map.get("type")));
+            PotionEffectType pet = PotionEffectType.getByKey(
+                    NamespacedKey.minecraft(String.valueOf(map.get("type")).toLowerCase(Locale.ROOT)));
             if (pet != null) {
                 int duration = map.get("duration") instanceof Number d ? d.intValue() * 20 : 0;
                 int amplifier = map.get("amplifier") instanceof Number a ? a.intValue() : 0;

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
@@ -10,6 +10,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -125,7 +126,8 @@ public class UpgradeManager {
                         int cost = trs.getInt(base + "cost", 1);
                         List<String> description = trs.getStringList(base + "description");
                         ConfigurationSection effectSec = trs.getConfigurationSection(base + "effect");
-                        PotionEffectType type = PotionEffectType.getByName(effectSec.getString("type", "BLINDNESS"));
+                        PotionEffectType type = PotionEffectType.getByKey(
+                                NamespacedKey.minecraft(effectSec.getString("type", "BLINDNESS").toLowerCase(Locale.ROOT)));
                         int duration = effectSec.getInt("duration", 5);
                         int amplifier = effectSec.getInt("amplifier", 0);
                         Trap trap = new Trap(id, name, item, cost, description, type, duration, amplifier);

--- a/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
+++ b/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
@@ -106,7 +106,7 @@ public class ItemBuilder {
             return this;
         }
         try {
-            PlayerProfile profile = Bukkit.createProfile(UUID.randomUUID());
+            PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID());
             if (texture.startsWith("http")) {
                 profile.getTextures().setSkin(new URL(texture));
             } else if (texture.length() > 60) {
@@ -116,7 +116,7 @@ public class ItemBuilder {
                 itemStack.setItemMeta(skullMeta);
                 return this;
             }
-            skullMeta.setPlayerProfile(profile);
+            skullMeta.setOwnerProfile(profile);
             itemStack.setItemMeta(skullMeta);
         } catch (MalformedURLException e) {
             skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(texture));


### PR DESCRIPTION
## Summary
- fix ItemBuilder head texture creation using PlayerProfile
- replace PotionEffectType#getByName to eliminate deprecation warnings
- document custom head fix and API updates

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b75a11f138832999ed48cdd3188dce