### PR TITLE
fix: convert skull texture string to URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Le texte des hologrammes de générateurs d'Émeraude reste lisible après l'apparition.
 - Les dragons de fin de partie se déplacent et attaquent correctement.
 - Correction des erreurs de compilation lors de l'application de textures de têtes personnalisées.
+- Conversion explicite des chaînes d'URL en `URL` dans `ItemBuilder#setSkullTexture` pour résoudre l'incompatibilité de type restante.
 - Suppression d'un avertissement de dépréciation en remplaçant `PotionEffectType#getByName` par `getByKey`.
 
 ## [4.3.1] - 2024-??-??

--- a/README.md
+++ b/README.md
@@ -482,4 +482,5 @@ animations:
 - Suppression d'avertissements Maven liés à une API dépréciée et à des opérations non vérifiées.
 - Résolution d'une erreur de compilation due à la redéfinition de la variable `key` dans `ShopManager#parseItem`.
 - Mise à jour de la gestion des textures de têtes personnalisées avec `PlayerProfile`.
+- Correction d'une incompatibilité de type dans `ItemBuilder#setSkullTexture` en convertissant les chaînes d'URL en objets `URL`.
 - Remplacement de `PotionEffectType#getByName` par `PotionEffectType#getByKey` pour supprimer les avertissements de dépréciation.

--- a/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
+++ b/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
@@ -110,7 +110,7 @@ public class ItemBuilder {
             if (texture.startsWith("http")) {
                 profile.getTextures().setSkin(new URL(texture));
             } else if (texture.length() > 60) {
-                profile.getTextures().setSkin(texture);
+                profile.getTextures().setSkin(new URL(texture));
             } else {
                 skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(texture));
                 itemStack.setItemMeta(skullMeta);


### PR DESCRIPTION
## Summary
- convert skull texture string to `URL` for PlayerProfile textures
- document skull texture fix in README and changelog

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b75b378de8832989005e18e3e9194e