### PR TITLE
Fix lobby NPC duplication by reusing existing entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PNJ de boutique et d'améliorations dotés de skins distincts par défaut.
 - Message de prime redessiné avec un préfixe dédié.
 \n### Corrigé
+- Duplication infinie des PNJ du lobby éliminée pour éviter la surcharge du serveur.
 - Les vitres trempées ne sont plus disponibles via les achats rapides.
 - La forge au niveau maximal génère immédiatement des émeraudes dans le générateur de l'équipe.
 - Le texte des hologrammes de générateurs d'Émeraude reste lisible après l'apparition.

--- a/README.md
+++ b/README.md
@@ -484,3 +484,4 @@ animations:
 - Mise à jour de la gestion des textures de têtes personnalisées avec `PlayerProfile`.
 - Correction d'une incompatibilité de type dans `ItemBuilder#setSkullTexture` en convertissant les chaînes d'URL en objets `URL`.
 - Remplacement de `PotionEffectType#getByName` par `PotionEffectType#getByKey` pour supprimer les avertissements de dépréciation.
+- Correction d'un bug critique de duplication infinie des PNJ du lobby provoquant une chute drastique des performances.

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -197,6 +197,18 @@ public class NpcManager {
 
     public void spawnNpc(NpcInfo info) {
         if (info.location == null || info.mode == null) return;
+
+        // Avoid spawning duplicate NPCs if one with the same id already exists
+        for (Entity entity : info.location.getWorld().getNearbyEntities(info.location, 1, 1, 1)) {
+            if (entity instanceof ArmorStand stand) {
+                String tag = stand.getPersistentDataContainer().get(npcKey, PersistentDataType.STRING);
+                if (tag != null && tag.equals("JOIN_NPC:" + info.id)) {
+                    info.stand = stand;
+                    return; // NPC already present
+                }
+            }
+        }
+
         ArmorStand npc = (ArmorStand) info.location.getWorld().spawnEntity(info.location, EntityType.ARMOR_STAND);
         npc.setInvisible(false);
         npc.setInvulnerable(true);


### PR DESCRIPTION
## Summary
- prevent spawning duplicate lobby NPCs by reusing existing tagged ArmorStands
- document critical NPC duplication fix in README and CHANGELOG

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b866b206e88329a258e822f7dd32e2