### PR TITLE
Fix tablist colors, enable fireball block breaking, and stabilize lobby NPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 - Tablist en jeu affichant la couleur d'équipe et l'état des lits.
 - Icônes du lobby (boutique, sélecteur d'équipe, sortie) converties en têtes personnalisées.
 \n### Modifié
-- Hologramme du PNJ central du lobby redésigné et synchronisé avec ses mouvements.
+- Hologramme du PNJ central du lobby stabilisé au-dessus d'un PNJ désormais statique.
 - PNJ de boutique et d'améliorations dotés de skins distincts par défaut.
 - Message de prime redessiné avec un préfixe dédié.
+- Section d'achats rapides remplie de vitres décoratives.
 \n### Corrigé
 - Duplication infinie des PNJ du lobby éliminée pour éviter la surcharge du serveur.
 - Les vitres trempées ne sont plus disponibles via les achats rapides.
@@ -18,6 +19,9 @@
 - Correction des erreurs de compilation lors de l'application de textures de têtes personnalisées.
 - Conversion explicite des chaînes d'URL en `URL` dans `ItemBuilder#setSkullTexture` pour résoudre l'incompatibilité de type restante.
 - Suppression d'un avertissement de dépréciation en remplaçant `PotionEffectType#getByName` par `getByKey`.
+- Les noms de la tablist conservent désormais la couleur de l'équipe.
+- Les boules de feu détruisent correctement la laine placée par les joueurs.
+- Hologramme du PNJ du lobby ne se duplique plus.
 
 ## [4.3.1] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.
 - 💬 **Chat et Tablist isolés** : Les messages et la liste des joueurs sont limités à votre partie pour éviter le spam entre arènes.
 - 🎨 **Couleurs d'équipe dynamiques** : Les pseudos des joueurs prennent la couleur de leur équipe dans la tablist et au-dessus de leur tête.
-- 📋 **Tablist en Jeu Détaillée** : Affiche pour chaque joueur la couleur de son équipe et l'état de son lit.
+- 📋 **Tablist en Jeu Détaillée** : Affiche pour chaque joueur la couleur exacte de son équipe et l'état de son lit.
 - 🎭 **Icônes de Lobby Personnalisées** : Boutique, sélecteur d'équipe et sortie utilisent des têtes texturées uniques.
-- 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, et détruisez celui de vos ennemis pour les éliminer définitivement.
+- 🛏️ **Mécaniques Classiques** : Protégez votre lit pour pouvoir réapparaître, détruisez celui de vos ennemis pour les éliminer définitivement et utilisez des boules de feu pour percer la laine.
 - 💰 **Système Économique** : Collectez du Fer, de l'Or, des Diamants et des Émeraudes à des vitesses différentes pour acheter de l'équipement.
 - 🎯 **Système de primes à paliers** : Devenez recherché en enchaînant les éliminations et offrez des récompenses croissantes à ceux qui vous arrêtent.
 - 📡 **Hologrammes Intégrés** : Compte à rebours dynamique au-dessus des générateurs de Diamants et d'Émeraudes sans dépendance externe.
 - 🔥 **Forge évolutive** : Améliorez la Forge de votre équipe pour accélérer le Fer et l'Or, le dernier niveau produisant même des Émeraudes sur votre île.
 - 🛒 **Boutiques Fonctionnelles** : Interagissez avec les PNJ pour acheter des objets dans une boutique colorée (vitres teintées par catégorie, section d'achats rapides enrichie) ou des améliorations permanentes pour votre équipe.
 - 🧍 **PNJ personnalisés** : Les vendeurs d'objets et d'améliorations arborent désormais des skins distincts.
-- 🪧 **Hologramme dynamique** : L'affichage du PNJ central du lobby est plus coloré et suit ses mouvements.
-- 🧱 **Achat rapide épuré** : Les vitres trempées ne sont plus proposées dans la section d'achats rapides.
+- 🪧 **Hologramme stable** : L'affichage du PNJ central du lobby reste unique et statique au-dessus de sa tête.
+- 🧱 **Achat rapide soigné** : Les vitres trempées ne sont plus proposées et les cases vides sont remplies de vitres décoratives.
 - 💎 **Forge Max fiable** : Le niveau maximal de forge génère immédiatement des émeraudes dans votre base.
 - 🏥 **Soin de Base** : Achetez une aura de régénération autour de votre lit pour soigner vos défenseurs.
 - 🔔 **Alarme Anti-Intrusion** : Un son puissant alerte toute l'équipe lorsqu'un piège est déclenché.

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopMenu.java
@@ -131,6 +131,16 @@ public class ShopMenu extends Menu {
             inventory.setItem(slot, stack);
             slotItems.put(slot, display);
         }
+
+        // Fill remaining slots in the quick buy menu with decorative panes
+        if (activeCategory == null) {
+            ItemStack pane = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+            for (int i = 0; i < getSize(); i++) {
+                if (!slotItems.containsKey(i) && !slotTabs.containsKey(i)) {
+                    inventory.setItem(i, pane);
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/SpecialItemListener.java
@@ -174,7 +174,8 @@ public class SpecialItemListener implements Listener {
                 fireball.setVelocity(player.getLocation().getDirection().multiply(1.5));
                 fireball.setShooter(player);
                 fireball.setIsIncendiary(false);
-                fireball.setYield(0f);
+                // Allow explosions to break nearby wool blocks
+                fireball.setYield(2f);
             });
         } else if (type == Material.EGG) {
             event.setCancelled(true);

--- a/src/main/java/com/heneria/bedwars/managers/NpcAnimationManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcAnimationManager.java
@@ -1,91 +1,27 @@
 package com.heneria.bedwars.managers;
 
 import com.heneria.bedwars.HeneriaBedwars;
-import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
-import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.Entity;
-import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.util.EulerAngle;
 
 /**
- * Runs subtle animations for lobby NPCs.
+ * Stubbed manager: lobby NPCs no longer use animations.
  */
 public class NpcAnimationManager {
 
-    private final HeneriaBedwars plugin;
-    private final NpcManager npcManager;
-    private BukkitRunnable task;
-    private int tick;
-    private boolean enabled;
-    private double levitationStrength;
-    private double presentationSpeed;
-
     public NpcAnimationManager(HeneriaBedwars plugin, NpcManager npcManager) {
-        this.plugin = plugin;
-        this.npcManager = npcManager;
+        // Animations removed, nothing to initialize
     }
 
     /**
-     * Starts the animation task.
+     * Starts the animation task. No-op as animations are disabled.
      */
     public void start() {
-        if (task != null) return;
-
-        enabled = plugin.getConfig().getBoolean("animations.lobby-npc.enable", true);
-        if (!enabled) {
-            return;
-        }
-
-        levitationStrength = plugin.getConfig().getDouble("animations.lobby-npc.levitation-strength", 0.1);
-        presentationSpeed = plugin.getConfig().getDouble("animations.lobby-npc.presentation-speed", 1.0);
-
-        task = new BukkitRunnable() {
-            @Override
-            public void run() {
-                tick++;
-                double phase = tick / 20.0 * presentationSpeed;
-                double bodyOffset = Math.sin(phase) * Math.toRadians(1.5);
-                double armOffset = Math.sin(phase) * Math.toRadians(20);
-                double yOffset = Math.sin(phase) * levitationStrength;
-                NamespacedKey npcKey = HeneriaBedwars.getNpcKey();
-                for (NpcManager.NpcInfo info : npcManager.getNpcs()) {
-                    ArmorStand stand = findStand(info, npcKey);
-                    if (stand == null) continue;
-                    EulerAngle body = stand.getBodyPose();
-                    stand.setBodyPose(new EulerAngle(bodyOffset, body.getY(), body.getZ()));
-
-                    stand.setRightArmPose(new EulerAngle(Math.toRadians(-10) + armOffset, 0, 0));
-
-                    Location base = info.location.clone();
-                    base.add(0, yOffset, 0);
-                    stand.teleport(base);
-                }
-            }
-        };
-        task.runTaskTimer(plugin, 0L, 1L);
+        // Intentionally empty
     }
 
     /**
-     * Stops the animation task.
+     * Stops the animation task. No-op as nothing is scheduled.
      */
     public void stop() {
-        if (task != null) {
-            task.cancel();
-            task = null;
-        }
-    }
-
-    private ArmorStand findStand(NpcManager.NpcInfo info, NamespacedKey npcKey) {
-        for (Entity entity : info.location.getWorld().getNearbyEntities(info.location, 1, 1, 1)) {
-            if (entity instanceof ArmorStand stand) {
-                String tag = stand.getPersistentDataContainer().get(npcKey, PersistentDataType.STRING);
-                if (tag != null && tag.equals("JOIN_NPC:" + info.id)) {
-                    return stand;
-                }
-            }
-        }
-        return null;
+        // Intentionally empty
     }
 }

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -154,9 +154,7 @@ public class NpcManager {
     }
 
     private Location hologramLocation(NpcInfo info) {
-        if (info.stand != null) {
-            return info.stand.getLocation().add(0, hologramOffsetY, 0);
-        }
+        // Always base the hologram on the original NPC location to avoid duplicates
         return info.location.clone().add(0, hologramOffsetY, 0);
     }
 

--- a/src/main/java/com/heneria/bedwars/managers/TablistManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/TablistManager.java
@@ -75,7 +75,8 @@ public class TablistManager {
             Team team = arena.getTeam(player);
             if (team != null) {
                 String bed = team.hasBed() ? MessageManager.get("scoreboard.bed-alive") : MessageManager.get("scoreboard.bed-destroyed");
-                player.setPlayerListName(team.getColor().getChatColor() + bed + " " + player.getName());
+                ChatColor teamColor = team.getColor().getChatColor();
+                player.setPlayerListName(teamColor + bed + " " + teamColor + player.getName());
             } else {
                 player.setPlayerListName(player.getName());
             }


### PR DESCRIPTION
## Summary
- ensure tablist uses true team color rather than bed status color
- allow fireball explosions to break wool blocks
- fill quick buy menu empty slots with decorative glass panes
- remove lobby NPC animation and keep hologram from duplicating
- document changes in README and CHANGELOG

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8710559e08329b21e40f1a4a49f82