### PR TITLE
Fix team redeclaration and remove deprecated API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Les noms de la tablist conservent désormais la couleur de l'équipe.
 - Les boules de feu détruisent correctement la laine placée par les joueurs.
 - Hologramme du PNJ du lobby ne se duplique plus.
+- Correction d'une variable `team` redéclarée dans `ShopMenu` causant un échec de compilation.
+- Remplacement de `PotionEffectType#getByKey` et `Enchantment#getByKey` par l'API `Registry` dans `ShopManager` pour éliminer l'avertissement de dépréciation.
 
 ## [4.3.1] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -487,3 +487,5 @@ animations:
 - Correction d'une incompatibilité de type dans `ItemBuilder#setSkullTexture` en convertissant les chaînes d'URL en objets `URL`.
 - Remplacement de `PotionEffectType#getByName` par `PotionEffectType#getByKey` pour supprimer les avertissements de dépréciation.
 - Correction d'un bug critique de duplication infinie des PNJ du lobby provoquant une chute drastique des performances.
+- Suppression d'une redéclaration de variable dans `ShopMenu#handleClick` causant un échec de compilation.
+- Remplacement de l'API dépréciée `getByKey` par `Registry` dans `ShopManager`.

--- a/src/main/java/com/heneria/bedwars/gui/shop/ShopMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/shop/ShopMenu.java
@@ -183,7 +183,7 @@ public class ShopMenu extends Menu {
                     "resource", type.getColor() + type.getDisplayName());
             Material material = item.material();
             Arena arena = HeneriaBedwars.getInstance().getArenaManager().getArena(clicker);
-            Team team = arena != null ? arena.getTeam(clicker) : null;
+            team = arena != null ? arena.getTeam(clicker) : null;
             if (material.toString().endsWith("_WOOL") && team != null) {
                 material = team.getColor().getWoolMaterial();
             }

--- a/src/main/java/com/heneria/bedwars/managers/ShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ShopManager.java
@@ -6,6 +6,7 @@ import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -134,7 +135,7 @@ public class ShopManager {
 
         List<PotionEffect> potionEffects = new ArrayList<>();
         for (Map<?, ?> map : config.getMapList(path + ".potion-effects")) {
-            PotionEffectType pet = PotionEffectType.getByKey(
+            PotionEffectType pet = Registry.POTION_EFFECT_TYPE.get(
                     NamespacedKey.minecraft(String.valueOf(map.get("type")).toLowerCase(Locale.ROOT)));
             if (pet != null) {
                 int duration = map.get("duration") instanceof Number d ? d.intValue() * 20 : 0;
@@ -149,7 +150,7 @@ public class ShopManager {
             NamespacedKey enchKey = typeObj != null
                     ? NamespacedKey.minecraft(String.valueOf(typeObj).toLowerCase(Locale.ROOT))
                     : null;
-            Enchantment ench = enchKey != null ? Enchantment.getByKey(enchKey) : null;
+            Enchantment ench = enchKey != null ? Registry.ENCHANTMENT.get(enchKey) : null;
             if (ench != null) {
                 int lvl = map.get("level") instanceof Number n ? n.intValue() : 1;
                 enchantments.put(ench, lvl);


### PR DESCRIPTION
## Summary
- resolve duplicate `team` variable in `ShopMenu#handleClick`
- replace deprecated `getByKey` lookups with `Registry` in `ShopManager`
- document compilation and deprecation fixes in README and changelog

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b872ed24a08329b05efc4c0fe72944