### PR TITLE
fix: use updated potion effect registry constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@
 - Hologramme du PNJ du lobby ne se duplique plus.
 - Correction d'une variable `team` redéclarée dans `ShopMenu` causant un échec de compilation.
 - Remplacement de `PotionEffectType#getByKey` et `Enchantment#getByKey` par l'API `Registry` dans `ShopManager` pour éliminer l'avertissement de dépréciation.
-- Correction d'une erreur de compilation en utilisant `Registry.POTION_EFFECT` au lieu de `Registry.POTION_EFFECT_TYPE` dans `ShopManager`.
-- Remplacement de `PotionEffectType#getByKey` par `Registry.POTION_EFFECT` dans `UpgradeManager` pour supprimer l'avertissement de dépréciation.
+- Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT` par `Registry.POTION_EFFECT_TYPE` dans `ShopManager`.
+- Remplacement de `PotionEffectType#getByKey` par `Registry.POTION_EFFECT_TYPE` dans `UpgradeManager` pour supprimer l'avertissement de dépréciation.
 
 ## [4.3.1] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -489,4 +489,4 @@ animations:
 - Correction d'un bug critique de duplication infinie des PNJ du lobby provoquant une chute drastique des performances.
 - Suppression d'une redéclaration de variable dans `ShopMenu#handleClick` causant un échec de compilation.
 - Remplacement de l'API dépréciée `getByKey` par `Registry` dans `ShopManager`.
-- Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT_TYPE` par `Registry.POTION_EFFECT` et migration de `UpgradeManager` vers cette API pour supprimer l'avertissement de dépréciation.
+- Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT` par `Registry.POTION_EFFECT_TYPE` et migration de `UpgradeManager` vers cette API pour supprimer l'avertissement de dépréciation.

--- a/src/main/java/com/heneria/bedwars/managers/ShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ShopManager.java
@@ -135,7 +135,7 @@ public class ShopManager {
 
         List<PotionEffect> potionEffects = new ArrayList<>();
         for (Map<?, ?> map : config.getMapList(path + ".potion-effects")) {
-            PotionEffectType pet = Registry.POTION_EFFECT.get(
+            PotionEffectType pet = Registry.POTION_EFFECT_TYPE.get(
                     NamespacedKey.minecraft(String.valueOf(map.get("type")).toLowerCase(Locale.ROOT)));
             if (pet != null) {
                 int duration = map.get("duration") instanceof Number d ? d.intValue() * 20 : 0;

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
@@ -127,7 +127,7 @@ public class UpgradeManager {
                         int cost = trs.getInt(base + "cost", 1);
                         List<String> description = trs.getStringList(base + "description");
                         ConfigurationSection effectSec = trs.getConfigurationSection(base + "effect");
-                        PotionEffectType type = Registry.POTION_EFFECT.get(
+                        PotionEffectType type = Registry.POTION_EFFECT_TYPE.get(
                                 NamespacedKey.minecraft(effectSec.getString("type", "BLINDNESS").toLowerCase(Locale.ROOT)));
                         int duration = effectSec.getInt("duration", 5);
                         int amplifier = effectSec.getInt("amplifier", 0);


### PR DESCRIPTION
## Summary
- replace deprecated `Registry.POTION_EFFECT` lookups with `Registry.POTION_EFFECT_TYPE`
- align documentation with current potion effect registry usage

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8759e97a08329888913833dbf6343