### PR TITLE
Fix potion effect registry access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Remplacement de `PotionEffectType#getByKey` et `Enchantment#getByKey` par l'API `Registry` dans `ShopManager` pour éliminer l'avertissement de dépréciation.
 - Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT` par `Registry.POTION_EFFECT_TYPE` dans `ShopManager`.
 - Remplacement de `PotionEffectType#getByKey` par `Registry.POTION_EFFECT_TYPE` dans `UpgradeManager` pour supprimer l'avertissement de dépréciation.
+- Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT_TYPE` par `Registry.EFFECT` dans `ShopManager` et `UpgradeManager`.
 
 ## [4.3.1] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -490,3 +490,4 @@ animations:
 - Suppression d'une redéclaration de variable dans `ShopMenu#handleClick` causant un échec de compilation.
 - Remplacement de l'API dépréciée `getByKey` par `Registry` dans `ShopManager`.
 - Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT` par `Registry.POTION_EFFECT_TYPE` et migration de `UpgradeManager` vers cette API pour supprimer l'avertissement de dépréciation.
+- Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT_TYPE` par `Registry.EFFECT` dans `ShopManager` et `UpgradeManager`.

--- a/src/main/java/com/heneria/bedwars/managers/ShopManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ShopManager.java
@@ -135,7 +135,7 @@ public class ShopManager {
 
         List<PotionEffect> potionEffects = new ArrayList<>();
         for (Map<?, ?> map : config.getMapList(path + ".potion-effects")) {
-            PotionEffectType pet = Registry.POTION_EFFECT_TYPE.get(
+            PotionEffectType pet = Registry.EFFECT.get(
                     NamespacedKey.minecraft(String.valueOf(map.get("type")).toLowerCase(Locale.ROOT)));
             if (pet != null) {
                 int duration = map.get("duration") instanceof Number d ? d.intValue() * 20 : 0;

--- a/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/UpgradeManager.java
@@ -127,7 +127,7 @@ public class UpgradeManager {
                         int cost = trs.getInt(base + "cost", 1);
                         List<String> description = trs.getStringList(base + "description");
                         ConfigurationSection effectSec = trs.getConfigurationSection(base + "effect");
-                        PotionEffectType type = Registry.POTION_EFFECT_TYPE.get(
+                        PotionEffectType type = Registry.EFFECT.get(
                                 NamespacedKey.minecraft(effectSec.getString("type", "BLINDNESS").toLowerCase(Locale.ROOT)));
                         int duration = effectSec.getInt("duration", 5);
                         int amplifier = effectSec.getInt("amplifier", 0);


### PR DESCRIPTION
## Summary
- replace deprecated `Registry.POTION_EFFECT_TYPE` with `Registry.EFFECT` when loading potion effects in ShopManager and UpgradeManager
- document potion effect registry fix in README and CHANGELOG

## Testing
- `mvn -q package -e` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68b8785985e883299488a8a994926011