### PR TITLE
Improve lobby hologram, chat colors and UI refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - PNJ de boutique et d'améliorations dotés de skins distincts par défaut.
 - Message de prime redessiné avec un préfixe dédié.
 - Section d'achats rapides remplie de vitres décoratives.
+- Position de l'hologramme du PNJ du lobby ajustée pour éviter tout chevauchement avec le nametag.
+- Butin de Guerre et Réduction d'Équipe déplacés vers la rangée 3 (slots 6 et 7) du menu d'améliorations.
+- Scoreboard et tablist rafraîchis à chaque tick pour une mise à jour instantanée.
 \n### Corrigé
 - Duplication infinie des PNJ du lobby éliminée pour éviter la surcharge du serveur.
 - Les vitres trempées ne sont plus disponibles via les achats rapides.
@@ -30,6 +33,8 @@
 - Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT` par `Registry.POTION_EFFECT_TYPE` dans `ShopManager`.
 - Remplacement de `PotionEffectType#getByKey` par `Registry.POTION_EFFECT_TYPE` dans `UpgradeManager` pour supprimer l'avertissement de dépréciation.
 - Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT_TYPE` par `Registry.EFFECT` dans `ShopManager` et `UpgradeManager`.
+- Bouton « Ressusciter » supprimé après la mort pour éviter l'affichage furtif.
+- Les messages de chat affichent désormais correctement la couleur de l'équipe.
 
 ## [4.3.1] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -493,3 +493,8 @@ animations:
 - Remplacement de l'API dépréciée `getByKey` par `Registry` dans `ShopManager`.
 - Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT` par `Registry.POTION_EFFECT_TYPE` et migration de `UpgradeManager` vers cette API pour supprimer l'avertissement de dépréciation.
 - Correction d'une erreur de compilation en remplaçant `Registry.POTION_EFFECT_TYPE` par `Registry.EFFECT` dans `ShopManager` et `UpgradeManager`.
+- Ajustement de la hauteur de l'hologramme des PNJ du lobby pour éviter tout chevauchement avec leur nametag.
+- Suppression du bouton "Ressusciter" qui clignotait brièvement après la mort des joueurs.
+- Déplacement de Butin de Guerre et Réduction d'Équipe vers la troisième rangée (slots 6 et 7) du menu d'améliorations.
+- Correction de l'affichage de la couleur d'équipe dans le chat en partie.
+- Rafraîchissement instantané des interfaces visuelles (scoreboard, tablist) pour une meilleure réactivité.

--- a/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/upgrades/TeamUpgradesMenu.java
@@ -76,9 +76,9 @@ public class TeamUpgradesMenu extends Menu {
         setUpgradeItem(21, "speed");
         setTrapItem(23, "miner-fatigue-trap");
 
-        // Third row - right side
-        setUpgradeItem(25, "war-loot");
-        setUpgradeItem(26, "team-discount");
+        // Third row - updated economic upgrades positions
+        setUpgradeItem(23, "war-loot");
+        setUpgradeItem(24, "team-discount");
 
         // Trap slots (row 4)
         ItemStack placeholder = new ItemBuilder(Material.GRAY_WOOL).setName("&7Aucun piège").build();

--- a/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/ChatListener.java
@@ -152,7 +152,7 @@ public class ChatListener implements Listener {
             ChatColor color = team != null ? team.getColor().getChatColor() : ChatColor.WHITE;
             String teamName = team != null ? team.getColor().getDisplayName() : "";
             String format = ChatColor.DARK_GRAY + "[" + color + teamName + ChatColor.DARK_GRAY + "] "
-                    + ChatColor.GRAY + "%1$s" + ChatColor.WHITE + ": %2$s";
+                    + color + "%1$s" + ChatColor.WHITE + ": %2$s";
             event.setFormat(format);
             return;
         }

--- a/src/main/java/com/heneria/bedwars/listeners/GameListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/GameListener.java
@@ -139,12 +139,12 @@ public class GameListener implements Listener {
                 ? arena.getLobbyLocation().clone().add(0, 20, 0)
                 : playerTeam.getSpawnLocation();
 
-        // Forcer la réapparition et téléporter le joueur en spectateur au-dessus du lobby
-        plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+        // Forcer la réapparition sans afficher l'écran de mort
+        plugin.getServer().getScheduler().runTask(plugin, () -> {
             player.spigot().respawn();
             player.setGameMode(GameMode.SPECTATOR);
             player.teleport(lobbyView);
-        }, 1L);
+        });
 
         Player killer = player.getKiller();
         if (killer != null) {

--- a/src/main/java/com/heneria/bedwars/managers/NpcManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/NpcManager.java
@@ -34,7 +34,7 @@ public class NpcManager {
     private final List<NpcInfo> npcs = new ArrayList<>();
     private final NamespacedKey npcKey;
     private BukkitTask hologramTask;
-    private final double hologramOffsetY = 2.2;
+    private final double hologramOffsetY = 2.5;
 
     public NpcManager(HeneriaBedwars plugin) {
         this.plugin = plugin;

--- a/src/main/java/com/heneria/bedwars/managers/ScoreboardManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ScoreboardManager.java
@@ -65,7 +65,7 @@ public class ScoreboardManager {
             public void run() {
                 updateAll();
             }
-        }.runTaskTimer(plugin, 20L, 20L);
+        }.runTaskTimer(plugin, 0L, 1L);
     }
 
     public void setScoreboard(Player player) {

--- a/src/main/java/com/heneria/bedwars/managers/TablistManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/TablistManager.java
@@ -55,7 +55,7 @@ public class TablistManager {
             public void run() {
                 updateAll();
             }
-        }.runTaskTimer(plugin, 0L, 100L);
+        }.runTaskTimer(plugin, 0L, 1L);
     }
 
     /**


### PR DESCRIPTION
## Summary
- raise lobby NPC hologram to avoid nametag overlap
- drop transient respawn button and reposition economic upgrades
- restore team chat colors and refresh UI elements every tick

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68b8896b96d08329b78fc00e095b65bb