### PR TITLE
Refactor team selector and quit menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Position de l'hologramme du PNJ du lobby ajustée pour éviter tout chevauchement avec le nametag.
 - Butin de Guerre et Réduction d'Équipe déplacés vers la rangée 3 (slots 6 et 7) du menu d'améliorations.
 - Scoreboard et tablist rafraîchis à chaque tick pour une mise à jour instantanée.
+- Menus « Sélecteur d'équipe » et « Quitter la partie » entièrement redessinés (3x9, clic gauche ou droit).
 \n### Corrigé
 - Duplication infinie des PNJ du lobby éliminée pour éviter la surcharge du serveur.
 - Les vitres trempées ne sont plus disponibles via les achats rapides.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Ce fichier `messages.yml` est généré automatiquement et permet d'adapter le p
 - 🕹️ **Cycle de Jeu Complet** : Rejoignez une arène, attendez dans le lobby avec un décompte, et lancez-vous dans la bataille.
 - 👁️ **Vue Spectateur Optimisée** : Après la mort, les joueurs sont téléportés au-dessus du lobby pour observer la partie.
 - ⚔️ **PvP 1.8** : Combat sans délai de recharge avec particules de coup critique à chaque attaque pour un ressenti classique.
-- 🎽 **Sélecteur d'équipe** : Choisissez votre camp grâce à un menu interactif avant le début de la partie.
+- 🎽 **Sélecteur d'équipe** : Menu 3x9 centré avec bannières colorées, accessible par clic gauche ou droit.
+- 🚪 **Menu Quitter la partie** : Confirmation stylisée (3x9) s'ouvrant via clic gauche ou droit.
 - 💬 **Chat et Tablist isolés** : Les messages et la liste des joueurs sont limités à votre partie pour éviter le spam entre arènes.
 - 🗨️ **Préfixe coloré dans le chat** : Les messages en partie indiquent clairement la couleur de l'équipe du joueur.
 - 🎨 **Couleurs d'équipe dynamiques** : Les pseudos des joueurs prennent la couleur de leur équipe dans la tablist et au-dessus de leur tête.

--- a/src/main/java/com/heneria/bedwars/gui/QuitArenaMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/QuitArenaMenu.java
@@ -1,0 +1,63 @@
+package com.heneria.bedwars.gui;
+
+import com.heneria.bedwars.arena.Arena;
+import com.heneria.bedwars.utils.ItemBuilder;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Confirmation menu displayed when a player attempts to leave an arena.
+ */
+public class QuitArenaMenu extends Menu {
+
+    private final Arena arena;
+
+    public QuitArenaMenu(Arena arena) {
+        this.arena = arena;
+    }
+
+    @Override
+    public String getTitle() {
+        return ChatColor.translateAlternateColorCodes('&', "&8» &cQuitter la partie ? &8«");
+    }
+
+    @Override
+    public int getSize() {
+        return 27;
+    }
+
+    @Override
+    public void setupItems() {
+        ItemStack light = new ItemBuilder(Material.LIGHT_GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        ItemStack dark = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            inventory.setItem(i, (i % 2 == 0) ? light : dark);
+        }
+        inventory.setItem(12, new ItemBuilder(Material.LIME_WOOL)
+                .setName("&aConfirmer")
+                .addLore("&7Retourner au lobby principal.")
+                .addLore("&e► Cliquez pour quitter")
+                .build());
+        inventory.setItem(14, new ItemBuilder(Material.RED_WOOL)
+                .setName("&cAnnuler")
+                .addLore("&7Rester dans la partie.")
+                .addLore("&e► Cliquez pour annuler")
+                .build());
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        int slot = event.getRawSlot();
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+        if (slot == 12) {
+            player.closeInventory();
+            arena.removePlayer(player);
+        } else if (slot == 14) {
+            player.closeInventory();
+        }
+    }
+}

--- a/src/main/java/com/heneria/bedwars/gui/TeamSelectorMenu.java
+++ b/src/main/java/com/heneria/bedwars/gui/TeamSelectorMenu.java
@@ -3,17 +3,17 @@ package com.heneria.bedwars.gui;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.arena.elements.Team;
 import com.heneria.bedwars.arena.enums.TeamColor;
-import com.heneria.bedwars.utils.MessageManager;
 import com.heneria.bedwars.utils.ItemBuilder;
+import com.heneria.bedwars.utils.MessageManager;
 import org.bukkit.Material;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 
 /**
  * Menu allowing players to choose their team before the game starts.
@@ -35,47 +35,35 @@ public class TeamSelectorMenu extends Menu {
 
     @Override
     public int getSize() {
-        int teams = arena.getTeams().size();
-        int innerRows = (int) Math.ceil(teams / 7.0);
-        int rows = Math.max(3, innerRows + 2);
-        return rows * 9;
+        // Fixed 3-row inventory
+        return 27;
     }
 
     @Override
     public void setupItems() {
         slotTeam.clear();
-        int maxPerTeam = arena.getMaxPlayers() / arena.getTeams().size();
-        ItemStack border = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
-        int rows = getSize() / 9;
-        for (int r = 0; r < rows; r++) {
-            for (int c = 0; c < 9; c++) {
-                if (r == 0 || r == rows - 1 || c == 0 || c == 8) {
-                    inventory.setItem(r * 9 + c, border);
-                }
-            }
+        int teams = arena.getTeams().size();
+        int maxPerTeam = arena.getMaxPlayers() / teams;
+
+        // Fill background with grey glass panes
+        ItemStack background = new ItemBuilder(Material.GRAY_STAINED_GLASS_PANE).setName(" ").build();
+        for (int i = 0; i < getSize(); i++) {
+            inventory.setItem(i, background);
         }
+
+        // Center team icons on the middle row
+        int start = 13 - teams / 2;
         int index = 0;
         for (Map.Entry<TeamColor, Team> entry : arena.getTeams().entrySet()) {
             TeamColor color = entry.getKey();
             Team team = entry.getValue();
-            int row = index / 7;
-            int col = index % 7;
-            int slot = 10 + row * 9 + col;
+            int slot = start + index;
             int size = team.getMembers().size();
-            boolean full = size >= maxPerTeam;
             ItemBuilder builder = new ItemBuilder(color.getWoolMaterial())
-                    .setName(color.getChatColor() + team.getColor().getDisplayName());
-            builder.addLore((full ? "&c" : "&a") + (full ? "Équipe pleine" : "Clique pour rejoindre"));
-            builder.addLore("&7" + size + "/" + maxPerTeam + " Joueurs");
-            if (size > 0) {
-                builder.addLore(" &eMembres:");
-                for (UUID id : team.getMembers()) {
-                    Player p = Bukkit.getPlayer(id);
-                    if (p != null) {
-                        builder.addLore("  &7» " + p.getName());
-                    }
-                }
-            }
+                    .setName(color.getChatColor() + "Équipe " + color.getDisplayName())
+                    .addLore("&7Joueurs: &a" + size + "/" + maxPerTeam)
+                    .addLore(" ")
+                    .addLore("&e► Cliquez pour rejoindre");
             inventory.setItem(slot, builder.build());
             slotTeam.put(slot, color);
             index++;

--- a/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
@@ -3,6 +3,7 @@ package com.heneria.bedwars.listeners;
 import com.heneria.bedwars.HeneriaBedwars;
 import com.heneria.bedwars.arena.Arena;
 import com.heneria.bedwars.managers.ArenaManager;
+import com.heneria.bedwars.gui.QuitArenaMenu;
 import com.heneria.bedwars.utils.GameUtils;
 import com.heneria.bedwars.utils.ItemBuilder;
 import com.heneria.bedwars.utils.MessageManager;
@@ -48,8 +49,9 @@ public class LeaveItemListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
         Action action = event.getAction();
-        // Trigger on both right-click in air and on block
-        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+        // Allow opening with any click (left or right, air or block)
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK
+                && action != Action.LEFT_CLICK_AIR && action != Action.LEFT_CLICK_BLOCK) {
             return;
         }
         if (event.getHand() != org.bukkit.inventory.EquipmentSlot.HAND) {
@@ -69,6 +71,6 @@ public class LeaveItemListener implements Listener {
             return;
         }
         event.setCancelled(true);
-        arena.removePlayer(player);
+        new QuitArenaMenu(arena).open(player);
     }
 }

--- a/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
@@ -46,8 +46,9 @@ public class TeamSelectorListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
         Action action = event.getAction();
-        // Trigger on both right-click in air and on block
-        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+        // Allow opening with any click (left or right, air or block)
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK
+                && action != Action.LEFT_CLICK_AIR && action != Action.LEFT_CLICK_BLOCK) {
             return;
         }
         if (event.getHand() != org.bukkit.inventory.EquipmentSlot.HAND) {

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -118,7 +118,7 @@ admin:
     admin-main-title: "&8HeneriaBedwars - Administration"
     arena-settings-title: "&8Configurer: {arena}"
     upgrades-title: "&aAméliorations"
-    team-selector-title: "&eSélection d'équipe"
+    team-selector-title: "&8» &bChoisissez votre équipe &8«"
 
 items:
   starter-lore: "&7Objet de départ"


### PR DESCRIPTION
## Summary
- Allow team selector and leave items to open menus via left or right click
- Redesign team selector layout with centered team icons
- Add confirmation GUI when leaving an arena

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b88b3907a88329ae4e2f74526feed8