### PR TITLE
fix build with Paper 1.21.3 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Le compteur de démarrage n'apparaît plus sur le scoreboard ni la tablist et le chat ne l'annonce qu'à 10 puis de 5 à 1 seconde(s).
 - Les blocs de laine récupérés se cumulent correctement dans l'inventaire.
 - Les PNJ de boutique et d'améliorations affichent désormais correctement leur skin.
-- Mise à jour de l'API vers Spigot 1.21.1 et correction des appels `PlayerProfile` et du scoreboard pour supprimer les erreurs de compilation.
+- Migration vers l'API Paper 1.21.3 et correction des appels `PlayerProfile` et du scoreboard pour supprimer les erreurs de compilation.
 
 ## [4.3.1] - 2024-??-??
 

--- a/README.md
+++ b/README.md
@@ -502,3 +502,4 @@ animations:
 - Correction de l'affichage de la couleur d'équipe dans le chat en partie.
 - Rafraîchissement instantané des interfaces visuelles (scoreboard, tablist) pour une meilleure réactivité.
 - Mise à jour vers l'API Spigot 1.21.1 avec adoption de l'API moderne du scoreboard et correction des méthodes de profil joueur pour assurer un build Maven sans erreur.
+- Migration vers l'API Paper 1.21.3 et adaptation du scoreboard aux composants Adventure pour supprimer les erreurs de compilation restantes.

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
+            <id>paper-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
@@ -65,9 +69,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/heneria/bedwars/managers/ScoreboardManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ScoreboardManager.java
@@ -19,6 +19,7 @@ import com.heneria.bedwars.utils.MessageManager;
 import com.heneria.bedwars.stats.PlayerStats;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 import java.io.File;
 import java.time.LocalDate;
@@ -73,7 +74,8 @@ public class ScoreboardManager {
     public void setScoreboard(Player player) {
         Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
         String initialTitle = mainLobbyTitle != null ? mainLobbyTitle : (lobbyTitle != null ? lobbyTitle : (gameTitle != null ? gameTitle : "BedWars"));
-        Objective obj = board.registerNewObjective("hbw", Criteria.DUMMY, Component.text(ChatColor.translateAlternateColorCodes('&', initialTitle)));
+        Component titleComponent = LegacyComponentSerializer.legacyAmpersand().deserialize(initialTitle);
+        Objective obj = board.registerNewObjective("hbw", Criteria.DUMMY, titleComponent);
         obj.setDisplaySlot(DisplaySlot.SIDEBAR);
         setBoard(player, board);
     }
@@ -109,7 +111,8 @@ public class ScoreboardManager {
         Objective obj = board.getObjective(DisplaySlot.SIDEBAR);
         if (obj == null) {
             String defaultTitle = mainLobbyTitle != null ? mainLobbyTitle : (lobbyTitle != null ? lobbyTitle : (gameTitle != null ? gameTitle : "BedWars"));
-            obj = board.registerNewObjective("hbw", Criteria.DUMMY, Component.text(ChatColor.translateAlternateColorCodes('&', defaultTitle)));
+            Component defaultComponent = LegacyComponentSerializer.legacyAmpersand().deserialize(defaultTitle);
+            obj = board.registerNewObjective("hbw", Criteria.DUMMY, defaultComponent);
             obj.setDisplaySlot(DisplaySlot.SIDEBAR);
         }
         GameState state = arena != null ? arena.getState() : null;
@@ -128,7 +131,8 @@ public class ScoreboardManager {
         if (title == null || lines == null) {
             return;
         }
-        obj.displayName(Component.text(ChatColor.translateAlternateColorCodes('&', replacePlaceholders(title, player, arena))));
+        Component titleComponent = LegacyComponentSerializer.legacyAmpersand().deserialize(replacePlaceholders(title, player, arena));
+        obj.displayName(titleComponent);
 
         for (String entry : new HashSet<>(board.getEntries())) {
             board.resetScores(entry);


### PR DESCRIPTION
## Summary
- switch to Paper 1.21.3 API and use Adventure components in the scoreboard
- document Paper migration in README and changelog

## Testing
- `mvn -q -e test-compile` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b897778d008329a4d138eeb4f0f441