### PR TITLE
fix: resolve PlayerProfile type conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -494,6 +494,7 @@
 - Correction d'un bug critique où la validation du nom d'arène échouait systématiquement, empêchant toute création.
 - Correction définitive d'une régression critique où le wizard de création d'arène se bloquait silencieusement après la saisie du nom.
 - Correction majeure et définitive du wizard de création d'arène, résolvant le blocage silencieux et le bug du coût en XP.
+- Standardisation de la dépendance Maven sur l'API Paper 1.21.3 et remplacement de `PlayerProfile` Bukkit par celui de Paper pour éliminer les erreurs de compilation.
 
 ## [0.0.1] - En développement
 

--- a/README.md
+++ b/README.md
@@ -503,3 +503,4 @@ animations:
 - Rafraîchissement instantané des interfaces visuelles (scoreboard, tablist) pour une meilleure réactivité.
 - Mise à jour vers l'API Spigot 1.21.1 avec adoption de l'API moderne du scoreboard et correction des méthodes de profil joueur pour assurer un build Maven sans erreur.
 - Migration vers l'API Paper 1.21.3 et adaptation du scoreboard aux composants Adventure pour supprimer les erreurs de compilation restantes.
+- Standardisation complète sur l'API Paper et remplacement de `PlayerProfile` Bukkit par la version Paper pour corriger une incompatibilité de type et les erreurs de compilation associées.

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,6 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
             <id>paper-repo</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -39,7 +39,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.profile.PlayerProfile;
+import com.destroystokyo.paper.profile.PlayerProfile;
 
 import java.util.*;
 
@@ -864,7 +864,7 @@ public class Arena {
         if (meta == null || skinName == null || skinName.isEmpty()) {
             return;
         }
-        PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID(), skinName);
+        PlayerProfile profile = Bukkit.createProfile(UUID.randomUUID(), skinName);
         profile.update();
         meta.setPlayerProfile(profile);
     }


### PR DESCRIPTION
## Summary
- remove spigot repository and rely solely on Paper API
- switch `PlayerProfile` usage to Paper's API to fix type mismatch
- document build configuration update

## Testing
- `mvn -q -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b899fb4f748329be90cca44328826c