### PR TITLE
chore: remove unstable features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - HeneriaBedwars
 
+## [4.3.3] - 2024-??-??
+### Modifié
+- Retrait temporaire des têtes personnalisées, des attributs de joueur modernes et de l'utilisation de Kyori Adventure pour restaurer la stabilité de la compilation.
+
 ## [4.3.2] - 2024-??-??
 \n### Ajouté
 - Système de primes à paliers avec récompenses évolutives.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Le plugin est structuré autour d'un cycle de jeu complet et d'outils d'administ
   - `scoreboard.yml` : Personnalisez les tableaux de bord du lobby principal, du lobby d'attente et de la partie via les sections `main-lobby`, `lobby` et `game`. La section `main-lobby` inclut une rubrique `Infos` (grade, rang, Elo, Henacoins) reposant sur PlaceholderAPI (`%luckperms_prefix%`, `%vault_eco_balance_formatted%`).
   - `tablist.yml` : Configurez l'en-tête et le pied de page du lobby principal (`main-lobby`), du lobby d'attente (`waiting-lobby`) et de la partie (`game`) avec couleurs, sauts de ligne (`\n`) et placeholders.
   - `events.yml` : Planifiez les événements automatiques (amélioration des générateurs, Mort Subite, apparition de dragons) et définissez un `display-name` lisible pour l'affichage du prochain événement sur le scoreboard.
-  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`), la hauteur de téléportation anti-vide (`void-teleport-height`), personnalisez le format du chat via `chat-format`, contrôlez les animations du lobby via `animations.lobby-npc` (`enable`, `levitation-strength`, `presentation-speed`) et définissez les textures des items du lobby (`team-selector-item.skin`, `leave-item.skin`, `lobby-shop-item.skin`).
+  - `config.yml` : Ajustez les réglages globaux, comme les dégâts infligés par le Golem de Fer (`mobs.iron-golem.damage`), la hauteur de téléportation anti-vide (`void-teleport-height`), personnalisez le format du chat via `chat-format` et contrôlez les animations du lobby via `animations.lobby-npc` (`enable`, `levitation-strength`, `presentation-speed`).
   - `special_shop.yml` : Définissez les objets uniques vendus par le PNJ spécial de milieu de partie, avec l'option `purchase-limit` pour limiter le nombre d'achats par joueur.
   - `messages.yml` : Traduisez et personnalisez tous les messages du plugin, y compris `server.join-message` et `server.leave-message` (préfixe vide par défaut).
 
@@ -488,8 +488,6 @@ animations:
 - Correction d'une erreur de compilation en renommant `PotionEffectType.JUMP` en `PotionEffectType.JUMP_BOOST`.
 - Suppression d'avertissements Maven liés à une API dépréciée et à des opérations non vérifiées.
 - Résolution d'une erreur de compilation due à la redéfinition de la variable `key` dans `ShopManager#parseItem`.
-- Mise à jour de la gestion des textures de têtes personnalisées avec `PlayerProfile`.
-- Correction d'une incompatibilité de type dans `ItemBuilder#setSkullTexture` en convertissant les chaînes d'URL en objets `URL`.
 - Remplacement de `PotionEffectType#getByName` par `PotionEffectType#getByKey` pour supprimer les avertissements de dépréciation.
 - Correction d'un bug critique de duplication infinie des PNJ du lobby provoquant une chute drastique des performances.
 - Suppression d'une redéclaration de variable dans `ShopMenu#handleClick` causant un échec de compilation.
@@ -501,5 +499,3 @@ animations:
 - Déplacement de Butin de Guerre et Réduction d'Équipe vers la troisième rangée (slots 6 et 7) du menu d'améliorations.
 - Correction de l'affichage de la couleur d'équipe dans le chat en partie.
 - Rafraîchissement instantané des interfaces visuelles (scoreboard, tablist) pour une meilleure réactivité.
-- Mise à jour vers l'API Spigot 1.21.1 avec adoption de l'API moderne du scoreboard et correction des méthodes de profil joueur pour assurer un build Maven sans erreur.
-- Migration vers l'API Paper 1.21.3 et adaptation du scoreboard aux composants Adventure pour supprimer les erreurs de compilation restantes.

--- a/src/main/java/com/heneria/bedwars/arena/Arena.java
+++ b/src/main/java/com/heneria/bedwars/arena/Arena.java
@@ -19,8 +19,6 @@ import org.bukkit.Material;
 import org.bukkit.GameMode;
 import com.heneria.bedwars.listeners.TeamSelectorListener;
 import com.heneria.bedwars.listeners.LeaveItemListener;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Bed;
@@ -39,7 +37,6 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.profile.PlayerProfile;
 
 import java.util.*;
 
@@ -325,10 +322,6 @@ public class Arena {
             MessageManager.sendMessage(player, "admin.bypass-auto-disabled");
         }
         savedStates.put(player.getUniqueId(), new PlayerData(player));
-        AttributeInstance speed = player.getAttribute(Attribute.GENERIC_ATTACK_SPEED);
-        if (speed != null) {
-            speed.setBaseValue(1024.0D);
-        }
         player.getInventory().clear();
         player.teleport(lobbyLocation);
         player.setLevel(0);
@@ -864,9 +857,7 @@ public class Arena {
         if (meta == null || skinName == null || skinName.isEmpty()) {
             return;
         }
-        PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID(), skinName);
-        profile.update();
-        meta.setPlayerProfile(profile);
+        meta.setOwningPlayer(Bukkit.getOfflinePlayer(skinName));
     }
 
     private void equipNpcArmor(ArmorStand npc, Material chestplate, Material leggings, Material boots, TeamColor color) {

--- a/src/main/java/com/heneria/bedwars/arena/PlayerData.java
+++ b/src/main/java/com/heneria/bedwars/arena/PlayerData.java
@@ -2,8 +2,6 @@ package com.heneria.bedwars.arena;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -18,7 +16,6 @@ public class PlayerData {
     private final float exp;
     private final int level;
     private final GameMode gameMode;
-    private final double attackSpeed;
 
     /**
      * Captures the current state of the given player.
@@ -32,8 +29,6 @@ public class PlayerData {
         this.exp = player.getExp();
         this.level = player.getLevel();
         this.gameMode = player.getGameMode();
-        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_ATTACK_SPEED);
-        this.attackSpeed = attr != null ? attr.getBaseValue() : 4.0D;
     }
 
     /**
@@ -48,10 +43,6 @@ public class PlayerData {
         player.setExp(exp);
         player.setLevel(level);
         player.setGameMode(gameMode);
-        AttributeInstance attr = player.getAttribute(Attribute.GENERIC_ATTACK_SPEED);
-        if (attr != null) {
-            attr.setBaseValue(attackSpeed);
-        }
     }
 }
 

--- a/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/LeaveItemListener.java
@@ -32,10 +32,8 @@ public class LeaveItemListener implements Listener {
      * @return the configured ItemStack
      */
     public static ItemStack createLeaveItem() {
-        String skin = HeneriaBedwars.getInstance().getConfig().getString("leave-item.skin", "MHF_Bed");
-        ItemStack item = new ItemBuilder(Material.PLAYER_HEAD)
+        ItemStack item = new ItemBuilder(Material.RED_BED)
                 .setName(MessageManager.get("items.leave-item-name"))
-                .setSkullTexture(skin)
                 .build();
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {

--- a/src/main/java/com/heneria/bedwars/listeners/LobbyShopItemListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/LobbyShopItemListener.java
@@ -23,11 +23,9 @@ public class LobbyShopItemListener implements Listener {
     public LobbyShopItemListener() {
         var cfg = HeneriaBedwars.getInstance().getConfig();
         String name = cfg.getString("lobby-shop-item.name", "&aBoutique Cosmétiques");
-        String skin = cfg.getString("lobby-shop-item.skin", "MHF_Chest");
         var lore = cfg.getStringList("lobby-shop-item.lore");
-        ItemBuilder builder = new ItemBuilder(Material.PLAYER_HEAD)
-                .setName(name)
-                .setSkullTexture(skin);
+        ItemBuilder builder = new ItemBuilder(Material.CHEST)
+                .setName(name);
         for (String line : lore) {
             builder.addLore(line);
         }

--- a/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
+++ b/src/main/java/com/heneria/bedwars/listeners/TeamSelectorListener.java
@@ -29,10 +29,8 @@ public class TeamSelectorListener implements Listener {
     public static final NamespacedKey TEAM_SELECTOR_KEY = new NamespacedKey(HeneriaBedwars.getInstance(), "team-selector");
 
     public static ItemStack createSelectorItem() {
-        String skin = HeneriaBedwars.getInstance().getConfig().getString("team-selector-item.skin", "MHF_Banner");
-        ItemStack item = new ItemBuilder(Material.PLAYER_HEAD)
+        ItemStack item = new ItemBuilder(Material.WHITE_BANNER)
                 .setName(MessageManager.get("items.team-selector-name"))
-                .setSkullTexture(skin)
                 .build();
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {

--- a/src/main/java/com/heneria/bedwars/managers/ScoreboardManager.java
+++ b/src/main/java/com/heneria/bedwars/managers/ScoreboardManager.java
@@ -18,8 +18,6 @@ import org.bukkit.scoreboard.Criteria;
 import com.heneria.bedwars.utils.MessageManager;
 import com.heneria.bedwars.stats.PlayerStats;
 import me.clip.placeholderapi.PlaceholderAPI;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 import java.io.File;
 import java.time.LocalDate;
@@ -74,8 +72,7 @@ public class ScoreboardManager {
     public void setScoreboard(Player player) {
         Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
         String initialTitle = mainLobbyTitle != null ? mainLobbyTitle : (lobbyTitle != null ? lobbyTitle : (gameTitle != null ? gameTitle : "BedWars"));
-        Component titleComponent = LegacyComponentSerializer.legacyAmpersand().deserialize(initialTitle);
-        Objective obj = board.registerNewObjective("hbw", Criteria.DUMMY, titleComponent);
+        Objective obj = board.registerNewObjective("hbw", Criteria.DUMMY, ChatColor.translateAlternateColorCodes('&', initialTitle));
         obj.setDisplaySlot(DisplaySlot.SIDEBAR);
         setBoard(player, board);
     }
@@ -111,8 +108,7 @@ public class ScoreboardManager {
         Objective obj = board.getObjective(DisplaySlot.SIDEBAR);
         if (obj == null) {
             String defaultTitle = mainLobbyTitle != null ? mainLobbyTitle : (lobbyTitle != null ? lobbyTitle : (gameTitle != null ? gameTitle : "BedWars"));
-            Component defaultComponent = LegacyComponentSerializer.legacyAmpersand().deserialize(defaultTitle);
-            obj = board.registerNewObjective("hbw", Criteria.DUMMY, defaultComponent);
+            obj = board.registerNewObjective("hbw", Criteria.DUMMY, ChatColor.translateAlternateColorCodes('&', defaultTitle));
             obj.setDisplaySlot(DisplaySlot.SIDEBAR);
         }
         GameState state = arena != null ? arena.getState() : null;
@@ -131,8 +127,7 @@ public class ScoreboardManager {
         if (title == null || lines == null) {
             return;
         }
-        Component titleComponent = LegacyComponentSerializer.legacyAmpersand().deserialize(replacePlaceholders(title, player, arena));
-        obj.displayName(titleComponent);
+        obj.setDisplayName(ChatColor.translateAlternateColorCodes('&', replacePlaceholders(title, player, arena)));
 
         for (String entry : new HashSet<>(board.getEntries())) {
             board.resetScores(entry);

--- a/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
+++ b/src/main/java/com/heneria/bedwars/utils/ItemBuilder.java
@@ -6,11 +6,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.Bukkit;
-import org.bukkit.profile.PlayerProfile;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.UUID;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -88,38 +83,6 @@ public class ItemBuilder {
     public ItemBuilder setSkullOwner(String skin) {
         if (skin != null && meta instanceof SkullMeta skullMeta) {
             skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(skin));
-            itemStack.setItemMeta(skullMeta);
-        }
-        return this;
-    }
-
-    /**
-     * Applies a custom texture to a player head using either a skin URL,
-     * a Base64 string or a known player name. Falls back to the skin owner
-     * method if the value is not a URL or Base64 data.
-     *
-     * @param texture the texture data, URL or player name
-     * @return this builder
-     */
-    public ItemBuilder setSkullTexture(String texture) {
-        if (texture == null || !(meta instanceof SkullMeta skullMeta)) {
-            return this;
-        }
-        try {
-            PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID());
-            if (texture.startsWith("http")) {
-                profile.getTextures().setSkin(new URL(texture));
-            } else if (texture.length() > 60) {
-                profile.getTextures().setSkin(new URL(texture));
-            } else {
-                skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(texture));
-                itemStack.setItemMeta(skullMeta);
-                return this;
-            }
-            skullMeta.setOwnerProfile(profile);
-            itemStack.setItemMeta(skullMeta);
-        } catch (MalformedURLException e) {
-            skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(texture));
             itemStack.setItemMeta(skullMeta);
         }
         return this;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -44,12 +44,7 @@ generator-holograms:
 npc-skins:
   item-shop: "MHF_Villager"
   upgrade-shop: "MHF_Zombie"
-team-selector-item:
-  skin: "MHF_Banner"
-leave-item:
-  skin: "MHF_Bed"
 lobby-shop-item:
   name: "&aBoutique Cosmétiques"
   lore:
     - "&7Clique-droit pour ouvrir"
-  skin: "MHF_Chest"


### PR DESCRIPTION
## Summary
- drop PlayerProfile textured head system and modern attribute tweaks
- revert scoreboard to simple string titles
- remove skin config entries to restore stable build

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b89b6cf080832983b7bbcbfdf12e95